### PR TITLE
Avoid candidate, discard-changes if we wrote to candidate

### DIFF
--- a/build.act.json
+++ b/build.act.json
@@ -1,12 +1,12 @@
 {
     "dependencies": {
         "netconf": {
-            "url": "https://github.com/orchestron-orchestrator/netconf/archive/956c3c634576eaa89333bc976d3fe1c44b303ac5.zip",
-            "hash": "1220f06a94a27db599596cc58dc20c0e2a2bd8d92724ec4ddb77eb6e958db5eb4785"
+            "url": "https://github.com/orchestron-orchestrator/netconf/archive/910025d1ce958ad9748819e132fc6a7fe589837f.zip",
+            "hash": "122030175e3de35f8acf4e1c9ace70edc98678d15ddbe7be559059a3bd8c7c31eec8"
         },
         "yang": {
-            "url": "https://github.com/orchestron-orchestrator/acton-yang/archive/4dffae700bcbd3ee3f0822ac2464f3b92795ff33.zip",
-            "hash": "1220eef09813e9bcb694187db924bc457343c62642f328ec6aa042e13e08dce6bd59"
+            "url": "https://github.com/orchestron-orchestrator/acton-yang/archive/77b2d7f19cf0be49b6b307fc828e0409757d1762.zip",
+            "hash": "1220586d74d98b83c897fc2fe1b0701656af6cbd6183f448a6f804df17bcf8e0f18b"
         }
     },
     "zig_dependencies": {}

--- a/gen_dmc/build.act.json
+++ b/gen_dmc/build.act.json
@@ -1,8 +1,8 @@
 {
     "dependencies": {
         "yang": {
-            "url": "https://github.com/orchestron-orchestrator/acton-yang/archive/4dffae700bcbd3ee3f0822ac2464f3b92795ff33.zip",
-            "hash": "1220eef09813e9bcb694187db924bc457343c62642f328ec6aa042e13e08dce6bd59"
+            "url": "https://github.com/orchestron-orchestrator/acton-yang/archive/77b2d7f19cf0be49b6b307fc828e0409757d1762.zip",
+            "hash": "1220586d74d98b83c897fc2fe1b0701656af6cbd6183f448a6f804df17bcf8e0f18b"
         }
     },
     "zig_dependencies": {}

--- a/src/orchestron/device.act
+++ b/src/orchestron/device.act
@@ -216,6 +216,9 @@ actor Device(wcap: ?WorldCap=None, name: str, log_handler: logging.Handler, on_r
     def get_modules():
         return modset
 
+    def _is_writable_running():
+        return ":writable-running" in modset
+
     def edit_config(new_conf: yang.gdata.Node):
         print("Device.edit_config")
         conf = new_conf
@@ -227,7 +230,10 @@ actor Device(wcap: ?WorldCap=None, name: str, log_handler: logging.Handler, on_r
             return
         if client is not None:
             print("Device.edit_config Sending config...")
-            client.edit_config(new_conf.to_xmlstr(pretty=False), _on_conf, datastore="candidate")
+            if _is_writable_running():
+                client.edit_config(new_conf.to_xmlstr(pretty=False), _on_conf)
+            else:
+                client.edit_config(new_conf.to_xmlstr(pretty=False), _on_conf, datastore="candidate")
 
     def _on_conf(c, r):
         if r is not None:

--- a/src/orchestron/device.act
+++ b/src/orchestron/device.act
@@ -238,12 +238,24 @@ actor Device(wcap: ?WorldCap=None, name: str, log_handler: logging.Handler, on_r
     def _on_conf(c, r):
         if r is not None:
             print("Device._on_conf", r.encode())
-            c.commit(_on_commit)
+            if not _is_writable_running():
+                # We edit-config'd candidate, now commit
+                c.commit(_on_commit)
         else:
             print("Device._on_conf went to shit")
 
     def _on_commit(c, r):
         if r is not None:
             print("Device._on_commit", r.encode())
+            if any(filter(lambda c: c.tag == "rpc-error", r.children)) and not _is_writable_running():
+                # We commit'ed candidate, but got an error, now discard-changes
+                # TODO: what if the device does this (:rollback-on-error)?!
+                c.discard_changes(_on_discard_changes)
         else:
             print("Device._on_commit went to shit")
+
+    def _on_discard_changes(c, r):
+        if r is not None:
+            print("Device._on_discard_changes", r.encode())
+        else:
+            print("Device._on_discard_changes went to shit")


### PR DESCRIPTION
Default to targeting *running* datastore for `<edit-config>`. If we use *candidate*, run `<discard-changes>` if `<commit>` was unsuccessful.