### PR TITLE
Implement /device/mock

### DIFF
--- a/src/orchestron/device.act
+++ b/src/orchestron/device.act
@@ -126,6 +126,9 @@ actor Device(wcap: ?WorldCap=None, name: str, log_handler: logging.Handler, on_r
     _log.name = "Device " + name
 
     if wcap == None:
+        # This is the "init" modset, where we pretend to be an IOS XR device,
+        # even when the /orfs:device entry does not exist at all. This is really
+        # only useful for testing RFS transforms without the /orfs:device entry.
         # TODO: remove this and inject mock support modules elsewhere
         mxr1 = parse_cap("http://cisco.com/ns/yang/Cisco-IOS-XR-um-hostname-cfg?module=Cisco-IOS-XR-um-hostname-cfg&revision=2021-04-21")
         modset[mxr1.name] = mxr1
@@ -170,9 +173,15 @@ actor Device(wcap: ?WorldCap=None, name: str, log_handler: logging.Handler, on_r
         if wcap == None:
             print("Device in MOCK mode, pretending to connect to device...")
             state = 1
-            for mock_cap in conf.mock.modules.elements:
-                m = ModCap(mock_cap.name, mock_cap.namespace, mock_cap.revision, mock_cap.feature)
-                modset[m.name] = m
+
+            if len(conf.mock.module.elements) > 0:
+                # Replace init modset with mock modset
+                mock_modset = {}
+                for mock_cap in conf.mock.module.elements:
+                    m = ModCap(mock_cap.name, mock_cap.namespace, mock_cap.revision, mock_cap.feature)
+                    print("Adding mock cap", m)
+                    mock_modset[m.name] = m
+                modset = mock_modset
             return
 
         if state == 1:

--- a/src/orchestron/device.act
+++ b/src/orchestron/device.act
@@ -125,18 +125,6 @@ actor Device(wcap: ?WorldCap=None, name: str, log_handler: logging.Handler, on_r
     _log = logging.Logger(log_handler)
     _log.name = "Device " + name
 
-    if wcap == None:
-        # This is the "init" modset, where we pretend to be an IOS XR device,
-        # even when the /orfs:device entry does not exist at all. This is really
-        # only useful for testing RFS transforms without the /orfs:device entry.
-        # TODO: remove this and inject mock support modules elsewhere
-        mxr1 = parse_cap("http://cisco.com/ns/yang/Cisco-IOS-XR-um-hostname-cfg?module=Cisco-IOS-XR-um-hostname-cfg&revision=2021-04-21")
-        modset[mxr1.name] = mxr1
-        mxr2 = parse_cap("http://cisco.com/ns/yang/Cisco-IOS-XR-um-interface-cfg?module=Cisco-IOS-XR-um-interface-cfg&revision=2022-07-11")
-        modset[mxr2.name] = mxr2
-        mxr3 = parse_cap("http://cisco.com/ns/yang/Cisco-IOS-XR-um-if-ipv4-cfg?module=Cisco-IOS-XR-um-if-ipv4-cfg&revision=2022-07-11")
-        modset[mxr3.name] = mxr3
-
     def _on_connect(c):
         _log.info("Connected to device")
         state = 1
@@ -174,14 +162,28 @@ actor Device(wcap: ?WorldCap=None, name: str, log_handler: logging.Handler, on_r
             print("Device in MOCK mode, pretending to connect to device...")
             state = 1
 
+            preset_caps = []
+            if "cisco-ios-xr" in conf.mock.preset:
+                preset_caps.extend([
+                    "http://cisco.com/ns/yang/Cisco-IOS-XR-um-hostname-cfg?module=Cisco-IOS-XR-um-hostname-cfg&revision=2021-04-21",
+                    "http://cisco.com/ns/yang/Cisco-IOS-XR-um-interface-cfg?module=Cisco-IOS-XR-um-interface-cfg&revision=2022-07-11",
+                    "http://cisco.com/ns/yang/Cisco-IOS-XR-um-if-ipv4-cfg?module=Cisco-IOS-XR-um-if-ipv4-cfg&revision=2022-07-11",
+                ])
+            if "juniper-junos" in conf.mock.preset:
+                preset_caps.extend([
+                    "http://xml.juniper.net/netconf/junos/1.0",
+                    "http://xml.juniper.net/dmi/system/1.0",
+                ])
+            for cap in preset_caps:
+                m = parse_cap(cap)
+                modset[m.name] = m
+                print("Adding preset cap", m.name)
+
             if len(conf.mock.module.elements) > 0:
-                # Replace init modset with mock modset
-                mock_modset = {}
                 for mock_cap in conf.mock.module.elements:
                     m = ModCap(mock_cap.name, mock_cap.namespace, mock_cap.revision, mock_cap.feature)
-                    print("Adding mock cap", m)
-                    mock_modset[m.name] = m
-                modset = mock_modset
+                    print("Adding mock cap", m.name)
+                    modset[m.name] = m
             return
 
         if state == 1:

--- a/src/orchestron/device_meta_config.act
+++ b/src/orchestron/device_meta_config.act
@@ -356,7 +356,7 @@ class orchestron_rfs__device__initial_credentials(yang.adata.MNode):
         return res
 
 
-class orchestron_rfs__device__mock__modules_entry(yang.adata.MNode):
+class orchestron_rfs__device__mock__module_entry(yang.adata.MNode):
     name: str
     namespace: str
     revision: ?str
@@ -387,18 +387,18 @@ class orchestron_rfs__device__mock__modules_entry(yang.adata.MNode):
         return yang.gdata.ListElement([str(self.name)], children)
 
     @staticmethod
-    mut def from_gdata(n: yang.gdata.Node) -> orchestron_rfs__device__mock__modules_entry:
-        return orchestron_rfs__device__mock__modules_entry(name=n.get_str("name"), namespace=n.get_str("namespace"), revision=n.get_opt_str("revision"), feature=n.get_opt_strs("feature"))
+    mut def from_gdata(n: yang.gdata.Node) -> orchestron_rfs__device__mock__module_entry:
+        return orchestron_rfs__device__mock__module_entry(name=n.get_str("name"), namespace=n.get_str("namespace"), revision=n.get_opt_str("revision"), feature=n.get_opt_strs("feature"))
 
     @staticmethod
-    mut def from_xml(n: xml.Node) -> orchestron_rfs__device__mock__modules_entry:
-        return orchestron_rfs__device__mock__modules_entry(name=yang.gdata.from_xml_str(n, "name"), namespace=yang.gdata.from_xml_str(n, "namespace"), revision=yang.gdata.from_xml_opt_str(n, "revision"), feature=yang.gdata.from_xml_opt_strs(n, "feature"))
+    mut def from_xml(n: xml.Node) -> orchestron_rfs__device__mock__module_entry:
+        return orchestron_rfs__device__mock__module_entry(name=yang.gdata.from_xml_str(n, "name"), namespace=yang.gdata.from_xml_str(n, "namespace"), revision=yang.gdata.from_xml_opt_str(n, "revision"), feature=yang.gdata.from_xml_opt_strs(n, "feature"))
 
-class orchestron_rfs__device__mock__modules(yang.adata.MNode):
-    elements: list[orchestron_rfs__device__mock__modules_entry]
+class orchestron_rfs__device__mock__module(yang.adata.MNode):
+    elements: list[orchestron_rfs__device__mock__module_entry]
     mut def __init__(self, elements=[]):
         self._ns = "http://orchestron.org/yang/orchestron-rfs.yang"
-        self._name = 'modules'
+        self._name = 'module'
         self.elements = elements
 
     mut def create(self, name, namespace):
@@ -410,7 +410,7 @@ class orchestron_rfs__device__mock__modules(yang.adata.MNode):
             if match:
                 return e
 
-        res = orchestron_rfs__device__mock__modules_entry(name, namespace)
+        res = orchestron_rfs__device__mock__module_entry(name, namespace)
         self.elements.append(res)
         return res
 
@@ -423,45 +423,45 @@ class orchestron_rfs__device__mock__modules(yang.adata.MNode):
         return yang.gdata.List(['name'], elements)
 
     @staticmethod
-    mut def from_gdata(n: yang.gdata.List) -> list[orchestron_rfs__device__mock__modules_entry]:
+    mut def from_gdata(n: yang.gdata.List) -> list[orchestron_rfs__device__mock__module_entry]:
         res = []
         for e in n.elements:
-            res.append(orchestron_rfs__device__mock__modules_entry.from_gdata(e))
+            res.append(orchestron_rfs__device__mock__module_entry.from_gdata(e))
         return res
 
     @staticmethod
-    mut def from_xml(nodes: list[xml.Node]) -> list[orchestron_rfs__device__mock__modules_entry]:
+    mut def from_xml(nodes: list[xml.Node]) -> list[orchestron_rfs__device__mock__module_entry]:
         res = []
         for node in nodes:
-            res.append(orchestron_rfs__device__mock__modules_entry.from_xml(node))
+            res.append(orchestron_rfs__device__mock__module_entry.from_xml(node))
         return res
 
 
 class orchestron_rfs__device__mock(yang.adata.MNode):
-    modules: orchestron_rfs__device__mock__modules
+    module: orchestron_rfs__device__mock__module
 
-    mut def __init__(self, modules: list[orchestron_rfs__device__mock__modules_entry]=[]):
+    mut def __init__(self, module: list[orchestron_rfs__device__mock__module_entry]=[]):
         self._ns = "http://orchestron.org/yang/orchestron-rfs.yang"
-        self.modules = orchestron_rfs__device__mock__modules(elements=modules)
-        self.modules._parent = self
+        self.module = orchestron_rfs__device__mock__module(elements=module)
+        self.module._parent = self
 
     mut def to_gdata(self) -> yang.gdata.Node:
         children = {}
-        _modules = self.modules
-        if _modules is not None:
-            children['modules'] = _modules.to_gdata()
+        _module = self.module
+        if _module is not None:
+            children['module'] = _module.to_gdata()
         return yang.gdata.Container(children)
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> orchestron_rfs__device__mock:
         if n != None:
-            return orchestron_rfs__device__mock(modules=orchestron_rfs__device__mock__modules.from_gdata(n.get_list("modules")))
+            return orchestron_rfs__device__mock(module=orchestron_rfs__device__mock__module.from_gdata(n.get_list("module")))
         return orchestron_rfs__device__mock()
 
     @staticmethod
     mut def from_xml(n: ?xml.Node) -> orchestron_rfs__device__mock:
         if n != None:
-            return orchestron_rfs__device__mock(modules=orchestron_rfs__device__mock__modules.from_xml(yang.gdata.get_xml_children(n, "modules")))
+            return orchestron_rfs__device__mock(module=orchestron_rfs__device__mock__module.from_xml(yang.gdata.get_xml_children(n, "module")))
         return orchestron_rfs__device__mock()
 
 

--- a/src/orchestron/device_meta_config.act
+++ b/src/orchestron/device_meta_config.act
@@ -438,16 +438,22 @@ class orchestron_rfs__device__mock__module(yang.adata.MNode):
 
 
 class orchestron_rfs__device__mock(yang.adata.MNode):
+    preset: list[str]
     module: orchestron_rfs__device__mock__module
 
-    mut def __init__(self, module: list[orchestron_rfs__device__mock__module_entry]=[]):
+    mut def __init__(self, preset: ?list[str]=None, module: list[orchestron_rfs__device__mock__module_entry]=[]):
         self._ns = "http://orchestron.org/yang/orchestron-rfs.yang"
+        if preset is not None:
+            self.preset = preset
+        else:
+            self.preset = []
         self.module = orchestron_rfs__device__mock__module(elements=module)
         self.module._parent = self
 
     mut def to_gdata(self) -> yang.gdata.Node:
         children = {}
         _module = self.module
+        children['preset'] = yang.gdata.LeafList(self.preset)
         if _module is not None:
             children['module'] = _module.to_gdata()
         return yang.gdata.Container(children)
@@ -455,13 +461,13 @@ class orchestron_rfs__device__mock(yang.adata.MNode):
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> orchestron_rfs__device__mock:
         if n != None:
-            return orchestron_rfs__device__mock(module=orchestron_rfs__device__mock__module.from_gdata(n.get_list("module")))
+            return orchestron_rfs__device__mock(preset=n.get_opt_strs("preset"), module=orchestron_rfs__device__mock__module.from_gdata(n.get_list("module")))
         return orchestron_rfs__device__mock()
 
     @staticmethod
     mut def from_xml(n: ?xml.Node) -> orchestron_rfs__device__mock:
         if n != None:
-            return orchestron_rfs__device__mock(module=orchestron_rfs__device__mock__module.from_xml(yang.gdata.get_xml_children(n, "module")))
+            return orchestron_rfs__device__mock(preset=yang.gdata.from_xml_opt_strs(n, "preset"), module=orchestron_rfs__device__mock__module.from_xml(yang.gdata.get_xml_children(n, "module")))
         return orchestron_rfs__device__mock()
 
 

--- a/src/orchestron/yang.act
+++ b/src/orchestron/yang.act
@@ -84,6 +84,12 @@ rfs = """module orchestron-rfs {
     }
 
     container mock {
+      leaf-list preset {
+        type enumeration {
+          enum cisco-ios-xr;
+          enum juniper-junos;
+        }
+      }
       list module {
         key "name";
         leaf name {

--- a/src/orchestron/yang.act
+++ b/src/orchestron/yang.act
@@ -84,7 +84,7 @@ rfs = """module orchestron-rfs {
     }
 
     container mock {
-      list modules {
+      list module {
         key "name";
         leaf name {
           type string;


### PR DESCRIPTION
We add two options for mocking devices capabilities, for testing with no device present:
1. `/device/mock/mock`: a list of specific modules we want in the capabilities
2. `/device/mock/preset`: a preset list of modules that mocks a platform, like *cisco-ios-xr* or *juniper-junos*.