### PR TITLE
Fix gdata namespace qualifiers

### DIFF
--- a/src/orchestron/ttt.act
+++ b/src/orchestron/ttt.act
@@ -485,20 +485,24 @@ class _ContainerTransaction(_Transaction):
 
 ################# Lists ####################
 
-def List(template, key_names: list[str], key_types: list[str]) -> proc(list[str], ?Layer)->Node:
-    return lambda path, lower: Node(_List(path, template, key_names, key_types, lower))
+def List(template, key_names: list[str], key_types: list[str], ns:?str=None, module:?str=None) -> proc(list[str], ?Layer)->Node:
+    return lambda path, lower: Node(_List(path, template, key_names, key_types, ns, module, lower))
 
 class _List(_Node):
     liststate: ListState
+    ns: ?str
+    module: ?str
 
-    def __init__(self, path, template, key_names, key_types, lower: ?Layer):
+    def __init__(self, path, template, key_names, key_types, ns, module, lower: ?Layer):
         self.path = path
         self.key_names = key_names
         self.key_types = key_types
-        self.liststate = ListState(path, template, lower)
+        self.ns = ns
+        self.module = module
+        self.liststate = ListState(path, template, ns, module, lower)
 
     def newtrans(self):
-        return ListTransaction(self.path, self.liststate, self.key_names, self.key_types)
+        return ListTransaction(self.path, self.liststate, self.key_names, self.key_types, self.ns, self.module)
 
     def get(self):
         #print('####', '(List)', self.path, 'NODE GET', err=True)
@@ -507,10 +511,10 @@ class _List(_Node):
             r = node.get()
             if isinstance(r, gdata.Container):
                 res.append(r)
-        return gdata.List(self.key_names, res)
+        return gdata.List(self.key_names, res, ns=self.ns, module=self.module)
 
 
-actor ListState(path, template: proc(list[str], ?Layer) -> Node, lower: ?Layer):
+actor ListState(path, template: proc(list[str], ?Layer) -> Node, ns: ?str, module: ?str, lower: ?Layer):
     var elems = {}
     var active = {}
     var provisional = set()
@@ -554,12 +558,16 @@ class _ListTransaction(_Transaction):
     accum : dict[str, value]
     state : ?YieldState
     reset: bool
+    ns: ?str
+    module: ?str
 
-    def __init__(self, path, liststate, key_names, key_types):
+    def __init__(self, path, liststate, key_names, key_types, ns, module):
         self.path = path
         self.liststate = liststate
         self.key_names = key_names
         self.key_types = key_types
+        self.ns = ns
+        self.module = module
         self.elems = {}
         self.accum = {}
         self.state = None
@@ -710,10 +718,10 @@ class _ListTransaction(_Transaction):
                 for i, kn in enumerate(self.key_names):
                     r.children.setdefault(kn, gdata.Leaf(self.key_types[i], split_key[i]))
             res.append(r)
-        return gdata.List(self.key_names, res)
+        return gdata.List(self.key_names, res, ns=self.ns, module=self.module)
 
-def ListTransaction(path, liststate: ListState, key_names, key_types):
-    return Transaction(_ListTransaction(path, liststate, key_names, key_types))
+def ListTransaction(path, liststate: ListState, key_names, key_types, ns, module):
+    return Transaction(_ListTransaction(path, liststate, key_names, key_types, ns, module))
 
 
 ################# Transform #####################

--- a/src/orchestron/ttt.act
+++ b/src/orchestron/ttt.act
@@ -1033,7 +1033,7 @@ class _RFSTransaction(_TransformTransactionBase):
                     gdata.Container(dev_content)
                 ])
             })
-        }, ns="http://orchestron.org/yang/orchestron-device.yang")
+        }, ns="http://orchestron.org/yang/orchestron-device.yang", module="orchestron-device")
 
     def update_memory(self, newmem):
         self.memory = newmem

--- a/src/orchestron/ttt.act
+++ b/src/orchestron/ttt.act
@@ -1,5 +1,4 @@
 import yang.adata
-#import orchestron.gdata as gdata
 import yang.gdata as gdata
 import orchestron.device as odev
 from orchestron.device_meta_config import orchestron_rfs__device_entry as DeviceMetaConfig
@@ -318,47 +317,47 @@ actor Session(name: str, rootnode: Node, lowerlayer: ?Layer):
 
 ############## Containers ##################
 
-def Container(template={}, ns:?str=None) -> proc(list[str], ?Layer)->Node:
-    return lambda path, lower: Node(_Container(path, template, ns, lower))
+def Container(template={}, ns:?str=None, module:?str=None) -> proc(list[str], ?Layer)->Node:
+    return lambda path, lower: Node(_Container(path, template, ns, module, lower))
 
 class _Container(_Node):
     elems: dict[str, Node]
     ns: ?str
+    module: ?str
 
-    def __init__(self, path, template: dict[str, proc(list[str], ?Layer)->Node], ns, lower: ?Layer):
+    def __init__(self, path, template: dict[str, proc(list[str], ?Layer)->Node], ns, module, lower: ?Layer):
         self.path = path
         self.elems = {key: templ(path + [key], lower) for key, templ in template.items()}
         self.ns = ns
+        self.module = module
 
     def newtrans(self):
-        return ContainerTransaction(self.path, self.elems, self.ns)
+        return ContainerTransaction(self.path, self.elems, self.ns, self.module)
 
     def get(self):
         #print('####', '(Container)', self.path, actorid(),'NODE GET', err=True)
         res = {tag: node.get() for tag, node in self.elems.items()}
-        ns = self.ns
-        if len(self.path) <= 1 and ns is not None:
-            return gdata.Container(res, ns=ns)
-        else:
-            return gdata.Container(res, ns=self.ns)
+        return gdata.Container(res, ns=self.ns, module=self.module)
 
 
-def ContainerTransaction(path, contents, ns:?str=None):
-    return Transaction(_ContainerTransaction(path, contents, ns))
+def ContainerTransaction(path, contents, ns:?str=None, module:?str=None):
+    return Transaction(_ContainerTransaction(path, contents, ns, module))
 
 class _ContainerTransaction(_Transaction):
     elems : dict[str, Transaction]
     accum : dict[str, value]
     state : ?YieldState
     ns: ?str
+    module: ?str
 
-    def __init__(self, path, contents, ns):
+    def __init__(self, path, contents, ns, module):
         self.path = path
         self.elems = {}
         self.accum = {}
         self.state = None
         self.ns = ns
         self.elems = {key: node.newtrans() for key, node in contents.items()}
+        self.module = module
 
     def configure(self, tid, diff, out, force=False):
         #print('####', tid, '(Container)', self.path, 'configure force:', force, actorid(), err=True)
@@ -481,11 +480,7 @@ class _ContainerTransaction(_Transaction):
     def get(self):
         #print('####', '(Container)', self.path, actorid(), 'GET', err=True)
         res = {tag: node.get() for tag, node in self.elems.items()}
-        ns = self.ns
-        if len(self.path) <= 1 and ns is not None:
-            return gdata.Container(res, ns=ns)
-        else:
-            return gdata.Container(res, ns=self.ns)
+        return gdata.Container(res, ns=self.ns, module=self.module)
 
 
 ################# Lists ####################

--- a/src/orchestron/ttt_gen.act
+++ b/src/orchestron/ttt_gen.act
@@ -61,6 +61,12 @@ def dschema_to_tttsrc(sn: schema.DNode, indent=0, set_ns=True) -> TTTSrc:
     defs = []
     base_defs = []
     act_defs = []
+
+    def nsq(node: schema.DNode) -> str:
+        if set_ns and node.namespace != "":
+            return ", ns='{node.namespace}', module='{node.module}'"
+        return ""
+
     if isinstance(sn, schema.DList):
         for ext in sn.exts:
             extprefix = ext.prefix
@@ -155,8 +161,7 @@ def dschema_to_tttsrc(sn: schema.DNode, indent=0, set_ns=True) -> TTTSrc:
         modeled_input = {input_class}.from_gdata(gdata_input){wrapper_extra_models}
         {wrapper_return}
 """)
-                            nsq = ", ns='{sn.namespace}', module='{sn.module}'" if set_ns and sn.namespace != "" else ""
-                            return TTTSrc(src="ttt.List(ttt.Transform({transform}, {transform_actor_ctor}, lower, log_handler), {repr(sn.key)}, {repr(get_key_types(sn))}{nsq})", input_classes=input_classes, state_classes=state_classes, deserializers=deserializers, imports=imports, defs=defs, base_defs=base_defs, act_defs=act_defs)
+                            return TTTSrc(src="ttt.List(ttt.Transform({transform}, {transform_actor_ctor}, lower, log_handler), {repr(sn.key)}, {repr(get_key_types(sn))}{nsq(sn)})", input_classes=input_classes, state_classes=state_classes, deserializers=deserializers, imports=imports, defs=defs, base_defs=base_defs, act_defs=act_defs)
 
                         elif ext.name == "rfs-transform":
                             base_defs.append(f"""class {transform_name}(ttt.RFSFunction):
@@ -182,21 +187,18 @@ def dschema_to_tttsrc(sn: schema.DNode, indent=0, set_ns=True) -> TTTSrc:
         modeled_input = {input_class}.from_gdata(gdata_input){wrapper_extra_models}
         {wrapper_return}
 """)
-                            nsq = ", ns='{sn.namespace}', module='{sn.module}'" if set_ns and sn.namespace != "" else ""
-                            return TTTSrc(src="ttt.List(ttt.RFSTransform({transform}, dev_mgr, {transform_actor_ctor}, lower, log_handler), {repr(sn.key)}, {repr(get_key_types(sn))}{nsq})", input_classes=input_classes, state_classes=state_classes, deserializers=deserializers, imports=imports, defs=defs, base_defs=base_defs, act_defs=act_defs)
+                            return TTTSrc(src="ttt.List(ttt.RFSTransform({transform}, dev_mgr, {transform_actor_ctor}, lower, log_handler), {repr(sn.key)}, {repr(get_key_types(sn))}{nsq(sn)})", input_classes=input_classes, state_classes=state_classes, deserializers=deserializers, imports=imports, defs=defs, base_defs=base_defs, act_defs=act_defs)
                         raise ValueError("Unknown extension name: {ext.name}")
                     else:
                         raise ValueError("Missing argument to orchestron:transform. Add path to transform as arg.")
                 elif ext.name == "device":
                     if extarg is not None:
                         raise ValueError("Extraneous argument to orchestron:device. Remove argument.")
-                    nsq = ", ns='{sn.namespace}', module='{sn.module}'" if set_ns and sn.namespace != "" else ""
-                    return TTTSrc(src="ttt.List(ttt.Device(dev_mgr, log_handler), {repr(sn.key)}, {repr(get_key_types(sn))}{nsq})", input_classes=input_classes, state_classes=state_classes, deserializers=deserializers, imports=imports, defs=defs, base_defs=base_defs, act_defs=act_defs)
+                    return TTTSrc(src="ttt.List(ttt.Device(dev_mgr, log_handler), {repr(sn.key)}, {repr(get_key_types(sn))}{nsq(sn)})", input_classes=input_classes, state_classes=state_classes, deserializers=deserializers, imports=imports, defs=defs, base_defs=base_defs, act_defs=act_defs)
                 elif ext.name == "device-config":
                     if extarg is not None:
                         raise ValueError("Extraneous argument to orchestron:device-config. Remove argument.")
-                    nsq = ", ns='{sn.namespace}', module='{sn.module}'" if set_ns and sn.namespace != "" else ""
-                    return TTTSrc(src="ttt.List(ttt.DeviceConfig(dev_mgr, log_handler), {repr(sn.key)}, {repr(get_key_types(sn))}{nsq})", input_classes=input_classes, state_classes=state_classes, deserializers=deserializers, imports=imports, defs=defs, base_defs=base_defs, act_defs=act_defs)
+                    return TTTSrc(src="ttt.List(ttt.DeviceConfig(dev_mgr, log_handler), {repr(sn.key)}, {repr(get_key_types(sn))}{nsq(sn)})", input_classes=input_classes, state_classes=state_classes, deserializers=deserializers, imports=imports, defs=defs, base_defs=base_defs, act_defs=act_defs)
 
         # List without an extension
         children_res = children_to_tttsrc(sn)
@@ -207,8 +209,7 @@ def dschema_to_tttsrc(sn: schema.DNode, indent=0, set_ns=True) -> TTTSrc:
         defs.extend(children_res.defs)
         base_defs.extend(children_res.base_defs)
         act_defs.extend(children_res.act_defs)
-        nsq = ", ns='{sn.namespace}', module='{sn.module}'" if set_ns and sn.namespace != "" else ""
-        return TTTSrc(src="ttt.List(ttt.Container({{{children_res.src}}}), {repr(sn.key)}, {repr(get_key_types(sn))}{nsq})", input_classes=input_classes, state_classes=state_classes, deserializers=deserializers, imports=imports, defs=defs, base_defs=base_defs, act_defs=act_defs)
+        return TTTSrc(src="ttt.List(ttt.Container({{{children_res.src}}}), {repr(sn.key)}, {repr(get_key_types(sn))}{nsq(sn)})", input_classes=input_classes, state_classes=state_classes, deserializers=deserializers, imports=imports, defs=defs, base_defs=base_defs, act_defs=act_defs)
 
     elif isinstance(sn, schema.DNodeInner):
         sn_children = sn.children
@@ -220,8 +221,7 @@ def dschema_to_tttsrc(sn: schema.DNode, indent=0, set_ns=True) -> TTTSrc:
         defs.extend(children_res.defs)
         base_defs.extend(children_res.base_defs)
         act_defs.extend(children_res.act_defs)
-        nsq = (", ns='{sn.namespace}', module='{sn.module}'") if set_ns and sn.namespace != "" else ""
-        return TTTSrc(src="ttt.Container({{{children_res.src}}}{nsq})", input_classes=input_classes, state_classes=state_classes, deserializers=deserializers, imports=imports, defs=defs, base_defs=base_defs, act_defs=act_defs)
+        return TTTSrc(src="ttt.Container({{{children_res.src}}}{nsq(sn)})", input_classes=input_classes, state_classes=state_classes, deserializers=deserializers, imports=imports, defs=defs, base_defs=base_defs, act_defs=act_defs)
 
     raise NotImplementedError(f"Unhandled schema type: {type(sn)}")
 

--- a/src/orchestron/ttt_gen.act
+++ b/src/orchestron/ttt_gen.act
@@ -155,7 +155,8 @@ def dschema_to_tttsrc(sn: schema.DNode, indent=0, set_ns=True) -> TTTSrc:
         modeled_input = {input_class}.from_gdata(gdata_input){wrapper_extra_models}
         {wrapper_return}
 """)
-                            return TTTSrc(src=f"ttt.List(ttt.Transform({transform}, {transform_actor_ctor}, lower, log_handler), {repr(sn.key)}, {repr(get_key_types(sn))})", input_classes=input_classes, state_classes=state_classes, deserializers=deserializers, imports=imports, defs=defs, base_defs=base_defs, act_defs=act_defs)
+                            nsq = f", ns='{sn.namespace}', module='{sn.module}'" if sn.namespace != "" else ""
+                            return TTTSrc(src=f"ttt.List(ttt.Transform({transform}, {transform_actor_ctor}, lower, log_handler), {repr(sn.key)}, {repr(get_key_types(sn))}{nsq})", input_classes=input_classes, state_classes=state_classes, deserializers=deserializers, imports=imports, defs=defs, base_defs=base_defs, act_defs=act_defs)
 
                         elif ext.name == "rfs-transform":
                             base_defs.append(f"""class {transform_name}(ttt.RFSFunction):
@@ -181,18 +182,21 @@ def dschema_to_tttsrc(sn: schema.DNode, indent=0, set_ns=True) -> TTTSrc:
         modeled_input = {input_class}.from_gdata(gdata_input){wrapper_extra_models}
         {wrapper_return}
 """)
-                            return TTTSrc(src=f"ttt.List(ttt.RFSTransform({transform}, dev_mgr, {transform_actor_ctor}, lower, log_handler), {repr(sn.key)}, {repr(get_key_types(sn))})", input_classes=input_classes, state_classes=state_classes, deserializers=deserializers, imports=imports, defs=defs, base_defs=base_defs, act_defs=act_defs)
+                            nsq = f", ns='{sn.namespace}', module='{sn.module}'" if sn.namespace != "" else ""
+                            return TTTSrc(src=f"ttt.List(ttt.RFSTransform({transform}, dev_mgr, {transform_actor_ctor}, lower, log_handler), {repr(sn.key)}, {repr(get_key_types(sn))}{nsq})", input_classes=input_classes, state_classes=state_classes, deserializers=deserializers, imports=imports, defs=defs, base_defs=base_defs, act_defs=act_defs)
                         raise ValueError(f"Unknown extension name: {ext.name}")
                     else:
                         raise ValueError("Missing argument to orchestron:transform. Add path to transform as arg.")
                 elif ext.name == "device":
                     if extarg is not None:
                         raise ValueError("Extraneous argument to orchestron:device. Remove argument.")
-                    return TTTSrc(src=f"ttt.List(ttt.Device(dev_mgr, log_handler), {repr(sn.key)}, {repr(get_key_types(sn))})", input_classes=input_classes, state_classes=state_classes, deserializers=deserializers, imports=imports, defs=defs, base_defs=base_defs, act_defs=act_defs)
+                    nsq = f", ns='{sn.namespace}', module='{sn.module}'" if sn.namespace != "" else ""
+                    return TTTSrc(src=f"ttt.List(ttt.Device(dev_mgr, log_handler), {repr(sn.key)}, {repr(get_key_types(sn))}{nsq})", input_classes=input_classes, state_classes=state_classes, deserializers=deserializers, imports=imports, defs=defs, base_defs=base_defs, act_defs=act_defs)
                 elif ext.name == "device-config":
                     if extarg is not None:
                         raise ValueError("Extraneous argument to orchestron:device-config. Remove argument.")
-                    return TTTSrc(src=f"ttt.List(ttt.DeviceConfig(dev_mgr, log_handler), {repr(sn.key)}, {repr(get_key_types(sn))})", input_classes=input_classes, state_classes=state_classes, deserializers=deserializers, imports=imports, defs=defs, base_defs=base_defs, act_defs=act_defs)
+                    nsq = f", ns='{sn.namespace}', module='{sn.module}'" if sn.namespace != "" else ""
+                    return TTTSrc(src=f"ttt.List(ttt.DeviceConfig(dev_mgr, log_handler), {repr(sn.key)}, {repr(get_key_types(sn))}{nsq})", input_classes=input_classes, state_classes=state_classes, deserializers=deserializers, imports=imports, defs=defs, base_defs=base_defs, act_defs=act_defs)
 
         # List without an extension
         children_res = children_to_tttsrc(sn)
@@ -203,8 +207,8 @@ def dschema_to_tttsrc(sn: schema.DNode, indent=0, set_ns=True) -> TTTSrc:
         defs.extend(children_res.defs)
         base_defs.extend(children_res.base_defs)
         act_defs.extend(children_res.act_defs)
-        nsq = (", ns='{sn.namespace}', module='{sn.module}'") if set_ns and sn.namespace != "" else ""
-        return TTTSrc(src="ttt.List(ttt.Container({{{children_res.src}}}{nsq}), {repr(sn.key)}, {repr(get_key_types(sn))})", input_classes=input_classes, state_classes=state_classes, deserializers=deserializers, imports=imports, defs=defs, base_defs=base_defs, act_defs=act_defs)
+        nsq = f", ns='{sn.namespace}', module='{sn.module}'" if set_ns and sn.namespace != "" else ""
+        return TTTSrc(src=f"ttt.List(ttt.Container({{{children_res.src}}}{nsq}), {repr(sn.key)}, {repr(get_key_types(sn))}{nsq})", input_classes=input_classes, state_classes=state_classes, deserializers=deserializers, imports=imports, defs=defs, base_defs=base_defs, act_defs=act_defs)
 
     elif isinstance(sn, schema.DNodeInner):
         sn_children = sn.children

--- a/src/orchestron/ttt_gen.act
+++ b/src/orchestron/ttt_gen.act
@@ -155,8 +155,8 @@ def dschema_to_tttsrc(sn: schema.DNode, indent=0, set_ns=True) -> TTTSrc:
         modeled_input = {input_class}.from_gdata(gdata_input){wrapper_extra_models}
         {wrapper_return}
 """)
-                            nsq = f", ns='{sn.namespace}', module='{sn.module}'" if sn.namespace != "" else ""
-                            return TTTSrc(src=f"ttt.List(ttt.Transform({transform}, {transform_actor_ctor}, lower, log_handler), {repr(sn.key)}, {repr(get_key_types(sn))}{nsq})", input_classes=input_classes, state_classes=state_classes, deserializers=deserializers, imports=imports, defs=defs, base_defs=base_defs, act_defs=act_defs)
+                            nsq = ", ns='{sn.namespace}', module='{sn.module}'" if set_ns and sn.namespace != "" else ""
+                            return TTTSrc(src="ttt.List(ttt.Transform({transform}, {transform_actor_ctor}, lower, log_handler), {repr(sn.key)}, {repr(get_key_types(sn))}{nsq})", input_classes=input_classes, state_classes=state_classes, deserializers=deserializers, imports=imports, defs=defs, base_defs=base_defs, act_defs=act_defs)
 
                         elif ext.name == "rfs-transform":
                             base_defs.append(f"""class {transform_name}(ttt.RFSFunction):
@@ -182,21 +182,21 @@ def dschema_to_tttsrc(sn: schema.DNode, indent=0, set_ns=True) -> TTTSrc:
         modeled_input = {input_class}.from_gdata(gdata_input){wrapper_extra_models}
         {wrapper_return}
 """)
-                            nsq = f", ns='{sn.namespace}', module='{sn.module}'" if sn.namespace != "" else ""
-                            return TTTSrc(src=f"ttt.List(ttt.RFSTransform({transform}, dev_mgr, {transform_actor_ctor}, lower, log_handler), {repr(sn.key)}, {repr(get_key_types(sn))}{nsq})", input_classes=input_classes, state_classes=state_classes, deserializers=deserializers, imports=imports, defs=defs, base_defs=base_defs, act_defs=act_defs)
-                        raise ValueError(f"Unknown extension name: {ext.name}")
+                            nsq = ", ns='{sn.namespace}', module='{sn.module}'" if set_ns and sn.namespace != "" else ""
+                            return TTTSrc(src="ttt.List(ttt.RFSTransform({transform}, dev_mgr, {transform_actor_ctor}, lower, log_handler), {repr(sn.key)}, {repr(get_key_types(sn))}{nsq})", input_classes=input_classes, state_classes=state_classes, deserializers=deserializers, imports=imports, defs=defs, base_defs=base_defs, act_defs=act_defs)
+                        raise ValueError("Unknown extension name: {ext.name}")
                     else:
                         raise ValueError("Missing argument to orchestron:transform. Add path to transform as arg.")
                 elif ext.name == "device":
                     if extarg is not None:
                         raise ValueError("Extraneous argument to orchestron:device. Remove argument.")
-                    nsq = f", ns='{sn.namespace}', module='{sn.module}'" if sn.namespace != "" else ""
-                    return TTTSrc(src=f"ttt.List(ttt.Device(dev_mgr, log_handler), {repr(sn.key)}, {repr(get_key_types(sn))}{nsq})", input_classes=input_classes, state_classes=state_classes, deserializers=deserializers, imports=imports, defs=defs, base_defs=base_defs, act_defs=act_defs)
+                    nsq = ", ns='{sn.namespace}', module='{sn.module}'" if set_ns and sn.namespace != "" else ""
+                    return TTTSrc(src="ttt.List(ttt.Device(dev_mgr, log_handler), {repr(sn.key)}, {repr(get_key_types(sn))}{nsq})", input_classes=input_classes, state_classes=state_classes, deserializers=deserializers, imports=imports, defs=defs, base_defs=base_defs, act_defs=act_defs)
                 elif ext.name == "device-config":
                     if extarg is not None:
                         raise ValueError("Extraneous argument to orchestron:device-config. Remove argument.")
-                    nsq = f", ns='{sn.namespace}', module='{sn.module}'" if sn.namespace != "" else ""
-                    return TTTSrc(src=f"ttt.List(ttt.DeviceConfig(dev_mgr, log_handler), {repr(sn.key)}, {repr(get_key_types(sn))}{nsq})", input_classes=input_classes, state_classes=state_classes, deserializers=deserializers, imports=imports, defs=defs, base_defs=base_defs, act_defs=act_defs)
+                    nsq = ", ns='{sn.namespace}', module='{sn.module}'" if set_ns and sn.namespace != "" else ""
+                    return TTTSrc(src="ttt.List(ttt.DeviceConfig(dev_mgr, log_handler), {repr(sn.key)}, {repr(get_key_types(sn))}{nsq})", input_classes=input_classes, state_classes=state_classes, deserializers=deserializers, imports=imports, defs=defs, base_defs=base_defs, act_defs=act_defs)
 
         # List without an extension
         children_res = children_to_tttsrc(sn)
@@ -207,8 +207,8 @@ def dschema_to_tttsrc(sn: schema.DNode, indent=0, set_ns=True) -> TTTSrc:
         defs.extend(children_res.defs)
         base_defs.extend(children_res.base_defs)
         act_defs.extend(children_res.act_defs)
-        nsq = f", ns='{sn.namespace}', module='{sn.module}'" if set_ns and sn.namespace != "" else ""
-        return TTTSrc(src=f"ttt.List(ttt.Container({{{children_res.src}}}{nsq}), {repr(sn.key)}, {repr(get_key_types(sn))}{nsq})", input_classes=input_classes, state_classes=state_classes, deserializers=deserializers, imports=imports, defs=defs, base_defs=base_defs, act_defs=act_defs)
+        nsq = ", ns='{sn.namespace}', module='{sn.module}'" if set_ns and sn.namespace != "" else ""
+        return TTTSrc(src="ttt.List(ttt.Container({{{children_res.src}}}), {repr(sn.key)}, {repr(get_key_types(sn))}{nsq})", input_classes=input_classes, state_classes=state_classes, deserializers=deserializers, imports=imports, defs=defs, base_defs=base_defs, act_defs=act_defs)
 
     elif isinstance(sn, schema.DNodeInner):
         sn_children = sn.children

--- a/src/orchestron/ttt_gen.act
+++ b/src/orchestron/ttt_gen.act
@@ -203,8 +203,8 @@ def dschema_to_tttsrc(sn: schema.DNode, indent=0, set_ns=True) -> TTTSrc:
         defs.extend(children_res.defs)
         base_defs.extend(children_res.base_defs)
         act_defs.extend(children_res.act_defs)
-        ns = (", ns='{sn.namespace}'") if set_ns else ""
-        return TTTSrc(src=f"ttt.List(ttt.Container({{{children_res.src}}}{ns}), {repr(sn.key)}, {repr(get_key_types(sn))})", input_classes=input_classes, state_classes=state_classes, deserializers=deserializers, imports=imports, defs=defs, base_defs=base_defs, act_defs=act_defs)
+        nsq = (", ns='{sn.namespace}', module='{sn.module}'") if set_ns and sn.namespace != "" else ""
+        return TTTSrc(src="ttt.List(ttt.Container({{{children_res.src}}}{nsq}), {repr(sn.key)}, {repr(get_key_types(sn))})", input_classes=input_classes, state_classes=state_classes, deserializers=deserializers, imports=imports, defs=defs, base_defs=base_defs, act_defs=act_defs)
 
     elif isinstance(sn, schema.DNodeInner):
         sn_children = sn.children
@@ -216,8 +216,8 @@ def dschema_to_tttsrc(sn: schema.DNode, indent=0, set_ns=True) -> TTTSrc:
         defs.extend(children_res.defs)
         base_defs.extend(children_res.base_defs)
         act_defs.extend(children_res.act_defs)
-        ns = (", ns='{sn.namespace}'") if set_ns else ""
-        return TTTSrc(src=f"ttt.Container({{{children_res.src}}}{ns})", input_classes=input_classes, state_classes=state_classes, deserializers=deserializers, imports=imports, defs=defs, base_defs=base_defs, act_defs=act_defs)
+        nsq = (", ns='{sn.namespace}', module='{sn.module}'") if set_ns and sn.namespace != "" else ""
+        return TTTSrc(src="ttt.Container({{{children_res.src}}}{nsq})", input_classes=input_classes, state_classes=state_classes, deserializers=deserializers, imports=imports, defs=defs, base_defs=base_defs, act_defs=act_defs)
 
     raise NotImplementedError(f"Unhandled schema type: {type(sn)}")
 

--- a/test/golden/test_ttt_gen/odev
+++ b/test/golden/test_ttt_gen/odev
@@ -13,5 +13,5 @@ import yang.gdata
 
 
 def get_ttt(lower: ?ttt.Layer, dev_mgr: odev.DeviceManager, log_handler: ?logging.Handler=None) -> proc(list[str],?ttt.Layer)->ttt.Node:
-    r = ttt.Container({"devices": ttt.Container({"device": ttt.List(ttt.DeviceConfig(dev_mgr, log_handler), ['name'], ['string'])}, ns='http://orchestron.org/yang/orchestron-device.yang')}, ns='')
+    r = ttt.Container({"devices": ttt.Container({"device": ttt.List(ttt.DeviceConfig(dev_mgr, log_handler), ['name'], ['string'])}, ns='http://orchestron.org/yang/orchestron-device.yang', module='orchestron-device')})
     return r

--- a/test/golden/test_ttt_gen/odev
+++ b/test/golden/test_ttt_gen/odev
@@ -13,5 +13,5 @@ import yang.gdata
 
 
 def get_ttt(lower: ?ttt.Layer, dev_mgr: odev.DeviceManager, log_handler: ?logging.Handler=None) -> proc(list[str],?ttt.Layer)->ttt.Node:
-    r = ttt.Container({"devices": ttt.Container({"device": ttt.List(ttt.DeviceConfig(dev_mgr, log_handler), ['name'], ['string'])}, ns='http://orchestron.org/yang/orchestron-device.yang', module='orchestron-device')})
+    r = ttt.Container({"devices": ttt.Container({"device": ttt.List(ttt.DeviceConfig(dev_mgr, log_handler), ['name'], ['string'], ns='http://orchestron.org/yang/orchestron-device.yang', module='orchestron-device')}, ns='http://orchestron.org/yang/orchestron-device.yang', module='orchestron-device')})
     return r

--- a/test/golden/test_ttt_gen/odev
+++ b/test/golden/test_ttt_gen/odev
@@ -13,5 +13,5 @@ import yang.gdata
 
 
 def get_ttt(lower: ?ttt.Layer, dev_mgr: odev.DeviceManager, log_handler: ?logging.Handler=None) -> proc(list[str],?ttt.Layer)->ttt.Node:
-    r = ttt.Container({"devices": ttt.Container({"device": ttt.List(ttt.DeviceConfig(dev_mgr, log_handler), ['name'], ['string'], ns='http://orchestron.org/yang/orchestron-device.yang', module='orchestron-device')}, ns='http://orchestron.org/yang/orchestron-device.yang', module='orchestron-device')})
+    r = ttt.Container({"devices": ttt.Container({"device": ttt.List(ttt.DeviceConfig(dev_mgr, log_handler), ['name'], ['string'])}, ns='http://orchestron.org/yang/orchestron-device.yang', module='orchestron-device')})
     return r

--- a/test/golden/test_ttt_gen/ttt_gen_cfs_ttt
+++ b/test/golden/test_ttt_gen/ttt_gen_cfs_ttt
@@ -13,5 +13,5 @@ import respnet.cfs
 
 
 def get_ttt(lower: ?ttt.Layer, dev_mgr: odev.DeviceManager, log_handler: ?logging.Handler=None) -> proc(list[str],?ttt.Layer)->ttt.Node:
-    r = ttt.Container({"c1": ttt.Container({"foo": ttt.List(ttt.Container({"bar": ttt.List(ttt.Transform(respnet.cfs.Foobar, None, lower, log_handler), ['name'], ['string'])}), ['name'], ['string'])}, ns='http://example.com/foo', module='foo')})
+    r = ttt.Container({"c1": ttt.Container({"foo": ttt.List(ttt.Container({"bar": ttt.List(ttt.Transform(respnet.cfs.Foobar, None, lower, log_handler), ['name'], ['string'], ns='http://example.com/foo', module='foo')}), ['name'], ['string'])}, ns='http://example.com/foo', module='foo')})
     return r

--- a/test/golden/test_ttt_gen/ttt_gen_cfs_ttt
+++ b/test/golden/test_ttt_gen/ttt_gen_cfs_ttt
@@ -13,5 +13,5 @@ import respnet.cfs
 
 
 def get_ttt(lower: ?ttt.Layer, dev_mgr: odev.DeviceManager, log_handler: ?logging.Handler=None) -> proc(list[str],?ttt.Layer)->ttt.Node:
-    r = ttt.Container({"c1": ttt.Container({"foo": ttt.List(ttt.Container({"bar": ttt.List(ttt.Transform(respnet.cfs.Foobar, None, lower, log_handler), ['name'], ['string'])}), ['name'], ['string'])}, ns='http://example.com/foo')}, ns='')
+    r = ttt.Container({"c1": ttt.Container({"foo": ttt.List(ttt.Container({"bar": ttt.List(ttt.Transform(respnet.cfs.Foobar, None, lower, log_handler), ['name'], ['string'])}), ['name'], ['string'])}, ns='http://example.com/foo', module='foo')})
     return r

--- a/test/golden/test_ttt_gen/ttt_gen_cfs_ttt
+++ b/test/golden/test_ttt_gen/ttt_gen_cfs_ttt
@@ -13,5 +13,5 @@ import respnet.cfs
 
 
 def get_ttt(lower: ?ttt.Layer, dev_mgr: odev.DeviceManager, log_handler: ?logging.Handler=None) -> proc(list[str],?ttt.Layer)->ttt.Node:
-    r = ttt.Container({"c1": ttt.Container({"foo": ttt.List(ttt.Container({"bar": ttt.List(ttt.Transform(respnet.cfs.Foobar, None, lower, log_handler), ['name'], ['string'], ns='http://example.com/foo', module='foo')}), ['name'], ['string'])}, ns='http://example.com/foo', module='foo')})
+    r = ttt.Container({"c1": ttt.Container({"foo": ttt.List(ttt.Container({"bar": ttt.List(ttt.Transform(respnet.cfs.Foobar, None, lower, log_handler), ['name'], ['string'])}), ['name'], ['string'])}, ns='http://example.com/foo', module='foo')})
     return r

--- a/test/golden/test_ttt_gen/ttt_gen_rfs_ttt
+++ b/test/golden/test_ttt_gen/ttt_gen_rfs_ttt
@@ -13,5 +13,5 @@ import respnet.rfs
 
 
 def get_ttt(lower: ?ttt.Layer, dev_mgr: odev.DeviceManager, log_handler: ?logging.Handler=None) -> proc(list[str],?ttt.Layer)->ttt.Node:
-    r = ttt.Container({"device": ttt.List(ttt.Device(dev_mgr, log_handler), ['name'], ['string'], ns='http://orchestron.org/yang/orchestron-rfs.yang', module='orchestron-rfs'), "rfs": ttt.List(ttt.Container({"backbone-interface": ttt.List(ttt.RFSTransform(respnet.rfs.BBInterface, dev_mgr, None, lower, log_handler), ['name'], ['string'], ns='http://example.com/foo', module='foo')}, ns='http://orchestron.org/yang/orchestron-rfs.yang', module='orchestron-rfs'), ['name'], ['string'], ns='http://orchestron.org/yang/orchestron-rfs.yang', module='orchestron-rfs')})
+    r = ttt.Container({"device": ttt.List(ttt.Device(dev_mgr, log_handler), ['name'], ['string'], ns='http://orchestron.org/yang/orchestron-rfs.yang', module='orchestron-rfs'), "rfs": ttt.List(ttt.Container({"backbone-interface": ttt.List(ttt.RFSTransform(respnet.rfs.BBInterface, dev_mgr, None, lower, log_handler), ['name'], ['string'], ns='http://example.com/foo', module='foo')}), ['name'], ['string'], ns='http://orchestron.org/yang/orchestron-rfs.yang', module='orchestron-rfs')})
     return r

--- a/test/golden/test_ttt_gen/ttt_gen_rfs_ttt
+++ b/test/golden/test_ttt_gen/ttt_gen_rfs_ttt
@@ -13,5 +13,5 @@ import respnet.rfs
 
 
 def get_ttt(lower: ?ttt.Layer, dev_mgr: odev.DeviceManager, log_handler: ?logging.Handler=None) -> proc(list[str],?ttt.Layer)->ttt.Node:
-    r = ttt.Container({"device": ttt.List(ttt.Device(dev_mgr, log_handler), ['name'], ['string']), "rfs": ttt.List(ttt.Container({"backbone-interface": ttt.List(ttt.RFSTransform(respnet.rfs.BBInterface, dev_mgr, None, lower, log_handler), ['name'], ['string'])}, ns='http://orchestron.org/yang/orchestron-rfs.yang'), ['name'], ['string'])}, ns='')
+    r = ttt.Container({"device": ttt.List(ttt.Device(dev_mgr, log_handler), ['name'], ['string']), "rfs": ttt.List(ttt.Container({"backbone-interface": ttt.List(ttt.RFSTransform(respnet.rfs.BBInterface, dev_mgr, None, lower, log_handler), ['name'], ['string'])}, ns='http://orchestron.org/yang/orchestron-rfs.yang', module='orchestron-rfs'), ['name'], ['string'])})
     return r

--- a/test/golden/test_ttt_gen/ttt_gen_rfs_ttt
+++ b/test/golden/test_ttt_gen/ttt_gen_rfs_ttt
@@ -13,5 +13,5 @@ import respnet.rfs
 
 
 def get_ttt(lower: ?ttt.Layer, dev_mgr: odev.DeviceManager, log_handler: ?logging.Handler=None) -> proc(list[str],?ttt.Layer)->ttt.Node:
-    r = ttt.Container({"device": ttt.List(ttt.Device(dev_mgr, log_handler), ['name'], ['string']), "rfs": ttt.List(ttt.Container({"backbone-interface": ttt.List(ttt.RFSTransform(respnet.rfs.BBInterface, dev_mgr, None, lower, log_handler), ['name'], ['string'])}, ns='http://orchestron.org/yang/orchestron-rfs.yang', module='orchestron-rfs'), ['name'], ['string'])})
+    r = ttt.Container({"device": ttt.List(ttt.Device(dev_mgr, log_handler), ['name'], ['string'], ns='http://orchestron.org/yang/orchestron-rfs.yang', module='orchestron-rfs'), "rfs": ttt.List(ttt.Container({"backbone-interface": ttt.List(ttt.RFSTransform(respnet.rfs.BBInterface, dev_mgr, None, lower, log_handler), ['name'], ['string'], ns='http://example.com/foo', module='foo')}, ns='http://orchestron.org/yang/orchestron-rfs.yang', module='orchestron-rfs'), ['name'], ['string'], ns='http://orchestron.org/yang/orchestron-rfs.yang', module='orchestron-rfs')})
     return r


### PR DESCRIPTION
Include the new gdata `module` attribute in the TTT machinery, so that the transform outputs conform to namespace qualifier rules too. With this fix I can see the correct JSON output for each layer in respnet - including the module name prefix for top-level node.

I also adjusted ttt_gen.act to not emit empty namespace qualifiers for DRoot, just like I did in prdaclass.