### PR TITLE
Update acton-yang

### DIFF
--- a/build.act.json
+++ b/build.act.json
@@ -7,8 +7,8 @@
         },
         "yang": {
             "repo_url": "https://github.com/orchestron-orchestrator/acton-yang.git",
-            "url": "https://github.com/orchestron-orchestrator/acton-yang/archive/77eb1f35fa5ef9f171ec5fbb6631a8b8af8c983b.zip",
-            "hash": "12205b67c4f0bbec986e598e7a3cf4a12ec3943d9ca18a719c86ce1e58fdde5f6030"
+            "url": "https://github.com/orchestron-orchestrator/acton-yang/archive/d52ee0009b0479abc3ebcf75de385055014d4d8b.zip",
+            "hash": "1220ee5f04862415c8f923eb04793ce684badf48b2e64fe8847f1db72a7621ffd235"
         }
     },
     "zig_dependencies": {}

--- a/gen_dmc/build.act.json
+++ b/gen_dmc/build.act.json
@@ -2,8 +2,8 @@
     "dependencies": {
         "yang": {
             "repo_url": "https://github.com/orchestron-orchestrator/acton-yang.git",
-            "url": "https://github.com/orchestron-orchestrator/acton-yang/archive/77eb1f35fa5ef9f171ec5fbb6631a8b8af8c983b.zip",
-            "hash": "12205b67c4f0bbec986e598e7a3cf4a12ec3943d9ca18a719c86ce1e58fdde5f6030"
+            "url": "https://github.com/orchestron-orchestrator/acton-yang/archive/d52ee0009b0479abc3ebcf75de385055014d4d8b.zip",
+            "hash": "1220ee5f04862415c8f923eb04793ce684badf48b2e64fe8847f1db72a7621ffd235"
         }
     },
     "zig_dependencies": {}

--- a/src/orchestron/device_meta_config.act
+++ b/src/orchestron/device_meta_config.act
@@ -38,7 +38,7 @@ class orchestron_rfs__device__address__initial_credentials_entry(yang.adata.MNod
         _key = self.key
         if _key is not None:
             children['key'] = yang.gdata.Leaf('string', _key)
-        return yang.gdata.Container(children, [str(self.username), str(self.password), str(self.key)])
+        return yang.gdata.Container(children, [yang.gdata.yang_str(self.username), yang.gdata.yang_str(self.password), yang.gdata.yang_str(self.key)])
 
     @staticmethod
     mut def from_gdata(n: yang.gdata.Node) -> orchestron_rfs__device__address__initial_credentials_entry:
@@ -125,7 +125,7 @@ class orchestron_rfs__device__address_entry(yang.adata.MNode):
         _initial_credentials = self.initial_credentials
         if _initial_credentials is not None:
             children['initial-credentials'] = _initial_credentials.to_gdata()
-        return yang.gdata.Container(children, [str(self.name)])
+        return yang.gdata.Container(children, [yang.gdata.yang_str(self.name)])
 
     @staticmethod
     mut def from_gdata(n: yang.gdata.Node) -> orchestron_rfs__device__address_entry:
@@ -200,7 +200,7 @@ class orchestron_rfs__device__credentials__key_entry(yang.adata.MNode):
         _private_key = self.private_key
         if _private_key is not None:
             children['private-key'] = yang.gdata.Leaf('string', _private_key)
-        return yang.gdata.Container(children, [str(self.key)])
+        return yang.gdata.Container(children, [yang.gdata.yang_str(self.key)])
 
     @staticmethod
     mut def from_gdata(n: yang.gdata.Node) -> orchestron_rfs__device__credentials__key_entry:
@@ -316,7 +316,7 @@ class orchestron_rfs__device__initial_credentials_entry(yang.adata.MNode):
         _key = self.key
         if _key is not None:
             children['key'] = yang.gdata.Leaf('string', _key)
-        return yang.gdata.Container(children, [str(self.username), str(self.password), str(self.key)])
+        return yang.gdata.Container(children, [yang.gdata.yang_str(self.username), yang.gdata.yang_str(self.password), yang.gdata.yang_str(self.key)])
 
     @staticmethod
     mut def from_gdata(n: yang.gdata.Node) -> orchestron_rfs__device__initial_credentials_entry:
@@ -406,7 +406,7 @@ class orchestron_rfs__device__mock__module_entry(yang.adata.MNode):
         if _revision is not None:
             children['revision'] = yang.gdata.Leaf('string', _revision)
         children['feature'] = yang.gdata.LeafList('string', self.feature)
-        return yang.gdata.Container(children, [str(self.name)])
+        return yang.gdata.Container(children, [yang.gdata.yang_str(self.name)])
 
     @staticmethod
     mut def from_gdata(n: yang.gdata.Node) -> orchestron_rfs__device__mock__module_entry:
@@ -532,7 +532,7 @@ class orchestron_rfs__device_entry(yang.adata.MNode):
         _mock = self.mock
         if _mock is not None:
             children['mock'] = _mock.to_gdata()
-        return yang.gdata.Container(children, [str(self.name)])
+        return yang.gdata.Container(children, [yang.gdata.yang_str(self.name)])
 
     @staticmethod
     mut def from_gdata(n: yang.gdata.Node) -> orchestron_rfs__device_entry:


### PR DESCRIPTION
Revert list element key attribute serialization. The output is used in .to_xmlstr() and .to_dict() so we must preserve it until key_str() is available on all related nodes.