### PR TITLE
Restore list element Container missing key

### DIFF
--- a/src/orchestron/ttt.act
+++ b/src/orchestron/ttt.act
@@ -67,6 +67,32 @@ def merge(cfg_per_src: dict[str,gdata.Node]):
     else:
         raise ValueError("Nothing to merge")
 
+def split_key_str(key_str: str) -> list[str]:
+    """
+    Split a comma-separated string into individual components,
+    respecting escaped commas (\\,).
+    """
+    result = []
+    current = ""
+    i = 0
+
+    while i < len(key_str):
+        if key_str[i] == '\\' and i + 1 < len(key_str) and key_str[i + 1] == ',':
+            current += ','
+            i += 2
+        elif key_str[i] == ',':
+            result.append(current)
+            current = ""
+            i += 1
+        else:
+            current += key_str[i]
+            i += 1
+
+    # Last, or only element
+    if current != "" or i > 0:
+        result.append(current)
+
+    return result
 
 ##################### Node & Transactions #####################
 
@@ -255,6 +281,7 @@ actor Session(name: str, rootnode: Node, lowerlayer: ?Layer):
                 root.wait_complete(tid_state, done)
 
     def get():
+        #print('####', '(Layer)', name, 'GET', root, err=True)
         return root.get()
 
     def below():
@@ -281,6 +308,7 @@ class _Container(_Node):
         return ContainerTransaction(self.path, self.elems, self.ns)
 
     def get(self):
+        #print('####', '(Container)', self.path, actorid(),'NODE GET', err=True)
         res = {}
         for tag,node in self.elems.items():
             res[tag] = node.get()
@@ -410,6 +438,7 @@ class _ContainerTransaction(_Transaction):
             pass
 
     def get(self):
+        #print('####', '(Container)', self.path, actorid(), 'GET', err=True)
         res = {}
         for tag,node in self.elems.items():
             res[tag] = node.get()
@@ -436,6 +465,7 @@ class _List(_Node):
         return ListTransaction(self.path, self.liststate)
 
     def get(self):
+        #print('####', '(List)', self.path, 'NODE GET', err=True)
         res = []
         for key,node in self.liststate.all().items():
             r = node.get()
@@ -617,11 +647,21 @@ class _ListTransaction(_Transaction):
             #print('#### ...... (List)', self.path, 'wait_complete_cont empty state!!!', err=True)
 
     def get(self):
+        #print('####', '(List)', self.path, 'GET', err=True)
         res = []
         for key,node in self.liststate.all().items():
             r = node.get()
             if isinstance(r, gdata.Container):
-                res.append(r)
+                if r.key == []:
+                    # Restore the list element Container.key attribute and key leaf children, to keep the gdata valid
+                    #print('####', '(List)', self.path, 'RESTORING KEY', key, err=True)
+                    split_key = split_key_str(key)
+                    list_element = gdata.Container(r.children, split_key)
+                    for kn, kv in zip(["name"], split_key):
+                        list_element.children.setdefault(kn, gdata.Leaf("string", kv))
+                else:
+                    list_element = r
+                res.append(gdata.Container(r.children, list_element.key))
         return gdata.List(["name"], res)
 
 def ListTransaction(path, liststate: ListState):

--- a/src/orchestron/ttt.act
+++ b/src/orchestron/ttt.act
@@ -451,18 +451,20 @@ class _ContainerTransaction(_Transaction):
 
 ################# Lists ####################
 
-def List(template):
-    return lambda path: Node(_List(path, template))
+def List(template, key_names: list[str], key_types: list[str]):
+    return lambda path: Node(_List(path, template, key_names, key_types))
 
 class _List(_Node):
     liststate: ListState
 
-    def __init__(self, path, template):
+    def __init__(self, path, template, key_names, key_types):
         self.path = path
+        self.key_names = key_names
+        self.key_types = key_types
         self.liststate = ListState(path, template)
 
     def newtrans(self):
-        return ListTransaction(self.path, self.liststate)
+        return ListTransaction(self.path, self.liststate, self.key_names, self.key_types)
 
     def get(self):
         #print('####', '(List)', self.path, 'NODE GET', err=True)
@@ -471,7 +473,7 @@ class _List(_Node):
             r = node.get()
             if isinstance(r, gdata.Container):
                 res.append(r)
-        return gdata.List(["name"], res)
+        return gdata.List(self.key_names, res)
 
 
 actor ListState(path, template: proc(list[str]) -> Node):
@@ -514,14 +516,18 @@ actor ListState(path, template: proc(list[str]) -> Node):
 
 class _ListTransaction(_Transaction):
     liststate : ListState
+    key_names : list[str]
+    key_types : list[str]
     elems : dict[str, Transaction]
     accum : dict[str, value]
     state : ?YieldState
     reset: bool
 
-    def __init__(self, path, liststate):
+    def __init__(self, path, liststate, key_names, key_types):
         self.path = path
         self.liststate = liststate
+        self.key_names = key_names
+        self.key_types = key_types
         self.elems = {}
         self.accum = {}
         self.state = None
@@ -657,15 +663,15 @@ class _ListTransaction(_Transaction):
                     #print('####', '(List)', self.path, 'RESTORING KEY', key, err=True)
                     split_key = split_key_str(key)
                     list_element = gdata.Container(r.children, split_key)
-                    for kn, kv in zip(["name"], split_key):
-                        list_element.children.setdefault(kn, gdata.Leaf("string", kv))
+                    for i, kn in enumerate(self.key_names):
+                        list_element.children.setdefault(kn, gdata.Leaf(self.key_types[i], split_key[i]))
                 else:
                     list_element = r
-                res.append(gdata.Container(r.children, list_element.key))
-        return gdata.List(["name"], res)
+                res.append(gdata.Container(list_element.children, list_element.key))
+        return gdata.List(self.key_names, res)
 
-def ListTransaction(path, liststate: ListState):
-    return Transaction(_ListTransaction(path, liststate))
+def ListTransaction(path, liststate: ListState, key_names, key_types):
+    return Transaction(_ListTransaction(path, liststate, key_names, key_types))
 
 
 ################# Transform #####################

--- a/src/orchestron/ttt_gen.act
+++ b/src/orchestron/ttt_gen.act
@@ -17,6 +17,16 @@ def get_list_name(sn: schema.DList) -> str:
         return sn.name
     raise NotImplementedError("List without parent")
 
+def get_key_types(sn: schema.DList) -> list[str]:
+    key_types = []
+    for kn in sn.key:
+        kl = sn.get(kn)
+        if isinstance(kl, schema.DLeaf):
+            key_types.append(kl.type_.name)
+        else:
+            raise ValueError(f"Key {kn} is not a leaf")
+    return key_types
+
 class TTTSrc(object):
     def __init__(self, src: str, input_classes: list[str], deserializers: list[str], imports: list[str], defs: list[str], base_defs: list[str]):
         self.src = src
@@ -98,7 +108,7 @@ def dschema_to_tttsrc(sn: schema.DNode, indent=0, set_ns=True) -> TTTSrc:
         modeled_input = %s.from_gdata(gdata_input)
         return self.transform(modeled_input).to_gdata()
 """ % (transform_name, input_class, input_class, input_class, deserializer, input_class))
-                            return TTTSrc(src="ttt.List(ttt.Transform(%s, log_handler))" % transform, input_classes=input_classes, deserializers=deserializers, imports=imports, defs=defs, base_defs=base_defs)
+                            return TTTSrc(src=f"ttt.List(ttt.Transform({transform}, log_handler), {repr(sn.key)}, {repr(get_key_types(sn))})", input_classes=input_classes, deserializers=deserializers, imports=imports, defs=defs, base_defs=base_defs)
                         elif ext.name == "rfs-transform":
                             base_defs.append("""class %s(ttt.RFSFunction):
     transform: mut(%s, ttt.DeviceInfo) -> yang.adata.MNode
@@ -123,18 +133,18 @@ def dschema_to_tttsrc(sn: schema.DNode, indent=0, set_ns=True) -> TTTSrc:
         modeled_input = %s.from_gdata(gdata_input)
         return self.transform(modeled_input, device_info).to_gdata()
 """ % (transform_name, input_class, input_class, input_class, deserializer, input_class))
-                            return TTTSrc(src="ttt.List(ttt.RFSTransform(%s, dev_mgr, log_handler))" % transform, input_classes=input_classes, deserializers=deserializers, imports=imports, defs=defs, base_defs=base_defs)
+                            return TTTSrc(src=f"ttt.List(ttt.RFSTransform({transform}, dev_mgr, log_handler), {repr(sn.key)}, {repr(get_key_types(sn))})", input_classes=input_classes, deserializers=deserializers, imports=imports, defs=defs, base_defs=base_defs)
                         raise ValueError("Unknown extension name: %s" % ext.name)
                     else:
                         raise ValueError("Missing argument to orchestron:transform. Add path to transform as arg.")
                 elif ext.name == "device":
                     if extarg is not None:
                         raise ValueError("Extraneous argument to orchestron:device. Remove argument.")
-                    return TTTSrc(src="ttt.List(ttt.Device(dev_mgr, log_handler))", input_classes=input_classes, deserializers=deserializers, imports=imports, defs=defs, base_defs=base_defs)
+                    return TTTSrc(src=f"ttt.List(ttt.Device(dev_mgr, log_handler), {repr(sn.key)}, {repr(get_key_types(sn))})", input_classes=input_classes, deserializers=deserializers, imports=imports, defs=defs, base_defs=base_defs)
                 elif ext.name == "device-config":
                     if extarg is not None:
                         raise ValueError("Extraneous argument to orchestron:device-config. Remove argument.")
-                    return TTTSrc(src="ttt.List(ttt.DeviceConfig(dev_mgr, log_handler))", input_classes=input_classes, deserializers=deserializers, imports=imports, defs=defs, base_defs=base_defs)
+                    return TTTSrc(src=f"ttt.List(ttt.DeviceConfig(dev_mgr, log_handler), {repr(sn.key)}, {repr(get_key_types(sn))})", input_classes=input_classes, deserializers=deserializers, imports=imports, defs=defs, base_defs=base_defs)
 
         # List without an extension
         children_res = children_to_tttsrc(sn)
@@ -144,7 +154,7 @@ def dschema_to_tttsrc(sn: schema.DNode, indent=0, set_ns=True) -> TTTSrc:
         defs.extend(children_res.defs)
         base_defs.extend(children_res.base_defs)
         ns = (", ns='" + sn.namespace + "'") if set_ns else ""
-        return TTTSrc(src="ttt.List(ttt.Container({%s}%s))" % (children_res.src, ns), input_classes=input_classes, deserializers=deserializers, imports=imports, defs=defs, base_defs=base_defs)
+        return TTTSrc(src=f"ttt.List(ttt.Container({{{children_res.src}}}{ns}), {repr(sn.key)}, {repr(get_key_types(sn))})", input_classes=input_classes, deserializers=deserializers, imports=imports, defs=defs, base_defs=base_defs)
 
     elif isinstance(sn, schema.DNodeInner):
         sn_children = sn.children

--- a/src/test_ttt_callbacks.act
+++ b/src/test_ttt_callbacks.act
@@ -45,7 +45,7 @@ cfg2 = gdata.List(["name"], [
 
 actor reconf2_tester(done: action(?bool, ?Exception)->None, log_handler: logging.Handler):
     dev_mgr = odev.DeviceManager(None, log_handler)
-    stack = ttt.Layer("devices", ttt.List(ttt.DeviceConfig(dev_mgr)), None)
+    stack = ttt.Layer("devices", ttt.List(ttt.DeviceConfig(dev_mgr), ["name"], ["string"]), None)
     
     var devs = set()
     
@@ -104,8 +104,8 @@ def rfs_for_device(dev):
 
 actor complete_tester(done: action(?bool, ?Exception)->None, log_handler: logging.Handler):
     dev_mgr = odev.DeviceManager(None, log_handler)
-    stack = ttt.Layer("rfs", ttt.Container({"rfs": ttt.List(ttt.Container({"base": ttt.List(ttt.RFSTransform(Fun, dev_mgr))}))}),
-            ttt.Layer("devices", ttt.Container({"devices": ttt.Container({"device": ttt.List(ttt.DeviceConfig(dev_mgr))})}),
+    stack = ttt.Layer("rfs", ttt.Container({"rfs": ttt.List(ttt.Container({"base": ttt.List(ttt.RFSTransform(Fun, dev_mgr), ["id"], ["string"])}), ["name"], ["string"])}),
+            ttt.Layer("devices", ttt.Container({"devices": ttt.Container({"device": ttt.List(ttt.DeviceConfig(dev_mgr), ["name"], ["string"])})}),
             None))
 
     def reconf(dev):

--- a/src/test_ttt_layers.act
+++ b/src/test_ttt_layers.act
@@ -72,7 +72,7 @@ class TransF(ttt.TransformFunction):
 
 actor basic_output_tester(done: action(?bool, ?Exception)->None):
     out = ttt.Sink().newsession()
-    tlist = ttt.List(ttt.Transform(TransF)) ([])
+    tlist = ttt.List(ttt.Transform(TransF), ["name"], ["string"]) ([])
     t1 = tlist.newtrans()
 
     t1.configure("1", {'srcA': cfg1}, out)
@@ -98,7 +98,7 @@ def _test_basic_output(done, logger: logging.Handler):
 ########################
 
 actor layered_commit_tester(done: action(?bool, ?Exception)->None):
-    stack = ttt.Layer("top", ttt.List(ttt.Transform(TransF)), ttt.Sink())
+    stack = ttt.Layer("top", ttt.List(ttt.Transform(TransF), ["name"], ["string"]), ttt.Sink())
 
     sess = stack.newsession()
 
@@ -117,7 +117,7 @@ def _test_layered_commit(done, logger: logging.Handler):
 ########################
 
 actor simultaneous_commit_tester(done: action(?bool, ?Exception)->None):
-    stack = ttt.Layer("top", ttt.List(ttt.Transform(TransF)), ttt.Sink())
+    stack = ttt.Layer("top", ttt.List(ttt.Transform(TransF), ["name"], ["string"]), ttt.Sink())
     
     sess1 = stack.newsession()
     sess2 = stack.newsession()

--- a/src/test_ttt_list.act
+++ b/src/test_ttt_list.act
@@ -1,4 +1,5 @@
 import testing
+import diff
 import logging
 
 import orchestron.ttt as ttt
@@ -57,7 +58,7 @@ merge_1_2 = gdata.List(["name"], [
 ########################
 
 actor basic_commit_tester(done: action(?bool, ?Exception)->None):
-    tlist = ttt.List(ttt.Transform(ttt.PassThrough)) ([])
+    tlist = ttt.List(ttt.Transform(ttt.PassThrough), ["name"], ["string"]) ([])
     t1 = tlist.newtrans()
 
     t1.configure("1", {'srcA': tree1}, None)
@@ -76,7 +77,7 @@ def _test_basic_commit(done, logger: logging.Handler):
 ########################
 
 actor basic_delete_tester(done: action(?bool, ?Exception)->None):
-    tlist = ttt.List(ttt.Transform(ttt.PassThrough)) ([])
+    tlist = ttt.List(ttt.Transform(ttt.PassThrough), ["name"], ["string"]) ([])
     t1 = tlist.newtrans()
 
     def cont2(_r: value):
@@ -120,7 +121,7 @@ list1 = gdata.List(["name"], [
 ])
 
 actor simultaneous_create_tester(done: action(?bool, ?Exception)->None):
-    tlist = ttt.List(ttt.Transform(ttt.PassThrough)) ([])
+    tlist = ttt.List(ttt.Transform(ttt.PassThrough), ["name"], ["string"]) ([])
     t1 = tlist.newtrans()
     t2 = tlist.newtrans()
 
@@ -144,7 +145,7 @@ def _test_simultaneous_create(done, logger: logging.Handler):
 ########################
 
 actor aborted_create_tester(done: action(?bool, ?Exception)->None):
-    tlist = ttt.List(ttt.Transform(ttt.PassThrough)) ([])
+    tlist = ttt.List(ttt.Transform(ttt.PassThrough), ["name"], ["string"]) ([])
     t1 = tlist.newtrans()
 
     def cont1(_r: value):
@@ -186,7 +187,7 @@ y2b = gdata.List(["name"], [
 ])
 
 actor aborted_create_tester2(done: action(?bool, ?Exception)->None):
-    tlist = ttt.List(ttt.Transform(ttt.PassThrough)) ([])
+    tlist = ttt.List(ttt.Transform(ttt.PassThrough), ["name"], ["string"]) ([])
     t1 = tlist.newtrans()
     t2 = tlist.newtrans()
 
@@ -207,6 +208,56 @@ actor aborted_create_tester2(done: action(?bool, ?Exception)->None):
 
 def _test_aborted_create2(done, logger: logging.Handler):
     c = aborted_create_tester2(done)
+
+########################
+
+# This is a test for a TTT.List top node without a transform function. When we
+# read the data from TTT, we must get the same valid data back. That includes
+# the key attribute and key child leafs set for the list element Container.
+nested_tree = gdata.Container({
+    "top-list": gdata.List(["name"], [
+        gdata.Container({
+            # This is the key leaf for the top-list list element, and it must remain in the output.
+            "name": gdata.Leaf("str", "k1"),
+            "nested-list": gdata.List(["id"], [
+                gdata.Container({
+                    "id": gdata.Leaf("str", "k1"),
+                    "a": gdata.Leaf("int", 1)
+                }, ["k1-k1"])
+            ])
+        # This is the key attribute for the top-list list element, and it must remain in the output.
+        }, ["k1"]),
+        gdata.Container({
+            "name": gdata.Leaf("str", "k2"),
+            "nested-list": gdata.List(["id"], [
+                gdata.Container({
+                    "id": gdata.Leaf("str", "k2"),
+                    "a": gdata.Leaf("int", 2)
+                }, ["k2-k1"])
+            ])
+        }, ["k2"])
+    ])
+})
+
+actor nested_list_tester(done: action(?bool, ?Exception)->None):
+    tlist = ttt.Container({"top-list": ttt.List(ttt.Container({"nested-list": ttt.List(ttt.Transform(ttt.PassThrough), ["id"], ["string"])}), ["name"], ["string"])}) ([])
+    t1 = tlist.newtrans()
+    t1.configure("1", {'srcA': nested_tree}, None)
+
+    def cont1(_r: value):
+        t1.commit("1", True)
+        r = t1.get()
+        print(nested_tree.prsrc())
+        print(r.prsrc())
+        try:
+            testing.assertEqual(nested_tree, r)
+            done(True, None)
+        except Exception as e:
+            done(False, Exception(f"Diff:\n{diff.diff(nested_tree.prsrc(), r.prsrc(), color=True)}"))
+    t1.lock("1", None, cont1)
+
+def _test_nested_list(done, logger: logging.Handler):
+    c = nested_list_tester(done)
 
 ########################
 

--- a/test/golden/test_ttt_gen/odev
+++ b/test/golden/test_ttt_gen/odev
@@ -12,5 +12,5 @@ import yang.gdata
 
 
 def get_ttt(dev_mgr: odev.DeviceManager, log_handler: ?logging.Handler=None) -> proc(list[str])->ttt.Node:
-    r = ttt.Container({"devices": ttt.Container({"device": ttt.List(ttt.DeviceConfig(dev_mgr, log_handler))}, ns='http://orchestron.org/yang/orchestron-device.yang')}, ns='')
+    r = ttt.Container({"devices": ttt.Container({"device": ttt.List(ttt.DeviceConfig(dev_mgr, log_handler), ['name'], ['string'])}, ns='http://orchestron.org/yang/orchestron-device.yang')}, ns='')
     return r

--- a/test/golden/test_ttt_gen/ttt_gen_cfs_ttt
+++ b/test/golden/test_ttt_gen/ttt_gen_cfs_ttt
@@ -12,5 +12,5 @@ import yang.gdata
 import respnet.cfs
 
 def get_ttt(dev_mgr: odev.DeviceManager, log_handler: ?logging.Handler=None) -> proc(list[str])->ttt.Node:
-    r = ttt.Container({"c1": ttt.Container({"foo": ttt.List(ttt.Container({"bar": ttt.List(ttt.Transform(respnet.cfs.Foobar, log_handler))}))}, ns='http://example.com/foo')}, ns='')
+    r = ttt.Container({"c1": ttt.Container({"foo": ttt.List(ttt.Container({"bar": ttt.List(ttt.Transform(respnet.cfs.Foobar, log_handler), ['name'], ['string'])}), ['name'], ['string'])}, ns='http://example.com/foo')}, ns='')
     return r

--- a/test/golden/test_ttt_gen/ttt_gen_rfs_ttt
+++ b/test/golden/test_ttt_gen/ttt_gen_rfs_ttt
@@ -12,5 +12,5 @@ import yang.gdata
 import respnet.rfs
 
 def get_ttt(dev_mgr: odev.DeviceManager, log_handler: ?logging.Handler=None) -> proc(list[str])->ttt.Node:
-    r = ttt.Container({"device": ttt.List(ttt.Device(dev_mgr, log_handler)), "rfs": ttt.List(ttt.Container({"backbone-interface": ttt.List(ttt.RFSTransform(respnet.rfs.BBInterface, dev_mgr, log_handler))}, ns='http://orchestron.org/yang/orchestron-rfs.yang'))}, ns='')
+    r = ttt.Container({"device": ttt.List(ttt.Device(dev_mgr, log_handler), ['name'], ['string']), "rfs": ttt.List(ttt.Container({"backbone-interface": ttt.List(ttt.RFSTransform(respnet.rfs.BBInterface, dev_mgr, log_handler), ['name'], ['string'])}, ns='http://orchestron.org/yang/orchestron-rfs.yang'), ['name'], ['string'])}, ns='')
     return r


### PR DESCRIPTION
If we have a TTT tree comprising a ttt.List with a nested ttt.List, then the top-level list element gdata.Container node when read from TTT with .get(), is missing the key info. This makes the gdata structure invalid, and
results in errors in places where this data is used.

This is a temporary fix until we move away from the key attribute altogether and replace it with a method to construct the key on demand by reading the child key leaf values. Note how the list of key names is also hardcoded in the .get() method, which will also be addressed soon.