### PR TITLE
Refactor key leaf tracking in list element

### DIFF
--- a/src/orchestron/ttt.act
+++ b/src/orchestron/ttt.act
@@ -295,21 +295,30 @@ actor Session(name: str, rootnode: Node, lowerlayer: ?Layer):
 ############## Containers ##################
 
 def Container(template={}, ns:?str=None):
-    return lambda path: Node(_Container(path, template, ns))
+    return lambda path: Node(_Container(path, template, ns, []))
+
+# Specialized factory for the case when this is a container for a list element,
+# that in turn contains other embedded transform templates like List or
+# Container. This container must know the key leaf names for its associated
+# list, so that it may preserve them.
+def ListElement(template={}, ns:?str=None):
+    return lambda key_names: lambda path: Node(_Container(path, template, ns, key_names))
 
 class _Container(_Node):
     elems: dict[str, Node]
     ns: ?str
+    key_names: list[str]
 
-    def __init__(self, path, template: dict[str, proc(list[str])->Node], ns):
+    def __init__(self, path, template: dict[str, proc(list[str])->Node], ns, key_names):
         self.path = path
         self.elems = {}
         self.ns = ns
         for key,templ in template.items():
             self.elems[key] = templ(path+[key])
+        self.key_names = key_names
 
     def newtrans(self):
-        return ContainerTransaction(self.path, self.elems, self.ns)
+        return ContainerTransaction(self.path, self.elems, self.key_names, self.ns)
 
     def get(self):
         #print('####', '(Container)', self.path, actorid(),'NODE GET', err=True)
@@ -323,16 +332,18 @@ class _Container(_Node):
             return gdata.Container(res, ns=self.ns)
 
 
-def ContainerTransaction(path, contents, ns:?str=None):
-    return Transaction(_ContainerTransaction(path, contents, ns))
+def ContainerTransaction(path, contents, key_names, ns:?str=None):
+    return Transaction(_ContainerTransaction(path, contents, ns, key_names))
 
 class _ContainerTransaction(_Transaction):
     elems : dict[str, Transaction]
     accum : dict[str, value]
     state : ?YieldState
     ns: ?str
+    key_names: list[str]
+    key_leaves: dict[str, gdata.Node]
 
-    def __init__(self, path, contents, ns):
+    def __init__(self, path, contents, ns, key_names):
         self.path = path
         self.elems = {}
         self.accum = {}
@@ -340,10 +351,26 @@ class _ContainerTransaction(_Transaction):
         self.ns = ns
         for key,node in contents.items():
             self.elems[key] = node.newtrans()
+        self.key_names = key_names
+        self.key_leaves = {}
+        print('####', '(Container)', self.path, 'NEWTRANS', actorid(), key_names, err=True)
 
     def configure(self, tid, diff, out, force=False):
         #print('####', tid, '(Container)', self.path, 'configure force:', force, actorid(), err=True)
         diff_by_child = transpose(diff)
+
+        # Key leaf values are immutable, always present and are also the same
+        # regardless of the source. Just take the values from the first
+        # available source, once. The only exception to that is when the entire
+        # subtree is being deleted, denoted by the presence of WILDKEY
+        if WILDKEY not in diff_by_child:
+            for kn in self.key_names:
+                if kn not in self.key_leaves:
+                    kv = next(iter(diff_by_child[kn].values()))
+                    self.key_leaves[kn] = kv
+                # If key leaf is not present, input gdata is not valid!
+                del diff_by_child[kn]
+
         if len(diff_by_child) == 0 and force:
             for k in self.elems.keys():
                 diff_by_child[k] = {}
@@ -458,6 +485,7 @@ class _ContainerTransaction(_Transaction):
         for tag,node in self.elems.items():
             res[tag] = node.get()
         ns = self.ns
+        res.update(self.key_leaves.items())
         if len(self.path) <= 1 and ns is not None:
             return gdata.Container(res, ns=ns)
         else:
@@ -466,8 +494,18 @@ class _ContainerTransaction(_Transaction):
 
 ################# Lists ####################
 
-def List(template, key_names: list[str], key_types: list[str]):
+def List(template: proc(list[str]) -> Node, key_names: list[str], key_types: list[str]) -> proc(list[str]) -> Node:
     return lambda path: Node(_List(path, template, key_names, key_types))
+
+# Specialized factory for the case where this List does not contain a
+# "user-facing transform" - that is, the list was not annotated with the
+# "orchestron:X" extension, but is rather just a containing node for a
+# "user-facing transform" defined in one if its children. The template argument
+# here is a function is called with our key_names argument, and then returns a
+# function that returns the next Node given its path.
+# The only template that satisfies this constraint is the ListElement factory.
+def ListStructural(template: proc(list[str]) ->  proc(list[str]) -> Node, key_names: list[str], key_types: list[str]) -> proc(list[str]) -> Node:
+    return lambda path: Node(_List(path, template(key_names), key_names, key_types))
 
 class _List(_Node):
     liststate: ListState
@@ -690,8 +728,6 @@ class _ListTransaction(_Transaction):
                     #print('####', '(List)', self.path, 'RESTORING KEY', key, err=True)
                     split_key = split_key_str(key)
                     list_element = gdata.Container(r.children, split_key)
-                    for i, kn in enumerate(self.key_names):
-                        list_element.children.setdefault(kn, gdata.Leaf(self.key_types[i], split_key[i]))
                 else:
                     list_element = r
                 res.append(gdata.Container(list_element.children, list_element.key))

--- a/src/orchestron/ttt.act
+++ b/src/orchestron/ttt.act
@@ -494,8 +494,8 @@ class _ContainerTransaction(_Transaction):
 
 ################# Lists ####################
 
-def List(template: proc(list[str]) -> Node, key_names: list[str], key_types: list[str]) -> proc(list[str]) -> Node:
-    return lambda path: Node(_List(path, template, key_names, key_types))
+def List(template: proc(list[str]) -> Node, key_names: list[str]) -> proc(list[str]) -> Node:
+    return lambda path: Node(_List(path, template, key_names))
 
 # Specialized factory for the case where this List does not contain a
 # "user-facing transform" - that is, the list was not annotated with the
@@ -504,20 +504,19 @@ def List(template: proc(list[str]) -> Node, key_names: list[str], key_types: lis
 # here is a function is called with our key_names argument, and then returns a
 # function that returns the next Node given its path.
 # The only template that satisfies this constraint is the ListElement factory.
-def ListStructural(template: proc(list[str]) ->  proc(list[str]) -> Node, key_names: list[str], key_types: list[str]) -> proc(list[str]) -> Node:
-    return lambda path: Node(_List(path, template(key_names), key_names, key_types))
+def ListStructural(template: proc(list[str]) ->  proc(list[str]) -> Node, key_names: list[str]) -> proc(list[str]) -> Node:
+    return lambda path: Node(_List(path, template(key_names), key_names))
 
 class _List(_Node):
     liststate: ListState
 
-    def __init__(self, path, template, key_names, key_types):
+    def __init__(self, path, template, key_names):
         self.path = path
         self.key_names = key_names
-        self.key_types = key_types
         self.liststate = ListState(path, template)
 
     def newtrans(self):
-        return ListTransaction(self.path, self.liststate, self.key_names, self.key_types)
+        return ListTransaction(self.path, self.liststate, self.key_names)
 
     def get(self):
         #print('####', '(List)', self.path, 'NODE GET', err=True)
@@ -570,17 +569,15 @@ actor ListState(path, template: proc(list[str]) -> Node):
 class _ListTransaction(_Transaction):
     liststate : ListState
     key_names : list[str]
-    key_types : list[str]
     elems : dict[str, Transaction]
     accum : dict[str, value]
     state : ?YieldState
     reset: bool
 
-    def __init__(self, path, liststate, key_names, key_types):
+    def __init__(self, path, liststate, key_names):
         self.path = path
         self.liststate = liststate
         self.key_names = key_names
-        self.key_types = key_types
         self.elems = {}
         self.accum = {}
         self.state = None
@@ -733,8 +730,8 @@ class _ListTransaction(_Transaction):
                 res.append(gdata.Container(list_element.children, list_element.key))
         return gdata.List(self.key_names, res)
 
-def ListTransaction(path, liststate: ListState, key_names, key_types):
-    return Transaction(_ListTransaction(path, liststate, key_names, key_types))
+def ListTransaction(path, liststate: ListState, key_names):
+    return Transaction(_ListTransaction(path, liststate, key_names))
 
 
 ################# Transform #####################

--- a/src/orchestron/ttt_gen.act
+++ b/src/orchestron/ttt_gen.act
@@ -17,16 +17,6 @@ def get_list_name(sn: schema.DList) -> str:
         return sn.name
     raise NotImplementedError("List without parent")
 
-def get_key_types(sn: schema.DList) -> list[str]:
-    key_types = []
-    for kn in sn.key:
-        kl = sn.get(kn)
-        if isinstance(kl, schema.DLeaf):
-            key_types.append(kl.type_.name)
-        else:
-            raise ValueError(f"Key {kn} is not a leaf")
-    return key_types
-
 class TTTSrc(object):
     def __init__(self, src: str, input_classes: list[str], deserializers: list[str], imports: list[str], defs: list[str], base_defs: list[str]):
         self.src = src
@@ -108,7 +98,7 @@ def dschema_to_tttsrc(sn: schema.DNode, indent=0, set_ns=True) -> TTTSrc:
         modeled_input = %s.from_gdata(gdata_input)
         return self.transform(modeled_input).to_gdata()
 """ % (transform_name, input_class, input_class, input_class, deserializer, input_class))
-                            return TTTSrc(src=f"ttt.List(ttt.Transform({transform}, log_handler), {repr(sn.key)}, {repr(get_key_types(sn))})", input_classes=input_classes, deserializers=deserializers, imports=imports, defs=defs, base_defs=base_defs)
+                            return TTTSrc(src=f"ttt.List(ttt.Transform({transform}, log_handler), {repr(sn.key)})", input_classes=input_classes, deserializers=deserializers, imports=imports, defs=defs, base_defs=base_defs)
                         elif ext.name == "rfs-transform":
                             base_defs.append("""class %s(ttt.RFSFunction):
     transform: mut(%s, ttt.DeviceInfo) -> yang.adata.MNode
@@ -133,18 +123,18 @@ def dschema_to_tttsrc(sn: schema.DNode, indent=0, set_ns=True) -> TTTSrc:
         modeled_input = %s.from_gdata(gdata_input)
         return self.transform(modeled_input, device_info).to_gdata()
 """ % (transform_name, input_class, input_class, input_class, deserializer, input_class))
-                            return TTTSrc(src=f"ttt.List(ttt.RFSTransform({transform}, dev_mgr, log_handler), {repr(sn.key)}, {repr(get_key_types(sn))})", input_classes=input_classes, deserializers=deserializers, imports=imports, defs=defs, base_defs=base_defs)
+                            return TTTSrc(src=f"ttt.List(ttt.RFSTransform({transform}, dev_mgr, log_handler), {repr(sn.key)})", input_classes=input_classes, deserializers=deserializers, imports=imports, defs=defs, base_defs=base_defs)
                         raise ValueError("Unknown extension name: %s" % ext.name)
                     else:
                         raise ValueError("Missing argument to orchestron:transform. Add path to transform as arg.")
                 elif ext.name == "device":
                     if extarg is not None:
                         raise ValueError("Extraneous argument to orchestron:device. Remove argument.")
-                    return TTTSrc(src=f"ttt.List(ttt.Device(dev_mgr, log_handler), {repr(sn.key)}, {repr(get_key_types(sn))})", input_classes=input_classes, deserializers=deserializers, imports=imports, defs=defs, base_defs=base_defs)
+                    return TTTSrc(src=f"ttt.List(ttt.Device(dev_mgr, log_handler), {repr(sn.key)})", input_classes=input_classes, deserializers=deserializers, imports=imports, defs=defs, base_defs=base_defs)
                 elif ext.name == "device-config":
                     if extarg is not None:
                         raise ValueError("Extraneous argument to orchestron:device-config. Remove argument.")
-                    return TTTSrc(src=f"ttt.List(ttt.DeviceConfig(dev_mgr, log_handler), {repr(sn.key)}, {repr(get_key_types(sn))})", input_classes=input_classes, deserializers=deserializers, imports=imports, defs=defs, base_defs=base_defs)
+                    return TTTSrc(src=f"ttt.List(ttt.DeviceConfig(dev_mgr, log_handler), {repr(sn.key)})", input_classes=input_classes, deserializers=deserializers, imports=imports, defs=defs, base_defs=base_defs)
 
         # List without an extension
         children_res = children_to_tttsrc(sn)
@@ -154,7 +144,7 @@ def dschema_to_tttsrc(sn: schema.DNode, indent=0, set_ns=True) -> TTTSrc:
         defs.extend(children_res.defs)
         base_defs.extend(children_res.base_defs)
         ns = (", ns='" + sn.namespace + "'") if set_ns else ""
-        return TTTSrc(src=f"ttt.ListStructural(ttt.ListElement({{{children_res.src}}}{ns}), {repr(sn.key)}, {repr(get_key_types(sn))})", input_classes=input_classes, deserializers=deserializers, imports=imports, defs=defs, base_defs=base_defs)
+        return TTTSrc(src=f"ttt.ListStructural(ttt.ListElement({{{children_res.src}}}{ns}), {repr(sn.key)})", input_classes=input_classes, deserializers=deserializers, imports=imports, defs=defs, base_defs=base_defs)
 
     elif isinstance(sn, schema.DNodeInner):
         sn_children = sn.children

--- a/src/orchestron/ttt_gen.act
+++ b/src/orchestron/ttt_gen.act
@@ -154,7 +154,7 @@ def dschema_to_tttsrc(sn: schema.DNode, indent=0, set_ns=True) -> TTTSrc:
         defs.extend(children_res.defs)
         base_defs.extend(children_res.base_defs)
         ns = (", ns='" + sn.namespace + "'") if set_ns else ""
-        return TTTSrc(src=f"ttt.List(ttt.Container({{{children_res.src}}}{ns}), {repr(sn.key)}, {repr(get_key_types(sn))})", input_classes=input_classes, deserializers=deserializers, imports=imports, defs=defs, base_defs=base_defs)
+        return TTTSrc(src=f"ttt.ListStructural(ttt.ListElement({{{children_res.src}}}{ns}), {repr(sn.key)}, {repr(get_key_types(sn))})", input_classes=input_classes, deserializers=deserializers, imports=imports, defs=defs, base_defs=base_defs)
 
     elif isinstance(sn, schema.DNodeInner):
         sn_children = sn.children

--- a/src/test_ttt_callbacks.act
+++ b/src/test_ttt_callbacks.act
@@ -98,13 +98,15 @@ cfg3 = gdata.Container({
 def rfs_for_device(dev):
     return gdata.Container({
         'rfs': gdata.List(["name"], [
-            gdata.Container({}, [dev])
+            gdata.Container({
+                "name": gdata.Leaf("str", dev),
+            }, [dev])
         ])
     })
 
 actor complete_tester(done: action(?bool, ?Exception)->None, log_handler: logging.Handler):
     dev_mgr = odev.DeviceManager(None, log_handler)
-    stack = ttt.Layer("rfs", ttt.Container({"rfs": ttt.List(ttt.Container({"base": ttt.List(ttt.RFSTransform(Fun, dev_mgr), ["id"], ["string"])}), ["name"], ["string"])}),
+    stack = ttt.Layer("rfs", ttt.Container({"rfs": ttt.ListStructural(ttt.ListElement({"base": ttt.List(ttt.RFSTransform(Fun, dev_mgr), ["id"], ["string"])}), ["name"], ["string"])}),
             ttt.Layer("devices", ttt.Container({"devices": ttt.Container({"device": ttt.List(ttt.DeviceConfig(dev_mgr), ["name"], ["string"])})}),
             None))
 

--- a/src/test_ttt_callbacks.act
+++ b/src/test_ttt_callbacks.act
@@ -45,7 +45,7 @@ cfg2 = gdata.List(["name"], [
 
 actor reconf2_tester(done: action(?bool, ?Exception)->None, log_handler: logging.Handler):
     dev_mgr = odev.DeviceManager(None, log_handler)
-    stack = ttt.Layer("devices", ttt.List(ttt.DeviceConfig(dev_mgr), ["name"], ["string"]), None)
+    stack = ttt.Layer("devices", ttt.List(ttt.DeviceConfig(dev_mgr), ["name"]), None)
     
     var devs = set()
     
@@ -106,8 +106,8 @@ def rfs_for_device(dev):
 
 actor complete_tester(done: action(?bool, ?Exception)->None, log_handler: logging.Handler):
     dev_mgr = odev.DeviceManager(None, log_handler)
-    stack = ttt.Layer("rfs", ttt.Container({"rfs": ttt.ListStructural(ttt.ListElement({"base": ttt.List(ttt.RFSTransform(Fun, dev_mgr), ["id"], ["string"])}), ["name"], ["string"])}),
-            ttt.Layer("devices", ttt.Container({"devices": ttt.Container({"device": ttt.List(ttt.DeviceConfig(dev_mgr), ["name"], ["string"])})}),
+    stack = ttt.Layer("rfs", ttt.Container({"rfs": ttt.ListStructural(ttt.ListElement({"base": ttt.List(ttt.RFSTransform(Fun, dev_mgr), ["id"])}), ["name"])}),
+            ttt.Layer("devices", ttt.Container({"devices": ttt.Container({"device": ttt.List(ttt.DeviceConfig(dev_mgr), ["name"])})}),
             None))
 
     def reconf(dev):

--- a/src/test_ttt_container.act
+++ b/src/test_ttt_container.act
@@ -149,8 +149,8 @@ actor nested_delete_tester(done: action(?bool, ?Exception)->None):
     })
 
     tlist = ttt.Container({
-                "left": ttt.List(ttt.Transform(ttt.PassThrough), ["name"], ["str"]),
-                "right": ttt.List(ttt.Transform(ttt.PassThrough), ["name"], ["str"])
+                "left": ttt.List(ttt.Transform(ttt.PassThrough), ["name"]),
+                "right": ttt.List(ttt.Transform(ttt.PassThrough), ["name"])
             }) ([])
     t1 = tlist.newtrans()
     t1.configure("1", {"srcA": in1})

--- a/src/test_ttt_layers.act
+++ b/src/test_ttt_layers.act
@@ -72,7 +72,7 @@ class TransF(ttt.TransformFunction):
 
 actor basic_output_tester(done: action(?bool, ?Exception)->None):
     out = ttt.Sink().newsession()
-    tlist = ttt.List(ttt.Transform(TransF), ["name"], ["string"]) ([])
+    tlist = ttt.List(ttt.Transform(TransF), ["name"]) ([])
     t1 = tlist.newtrans()
 
     t1.configure("1", {'srcA': cfg1}, out)
@@ -97,7 +97,7 @@ def _test_basic_output(done, logger: logging.Handler):
 ########################
 
 actor layered_commit_tester(done: action(?bool, ?Exception)->None):
-    stack = ttt.Layer("top", ttt.List(ttt.Transform(TransF), ["name"], ["string"]), ttt.Sink())
+    stack = ttt.Layer("top", ttt.List(ttt.Transform(TransF), ["name"]), ttt.Sink())
 
     sess = stack.newsession()
 
@@ -116,7 +116,7 @@ def _test_layered_commit(done, logger: logging.Handler):
 ########################
 
 actor simultaneous_commit_tester(done: action(?bool, ?Exception)->None):
-    stack = ttt.Layer("top", ttt.List(ttt.Transform(TransF), ["name"], ["string"]), ttt.Sink())
+    stack = ttt.Layer("top", ttt.List(ttt.Transform(TransF), ["name"]), ttt.Sink())
     
     sess1 = stack.newsession()
     sess2 = stack.newsession()

--- a/src/test_ttt_list.act
+++ b/src/test_ttt_list.act
@@ -217,8 +217,8 @@ actor nested_delete_tester(done: action(?bool, ?Exception)->None):
             }, ["k2"]),
         ])
 
-    tlist = ttt.List(
-                ttt.Container({
+    tlist = ttt.ListStructural(
+                ttt.ListElement({
                     "left": ttt.Transform(ttt.PassThrough),
                     "right": ttt.Transform(ttt.PassThrough)
                 }), ["name"], ["str"]
@@ -389,7 +389,7 @@ nested_tree = gdata.Container({
 })
 
 actor nested_list_tester(done: action(?bool, ?Exception)->None):
-    tlist = ttt.Container({"top-list": ttt.List(ttt.Container({"nested-list": ttt.List(ttt.Transform(ttt.PassThrough), ["id"], ["string"])}), ["name"], ["string"])}) ([])
+    tlist = ttt.Container({"top-list": ttt.ListStructural(ttt.ListElement({"nested-list": ttt.List(ttt.Transform(ttt.PassThrough), ["id"], ["string"])}), ["name"], ["string"])}) ([])
     t1 = tlist.newtrans()
     t1.configure("1", {'srcA': nested_tree}, None)
 

--- a/src/test_ttt_list.act
+++ b/src/test_ttt_list.act
@@ -58,7 +58,7 @@ merge_1_2 = gdata.List(["name"], [
 ########################
 
 actor basic_commit_tester(done: action(?bool, ?Exception)->None):
-    tlist = ttt.List(ttt.Transform(ttt.PassThrough), ["name"], ["string"]) ([])
+    tlist = ttt.List(ttt.Transform(ttt.PassThrough), ["name"]) ([])
     t1 = tlist.newtrans()
 
     t1.configure("1", {'srcA': tree1}, None)
@@ -77,7 +77,7 @@ def _test_basic_commit(done, logger: logging.Handler):
 ########################
 
 actor basic_delete_tester(done: action(?bool, ?Exception)->None):
-    tlist = ttt.List(ttt.Transform(ttt.PassThrough), ["name"], ["string"]) ([])
+    tlist = ttt.List(ttt.Transform(ttt.PassThrough), ["name"]) ([])
     t1 = tlist.newtrans()
 
     def cont2(_r: value):
@@ -111,7 +111,7 @@ actor all_delete_tester(done: action(?bool, ?Exception)->None):
             }, ["k2"]),
         ])
 
-    tlist = ttt.List(ttt.Transform(ttt.PassThrough), ["name"], ["str"]) ([])
+    tlist = ttt.List(ttt.Transform(ttt.PassThrough), ["name"]) ([])
     t1 = tlist.newtrans()
     t1.configure("1", {"srcA": in1})
 
@@ -158,7 +158,7 @@ actor partial_delete_tester(done: action(?bool, ?Exception)->None):
             }, ["k3"]),
         ])
 
-    tlist = ttt.List(ttt.Transform(ttt.PassThrough), ["name"], ["str"]) ([])
+    tlist = ttt.List(ttt.Transform(ttt.PassThrough), ["name"]) ([])
     t1 = tlist.newtrans()
     t1.configure("1", {"srcA": inA, "srcB": inB})
 
@@ -221,7 +221,7 @@ actor nested_delete_tester(done: action(?bool, ?Exception)->None):
                 ttt.ListElement({
                     "left": ttt.Transform(ttt.PassThrough),
                     "right": ttt.Transform(ttt.PassThrough)
-                }), ["name"], ["str"]
+                }), ["name"]
             ) ([])
     t1 = tlist.newtrans()
     t1.configure("1", {"srcA": in1})
@@ -270,7 +270,7 @@ list1 = gdata.List(["name"], [
 ])
 
 actor simultaneous_create_tester(done: action(?bool, ?Exception)->None):
-    tlist = ttt.List(ttt.Transform(ttt.PassThrough), ["name"], ["string"]) ([])
+    tlist = ttt.List(ttt.Transform(ttt.PassThrough), ["name"]) ([])
     t1 = tlist.newtrans()
     t2 = tlist.newtrans()
 
@@ -294,7 +294,7 @@ def _test_simultaneous_create(done, logger: logging.Handler):
 ########################
 
 actor aborted_create_tester(done: action(?bool, ?Exception)->None):
-    tlist = ttt.List(ttt.Transform(ttt.PassThrough), ["name"], ["string"]) ([])
+    tlist = ttt.List(ttt.Transform(ttt.PassThrough), ["name"]) ([])
     t1 = tlist.newtrans()
 
     def cont1(_r: value):
@@ -336,7 +336,7 @@ y2b = gdata.List(["name"], [
 ])
 
 actor aborted_create_tester2(done: action(?bool, ?Exception)->None):
-    tlist = ttt.List(ttt.Transform(ttt.PassThrough), ["name"], ["string"]) ([])
+    tlist = ttt.List(ttt.Transform(ttt.PassThrough), ["name"]) ([])
     t1 = tlist.newtrans()
     t2 = tlist.newtrans()
 
@@ -389,7 +389,7 @@ nested_tree = gdata.Container({
 })
 
 actor nested_list_tester(done: action(?bool, ?Exception)->None):
-    tlist = ttt.Container({"top-list": ttt.ListStructural(ttt.ListElement({"nested-list": ttt.List(ttt.Transform(ttt.PassThrough), ["id"], ["string"])}), ["name"], ["string"])}) ([])
+    tlist = ttt.Container({"top-list": ttt.ListStructural(ttt.ListElement({"nested-list": ttt.List(ttt.Transform(ttt.PassThrough), ["id"])}), ["name"])}) ([])
     t1 = tlist.newtrans()
     t1.configure("1", {'srcA': nested_tree}, None)
 

--- a/test/golden/test_ttt_gen/odev
+++ b/test/golden/test_ttt_gen/odev
@@ -12,5 +12,5 @@ import yang.gdata
 
 
 def get_ttt(dev_mgr: odev.DeviceManager, log_handler: ?logging.Handler=None) -> proc(list[str])->ttt.Node:
-    r = ttt.Container({"devices": ttt.Container({"device": ttt.List(ttt.DeviceConfig(dev_mgr, log_handler), ['name'], ['string'])}, ns='http://orchestron.org/yang/orchestron-device.yang')}, ns='')
+    r = ttt.Container({"devices": ttt.Container({"device": ttt.List(ttt.DeviceConfig(dev_mgr, log_handler), ['name'])}, ns='http://orchestron.org/yang/orchestron-device.yang')}, ns='')
     return r

--- a/test/golden/test_ttt_gen/ttt_gen_cfs_ttt
+++ b/test/golden/test_ttt_gen/ttt_gen_cfs_ttt
@@ -12,5 +12,5 @@ import yang.gdata
 import respnet.cfs
 
 def get_ttt(dev_mgr: odev.DeviceManager, log_handler: ?logging.Handler=None) -> proc(list[str])->ttt.Node:
-    r = ttt.Container({"c1": ttt.Container({"foo": ttt.ListStructural(ttt.ListElement({"bar": ttt.List(ttt.Transform(respnet.cfs.Foobar, log_handler), ['name'], ['string'])}), ['name'], ['string'])}, ns='http://example.com/foo')}, ns='')
+    r = ttt.Container({"c1": ttt.Container({"foo": ttt.ListStructural(ttt.ListElement({"bar": ttt.List(ttt.Transform(respnet.cfs.Foobar, log_handler), ['name'])}), ['name'])}, ns='http://example.com/foo')}, ns='')
     return r

--- a/test/golden/test_ttt_gen/ttt_gen_cfs_ttt
+++ b/test/golden/test_ttt_gen/ttt_gen_cfs_ttt
@@ -12,5 +12,5 @@ import yang.gdata
 import respnet.cfs
 
 def get_ttt(dev_mgr: odev.DeviceManager, log_handler: ?logging.Handler=None) -> proc(list[str])->ttt.Node:
-    r = ttt.Container({"c1": ttt.Container({"foo": ttt.List(ttt.Container({"bar": ttt.List(ttt.Transform(respnet.cfs.Foobar, log_handler), ['name'], ['string'])}), ['name'], ['string'])}, ns='http://example.com/foo')}, ns='')
+    r = ttt.Container({"c1": ttt.Container({"foo": ttt.ListStructural(ttt.ListElement({"bar": ttt.List(ttt.Transform(respnet.cfs.Foobar, log_handler), ['name'], ['string'])}), ['name'], ['string'])}, ns='http://example.com/foo')}, ns='')
     return r

--- a/test/golden/test_ttt_gen/ttt_gen_rfs_ttt
+++ b/test/golden/test_ttt_gen/ttt_gen_rfs_ttt
@@ -12,5 +12,5 @@ import yang.gdata
 import respnet.rfs
 
 def get_ttt(dev_mgr: odev.DeviceManager, log_handler: ?logging.Handler=None) -> proc(list[str])->ttt.Node:
-    r = ttt.Container({"device": ttt.List(ttt.Device(dev_mgr, log_handler), ['name'], ['string']), "rfs": ttt.List(ttt.Container({"backbone-interface": ttt.List(ttt.RFSTransform(respnet.rfs.BBInterface, dev_mgr, log_handler), ['name'], ['string'])}, ns='http://orchestron.org/yang/orchestron-rfs.yang'), ['name'], ['string'])}, ns='')
+    r = ttt.Container({"device": ttt.List(ttt.Device(dev_mgr, log_handler), ['name'], ['string']), "rfs": ttt.ListStructural(ttt.ListElement({"backbone-interface": ttt.List(ttt.RFSTransform(respnet.rfs.BBInterface, dev_mgr, log_handler), ['name'], ['string'])}, ns='http://orchestron.org/yang/orchestron-rfs.yang'), ['name'], ['string'])}, ns='')
     return r

--- a/test/golden/test_ttt_gen/ttt_gen_rfs_ttt
+++ b/test/golden/test_ttt_gen/ttt_gen_rfs_ttt
@@ -12,5 +12,5 @@ import yang.gdata
 import respnet.rfs
 
 def get_ttt(dev_mgr: odev.DeviceManager, log_handler: ?logging.Handler=None) -> proc(list[str])->ttt.Node:
-    r = ttt.Container({"device": ttt.List(ttt.Device(dev_mgr, log_handler), ['name'], ['string']), "rfs": ttt.ListStructural(ttt.ListElement({"backbone-interface": ttt.List(ttt.RFSTransform(respnet.rfs.BBInterface, dev_mgr, log_handler), ['name'], ['string'])}, ns='http://orchestron.org/yang/orchestron-rfs.yang'), ['name'], ['string'])}, ns='')
+    r = ttt.Container({"device": ttt.List(ttt.Device(dev_mgr, log_handler), ['name']), "rfs": ttt.ListStructural(ttt.ListElement({"backbone-interface": ttt.List(ttt.RFSTransform(respnet.rfs.BBInterface, dev_mgr, log_handler), ['name'])}, ns='http://orchestron.org/yang/orchestron-rfs.yang'), ['name'])}, ns='')
     return r


### PR DESCRIPTION
Handle the case where a ttt._ContainerTransaction that tracks changes to embedded transforms in the list element, is also made aware of the key leaves for its list. These are *not* part of any embedded transforms, but are still the responsibility of the list element container. This means that ttt._ContainerTransaction must be provided with key_names from its containing list.

I tried expressing this with types and was somewhat successful - this case is now handled by the stack `ttt.ListStructural(ttt.ListElement(...), <key_names>)`. But what is missing is a constraint that would prevent `ttt.List(ttt.Container(...), <key_names>)` and only allow to ttt.List to contain "user-facing" transforms, a result of "orchestron:X" extension statements.

Once the `gdata.Container.key` attribute is removed, the last bit of "key restoring" hacks can be removed from `ttt._ListTransaction`.