### PR TITLE
Replace gdata.Container.key attr with key_str() method

### DIFF
--- a/build.act.json
+++ b/build.act.json
@@ -7,8 +7,8 @@
         },
         "yang": {
             "repo_url": "https://github.com/orchestron-orchestrator/acton-yang.git",
-            "url": "https://github.com/orchestron-orchestrator/acton-yang/archive/0a2c31bc9c3af692ade6efeb3ac34a67b3dd429a.zip",
-            "hash": "12204dc15a3cffa33496d399c9300c5e129b67bb618878c9aed56582051bba18953c"
+            "url": "https://github.com/orchestron-orchestrator/acton-yang/archive/2225dd6ccc16eea587637d72b509e5b064f03ed3.zip",
+            "hash": "122034e30e8754a7950a346c90946a50b8d715461f63c28251dcf96d804c1bd80cf4"
         }
     },
     "zig_dependencies": {}

--- a/gen_dmc/build.act.json
+++ b/gen_dmc/build.act.json
@@ -2,8 +2,8 @@
     "dependencies": {
         "yang": {
             "repo_url": "https://github.com/orchestron-orchestrator/acton-yang.git",
-            "url": "https://github.com/orchestron-orchestrator/acton-yang/archive/0a2c31bc9c3af692ade6efeb3ac34a67b3dd429a.zip",
-            "hash": "12204dc15a3cffa33496d399c9300c5e129b67bb618878c9aed56582051bba18953c"
+            "url": "https://github.com/orchestron-orchestrator/acton-yang/archive/2225dd6ccc16eea587637d72b509e5b064f03ed3.zip",
+            "hash": "122034e30e8754a7950a346c90946a50b8d715461f63c28251dcf96d804c1bd80cf4"
         }
     },
     "zig_dependencies": {}

--- a/src/orchestron/device_meta_config.act
+++ b/src/orchestron/device_meta_config.act
@@ -38,7 +38,7 @@ class orchestron_rfs__device__address__initial_credentials_entry(yang.adata.MNod
         _key = self.key
         if _key is not None:
             children['key'] = yang.gdata.Leaf('string', _key)
-        return yang.gdata.Container(children, [yang.gdata.yang_str(self.username), yang.gdata.yang_str(self.password), yang.gdata.yang_str(self.key)])
+        return yang.gdata.Container(children)
 
     @staticmethod
     mut def from_gdata(n: yang.gdata.Node) -> orchestron_rfs__device__address__initial_credentials_entry:
@@ -114,7 +114,7 @@ class orchestron_rfs__device__address_entry(yang.adata.MNode):
         _initial_credentials = self.initial_credentials
         if _initial_credentials is not None:
             children['initial-credentials'] = _initial_credentials.to_gdata()
-        return yang.gdata.Container(children, [yang.gdata.yang_str(self.name)])
+        return yang.gdata.Container(children)
 
     @staticmethod
     mut def from_gdata(n: yang.gdata.Node) -> orchestron_rfs__device__address_entry:
@@ -178,7 +178,7 @@ class orchestron_rfs__device__credentials__key_entry(yang.adata.MNode):
         _private_key = self.private_key
         if _private_key is not None:
             children['private-key'] = yang.gdata.Leaf('string', _private_key)
-        return yang.gdata.Container(children, [yang.gdata.yang_str(self.key)])
+        return yang.gdata.Container(children)
 
     @staticmethod
     mut def from_gdata(n: yang.gdata.Node) -> orchestron_rfs__device__credentials__key_entry:
@@ -277,7 +277,7 @@ class orchestron_rfs__device__initial_credentials_entry(yang.adata.MNode):
         _key = self.key
         if _key is not None:
             children['key'] = yang.gdata.Leaf('string', _key)
-        return yang.gdata.Container(children, [yang.gdata.yang_str(self.username), yang.gdata.yang_str(self.password), yang.gdata.yang_str(self.key)])
+        return yang.gdata.Container(children)
 
     @staticmethod
     mut def from_gdata(n: yang.gdata.Node) -> orchestron_rfs__device__initial_credentials_entry:
@@ -356,7 +356,7 @@ class orchestron_rfs__device__mock__module_entry(yang.adata.MNode):
         if _revision is not None:
             children['revision'] = yang.gdata.Leaf('string', _revision)
         children['feature'] = yang.gdata.LeafList('string', self.feature)
-        return yang.gdata.Container(children, [yang.gdata.yang_str(self.name)])
+        return yang.gdata.Container(children)
 
     @staticmethod
     mut def from_gdata(n: yang.gdata.Node) -> orchestron_rfs__device__mock__module_entry:
@@ -465,7 +465,7 @@ class orchestron_rfs__device_entry(yang.adata.MNode):
         _mock = self.mock
         if _mock is not None:
             children['mock'] = _mock.to_gdata()
-        return yang.gdata.Container(children, [yang.gdata.yang_str(self.name)])
+        return yang.gdata.Container(children)
 
     @staticmethod
     mut def from_gdata(n: yang.gdata.Node) -> orchestron_rfs__device_entry:

--- a/src/orchestron/ttt.act
+++ b/src/orchestron/ttt.act
@@ -18,7 +18,7 @@ def transpose(cfg_per_src: dict[str, gdata.Node]) -> dict[str, dict[str, gdata.N
     for src, conf in cfg_per_src.items():
         if isinstance(conf, gdata.List):
             for le in conf.elements:
-                key = le.key_str()
+                key = le.key_str(conf.keys)
                 if key in cfg_per_key:
                     cfg_per_key[key][src] = le
                 else:
@@ -344,6 +344,13 @@ class _ContainerTransaction(_Transaction):
     def configure(self, tid, diff, out, force=False):
         #print('####', tid, '(Container)', self.path, 'configure force:', force, actorid(), err=True)
         diff_by_child = transpose(diff)
+        # Extra nodes present in diff_by_child represent configuration that is
+        # not any of our embedded transforms. These may be key leaf values, or
+        # in general any other configuration nodes in the same list element.
+        # In any case this container is not responsible for tracking them, so we remove them.
+        for k in set(diff_by_child.keys()) - set(self.elems.keys()) - set([WILDKEY]):
+            del diff_by_child[k]
+
         if len(diff_by_child) == 0 and force:
             for k in self.elems.keys():
                 diff_by_child[k] = {}
@@ -685,16 +692,14 @@ class _ListTransaction(_Transaction):
             else:
                 r = node.get()
             if isinstance(r, gdata.Container):
-                if r.key == []:
-                    # Restore the list element Container.key attribute and key leaf children, to keep the gdata valid
-                    #print('####', '(List)', self.path, 'RESTORING KEY', key, err=True)
-                    split_key = split_key_str(key)
-                    list_element = gdata.Container(r.children, split_key)
-                    for i, kn in enumerate(self.key_names):
-                        list_element.children.setdefault(kn, gdata.Leaf(self.key_types[i], split_key[i]))
-                else:
-                    list_element = r
-                res.append(gdata.Container(list_element.children, list_element.key))
+                # Restore the list element key leaf leaf children to keep the
+                # gdata valid. This is only necessary when the elements of this
+                # list are not any of the ttt.Transform, but ttt.Container.
+                #print('####', '(List)', self.path, 'RESTORING KEY', key, err=True)
+                split_key = split_key_str(key)
+                for i, kn in enumerate(self.key_names):
+                    r.children.setdefault(kn, gdata.Leaf(self.key_types[i], split_key[i]))
+            res.append(r)
         return gdata.List(self.key_names, res)
 
 def ListTransaction(path, liststate: ListState, key_names, key_types):
@@ -870,7 +875,7 @@ class _TransformTransaction(_TransformTransactionBase):
         output = self.output
         if output is not None:
             #print('   #', tid, '(Transform)', self.path, 'CLEARING ' + output.prsrc(), err=True)
-            res = difference(self.output, gdata.Container(key=output.key))
+            res = difference(self.output, gdata.Container())
             if out is not None and res is not None:
                 out.configure(tid, {self.me: res})
 
@@ -918,11 +923,11 @@ class _RFSTransaction(_TransformTransactionBase):
     def compute(self, tid, merged, out):
         #print('####', tid, '(RFSTransform)', self.path, 'compute', actorid(), err=True)
         dev_content = {
-            "name": gdata.Leaf("str", self.devname),
+            "name": gdata.Leaf("string", self.devname),
         }
         modset, modset_id = self.dev.get_modules()
         if modset_id is not None:
-            dev_content["modset_id"] = gdata.Leaf("str", modset_id)
+            dev_content["modset_id"] = gdata.Leaf("string", modset_id)
         if len(modset) > 0:
             #print('####', tid, '(RFSTransform)', self.path, 'compute', self.devname, err=True)
             newout = self.function.transform_wrapper(merged, DeviceInfo(self.devname, modset))
@@ -941,7 +946,7 @@ class _RFSTransaction(_TransformTransactionBase):
     def clear(self, tid, out):
         output = self.output
         if out is not None and output is not None:
-            diff = difference(output, gdata.Container(key=output.key))
+            diff = difference(output, gdata.Container())
             if isinstance(diff, gdata.Container):
                 dev_content = {
                     "name": gdata.Leaf("str", self.devname),
@@ -954,7 +959,7 @@ class _RFSTransaction(_TransformTransactionBase):
         return gdata.Container({
             "devices": gdata.Container({
                 "device": gdata.List(["name"], [
-                    gdata.Container(dev_content, [self.devname])
+                    gdata.Container(dev_content)
                 ])
             })
         }, ns="http://orchestron.org/yang/orchestron-device.yang")

--- a/src/test_ttt_callbacks.act
+++ b/src/test_ttt_callbacks.act
@@ -30,17 +30,17 @@ def _test_reconf(done, logger: logging.Handler):
 
 cfg2 = gdata.List(["name"], [
     gdata.Container({
-        "name": gdata.Leaf("str", "k1"),
+        "name": gdata.Leaf("string", "k1"),
         "config": gdata.Container({
-            "val": gdata.Leaf("str", "one")
+            "val": gdata.Leaf("string", "one")
         })
-    }, ["k1"]),
+    }),
     gdata.Container({
-        "name": gdata.Leaf("str", "k2"),
+        "name": gdata.Leaf("string", "k2"),
         "config": gdata.Container({
-            "val": gdata.Leaf("str", "two")
+            "val": gdata.Leaf("string", "two")
         })
-    }, ["k2"])
+    })
 ])
 
 actor reconf2_tester(done: action(?bool, ?Exception)->None, log_handler: logging.Handler):
@@ -77,28 +77,32 @@ class Fun(ttt.RFSFunction):
 cfg3 = gdata.Container({
     "rfs": gdata.List(["name"], [
         gdata.Container({
-            "name": gdata.Leaf("str", "k1"),
+            "name": gdata.Leaf("string", "k1"),
             "base": gdata.List(["id"], [
                 gdata.Container({
-                    "val": gdata.Leaf("str", "one")
-                }, ["A"])
+                    "id": gdata.Leaf("string", "A"),
+                    "val": gdata.Leaf("string", "one")
+                })
             ])
-        }, ["k1"]),
+        }),
         gdata.Container({
-            "name": gdata.Leaf("str", "k2"),
+            "name": gdata.Leaf("string", "k2"),
             "base": gdata.List(["id"], [
                 gdata.Container({
-                    "val": gdata.Leaf("str", "two")
-                }, ["A"])
+                    "id": gdata.Leaf("string", "A"),
+                    "val": gdata.Leaf("string", "two")
+                })
             ])
-        }, ["k2"])
+        })
     ])
 })
 
 def rfs_for_device(dev):
     return gdata.Container({
         'rfs': gdata.List(["name"], [
-            gdata.Container({}, [dev])
+            gdata.Container({
+                "name": gdata.Leaf("string", dev)
+            })
         ])
     })
 

--- a/src/test_ttt_container.act
+++ b/src/test_ttt_container.act
@@ -10,12 +10,14 @@ tree1 = gdata.Container({
     'left': gdata.Container({
         "l1": gdata.List(["name"], [
             gdata.Container({
+                "name": gdata.Leaf("string", "k1"),
                 "n1": gdata.Leaf("int", 1),
                 "n2": gdata.Leaf("int", 2)
-            }, ["k1"]),
+            }),
             gdata.Container({
+                "name": gdata.Leaf("string", "k4"),
                 "n4": gdata.Leaf("int", 4)
-            }, ["k4"])
+            })
         ])
     }),
     'right': gdata.Container({
@@ -27,12 +29,14 @@ tree2 = gdata.Container({
     'left': gdata.Container({
         "l1": gdata.List(["name"], [
             gdata.Container({
+                "name": gdata.Leaf("string", "k1"),
                 "n2": gdata.Leaf("int", 2)
-            }, ["k1"]),
+            }),
             gdata.Container({
+                "name": gdata.Leaf("string", "k2"),
                 "n1": gdata.Leaf("int", 1),
                 "n3": gdata.Leaf("int", 3)
-            }, ["k2"])
+            })
         ]),
     }),
     'right': gdata.Container({
@@ -44,16 +48,19 @@ merge_1_2 = gdata.Container({
     'left': gdata.Container({
         "l1": gdata.List(["name"], [
             gdata.Container({
+                "name": gdata.Leaf("string", "k1"),
                 "n1": gdata.Leaf("int", 1),
                 "n2": gdata.Leaf("int", 2)
-            }, ["k1"]),
+            }),
             gdata.Container({
+                "name": gdata.Leaf("string", "k2"),
                 "n1": gdata.Leaf("int", 1),
                 "n3": gdata.Leaf("int", 3)
-            }, ["k2"]),
+            }),
             gdata.Container({
+                "name": gdata.Leaf("string", "k4"),
                 "n4": gdata.Leaf("int", 4)
-            }, ["k4"])
+            })
         ]),
     }),
     'right': gdata.Container({
@@ -135,16 +142,19 @@ actor nested_delete_tester(done: action(?bool, ?Exception)->None):
     in1 = gdata.Container({
         "left": gdata.List(["name"], [
             gdata.Container({
+                "name": gdata.Leaf("string", "k1"),
                 "x": gdata.Leaf("int", 1)
-            }, ["k1"]),
+            }),
             gdata.Container({
+                "name": gdata.Leaf("string", "k2"),
                 "x": gdata.Leaf("int", 2)
-            }, ["k2"])
+            })
         ]),
         "right": gdata.List(["name"], [
             gdata.Container({
+                "name": gdata.Leaf("string", "v1"),
                 "y": gdata.Leaf("int", 1)
-            }, ["v1"]),
+            }),
         ])
     })
 
@@ -296,8 +306,9 @@ tree0 = gdata.Container({
     'left': gdata.Container({
         "l1": gdata.List(["name"], [
             gdata.Container({
+                "name": gdata.Leaf("string", "k4"),
                 "n4": gdata.Leaf("int", 0)
-            }, ["k4"])
+            })
         ]),
     }),
     'right': gdata.Container({

--- a/src/test_ttt_layers.act
+++ b/src/test_ttt_layers.act
@@ -8,60 +8,80 @@ import yang.gdata as gdata
 
 cfg1 = gdata.List(["name"], [
     gdata.Container({
+        "name": gdata.Leaf("string", "k1"),
         "n1": gdata.Leaf("int", 1),
         "n2": gdata.Leaf("int", 2)
-    }, ["k1"]),
+    }),
     gdata.Container({
+        "name": gdata.Leaf("string", "k2"),
         "n1": gdata.Leaf("int", 4)
-    }, ["k4"])
+    })
 ])
 
 cfg2 = gdata.List(["name"], [
     gdata.Container({
+        "name": gdata.Leaf("string", "k1"),
         "n2": gdata.Leaf("int", 2),
         "n3": gdata.Leaf("int", 3)
-    }, ["k1"]),
+    }),
     gdata.Container({
+        "name": gdata.Leaf("string", "k3"),
         "n1": gdata.Leaf("int", 1),
         "n3": gdata.Leaf("int", 3)
-    }, ["k2"])
+    })
 ])
 
 out1 = gdata.Container({
     'devices': gdata.List(["id"], [
         gdata.Container({
+            "id": gdata.Leaf("string", "k1"),
             "n1": gdata.Leaf("int", 1),
             "n2": gdata.Leaf("int", 2)
-        }, ["k1"]),
+        }),
         gdata.Container({
+            "id": gdata.Leaf("string", "k2"),
             "n1": gdata.Leaf("int", 4)
-        }, ["k4"])
+        })
     ])
 })
 
 out1_2 = gdata.Container({
     'devices': gdata.List(["id"], [
         gdata.Container({
+            "id": gdata.Leaf("string", "k1"),
             "n1": gdata.Leaf("int", 1),
             "n2": gdata.Leaf("int", 2),
             "n3": gdata.Leaf("int", 3)
-        }, ["k1"]),
+        }),
         gdata.Container({
+            "id": gdata.Leaf("string", "k3"),
             "n1": gdata.Leaf("int", 1),
             "n3": gdata.Leaf("int", 3)
-        }, ["k2"]),
+        }),
         gdata.Container({
+            "id": gdata.Leaf("string", "k2"),
             "n1": gdata.Leaf("int", 4)
-        }, ["k4"])
+        })
     ])
 })
 
 class TransF(ttt.TransformFunction):
     def transform_wrapper(self, cfg):
+        """Simple transform that copies inputs to ouputs (sans keys)
+
+        The input list layer is keyed on "name", the output on "id". This
+        transform copies all child elements to the next layer, while renaming
+        the key.
+        """
         if isinstance(cfg, gdata.Container):
+            # Copy all child nodes
+            out = gdata.Container(dict(cfg.children.items()))
+            # "Rename" the key leaf
+            out.children["id"] = gdata.Leaf("string", cfg.get_leaf("name").val)
+            del out.children["name"]
             return gdata.Container({
                 'devices': gdata.List(["id"], [
-                    cfg
+                    out
                 ])
             })
         else:
@@ -151,11 +171,13 @@ cfg3 = gdata.Container({
 out3 = gdata.Container({
     'devices': gdata.List(["id"], [
         gdata.Container({
+            "id": gdata.Leaf("int", 1),
             "val": gdata.Leaf("int", 1)
-        }, ["1"]),
+        }),
         gdata.Container({
+            "id": gdata.Leaf("int", 2),
             "val": gdata.Leaf("int", 2)
-        }, ["2"])
+        })
     ])
 })
 
@@ -165,8 +187,9 @@ class WriteDev(ttt.TransformFunction):
         return gdata.Container({
             'devices': gdata.List(["id"], [
                 gdata.Container({
+                    "id": gdata.Leaf("int", i),
                     "val": gdata.Leaf("int", i)
-                }, [str(i)])
+                })
             ])
         })
 
@@ -224,7 +247,7 @@ actor multi_layer_tester(done: action(?bool, ?Exception)->None):
 
     def cont(_r: value):
         r1 = sess.below().get()
-        testing.assertEqual(r1, cfg3)
+        testing.assertEqual(r1.prsrc(), cfg3.prsrc())
         r2 = sess.below().below().get()
         testing.assertEqual(r2, out3)
         done(True, None)

--- a/src/test_ttt_list.act
+++ b/src/test_ttt_list.act
@@ -9,49 +9,60 @@ import yang.gdata as gdata
 
 tree1 = gdata.List(["name"], [
     gdata.Container({
+        "name": gdata.Leaf("string", "k1"),
         "n1": gdata.Leaf("int", 1),
         "n2": gdata.Leaf("int", 2)
-    }, ["k1"]),
+    }),
     gdata.Container({
+        "name": gdata.Leaf("string", "k4"),
         "n4": gdata.Leaf("int", 4)
-    }, ["k4"])
+    })
 ])
 
 tree1diff = gdata.List(["name"], [
-    gdata.Absent(["k1"]),
+    gdata.Absent({
+        "name": gdata.Leaf("string", "k1")
+    }),
     gdata.Container({
+        "name": gdata.Leaf("string", "k4"),
         "n4": gdata.Leaf("int", 0)
-    }, ["k4"])
+    })
 ])
 
 tree1pruned = gdata.List(["name"], [
     gdata.Container({
+        "name": gdata.Leaf("string", "k4"),
         "n4": gdata.Leaf("int", 0)
-    }, ["k4"])
+    })
 ])
 
 tree2 = gdata.List(["name"], [
     gdata.Container({
+        "name": gdata.Leaf("string", "k1"),
         "n2": gdata.Leaf("int", 2)
-    }, ["k1"]),
+    }),
     gdata.Container({
+        "name": gdata.Leaf("string", "k2"),
         "n1": gdata.Leaf("int", 1),
         "n3": gdata.Leaf("int", 3)
-    }, ["k2"])
+    })
 ])
 
 merge_1_2 = gdata.List(["name"], [
     gdata.Container({
+        "name": gdata.Leaf("string", "k1"),
         "n1": gdata.Leaf("int", 1),
         "n2": gdata.Leaf("int", 2)
-    }, ["k1"]),
+    }),
     gdata.Container({
+        "name": gdata.Leaf("string", "k2"),
         "n1": gdata.Leaf("int", 1),
         "n3": gdata.Leaf("int", 3)
-    }, ["k2"]),
+    }),
     gdata.Container({
+        "name": gdata.Leaf("string", "k4"),
         "n4": gdata.Leaf("int", 4)
-    }, ["k4"])
+    })
 ])
 
 
@@ -104,11 +115,13 @@ def _test_basic_delete(done, logger: logging.Handler):
 actor all_delete_tester(done: action(?bool, ?Exception)->None):
     in1 = gdata.List(["name"], [
             gdata.Container({
+                "name": gdata.Leaf("str", "k1"),
                 "x": gdata.Leaf("int", 1)
-            }, ["k1"]),
+            }),
             gdata.Container({
+                "name": gdata.Leaf("str", "k2"),
                 "x": gdata.Leaf("int", 2)
-            }, ["k2"]),
+            }),
         ])
 
     tlist = ttt.List(ttt.Transform(ttt.PassThrough), ["name"], ["str"]) ([])
@@ -142,20 +155,24 @@ def _test_all_delete(done, logger: logging.Handler):
 actor partial_delete_tester(done: action(?bool, ?Exception)->None):
     inA = gdata.List(["name"], [
             gdata.Container({
+                "name": gdata.Leaf("str", "k1"),
                 "x": gdata.Leaf("int", 1)
-            }, ["k1"]),
+            }),
             gdata.Container({
+                "name": gdata.Leaf("str", "k2"),
                 "x": gdata.Leaf("int", 2)
-            }, ["k2"])
+            })
         ])
 
     inB = gdata.List(["name"], [
             gdata.Container({
+                "name": gdata.Leaf("str", "k2"),
                 "x": gdata.Leaf("int", 2)
-            }, ["k2"]),
+            }),
             gdata.Container({
+                "name": gdata.Leaf("str", "k3"),
                 "x": gdata.Leaf("int", 3)
-            }, ["k3"]),
+            }),
         ])
 
     tlist = ttt.List(ttt.Transform(ttt.PassThrough), ["name"], ["str"]) ([])
@@ -167,14 +184,17 @@ actor partial_delete_tester(done: action(?bool, ?Exception)->None):
         out1 = t1.get()
         exp1 = gdata.List(["name"], [
                 gdata.Container({
+                    "name": gdata.Leaf("str", "k1"),
                     "x": gdata.Leaf("int", 1)
-                }, ["k1"]),
+                }),
                 gdata.Container({
+                    "name": gdata.Leaf("str", "k2"),
                     "x": gdata.Leaf("int", 2)
-                }, ["k2"]),
+                }),
                 gdata.Container({
+                    "name": gdata.Leaf("str", "k3"),
                     "x": gdata.Leaf("int", 3)
-                }, ["k3"]),
+                }),
             ])
         testing.assertEqual(out1, exp1)
         t1.configure("1", {"srcA": gdata.Absent()})
@@ -205,7 +225,7 @@ actor nested_delete_tester(done: action(?bool, ?Exception)->None):
                 "right": gdata.Container({
                     "y": gdata.Leaf("int", 1)
                 }),
-            }, ["k1"]),
+            }),
             gdata.Container({
                 "name": gdata.Leaf("str", "k2"),
                 "left": gdata.Container({
@@ -214,7 +234,7 @@ actor nested_delete_tester(done: action(?bool, ?Exception)->None):
                 "right": gdata.Container({
                     "y": gdata.Leaf("int", 2)
                 }),
-            }, ["k2"]),
+            }),
         ])
 
     tlist = ttt.List(
@@ -252,21 +272,24 @@ def _test_nested_delete(done, logger: logging.Handler):
 
 list1a = gdata.List(["name"], [
     gdata.Container({
+        "name": gdata.Leaf("string", "key1"),
         "a": gdata.Leaf("int", 0)
-    }, ["key1"])
+    })
 ])
 
 list1b = gdata.List(["name"], [
     gdata.Container({
+        "name": gdata.Leaf("string", "key1"),
         "b": gdata.Leaf("int", 1)
-    }, ["key1"])
+    })
 ])
 
 list1 = gdata.List(["name"], [
     gdata.Container({
+        "name": gdata.Leaf("string", "key1"),
         "a": gdata.Leaf("int", 0),
         "b": gdata.Leaf("int", 1)
-    }, ["key1"])
+    })
 ])
 
 actor simultaneous_create_tester(done: action(?bool, ?Exception)->None):
@@ -313,26 +336,31 @@ def _test_aborted_create(done, logger: logging.Handler):
 
 y1 = gdata.List(["name"], [
     gdata.Container({
+        "name": gdata.Leaf("string", "key0"),
         "a": gdata.Leaf("int", 0)
-    }, ["key0"]),
+    }),
     gdata.Container({
+        "name": gdata.Leaf("string", "key1"),
         "a": gdata.Leaf("int", 1)
-    }, ["key1"])
+    })
 ])
 
 y2 = gdata.List(["name"], [
     gdata.Container({
+        "name": gdata.Leaf("string", "key1"),
         "b": gdata.Leaf("int", 1)
-    }, ["key1"]),
+    }),
     gdata.Container({
+        "name": gdata.Leaf("string", "key2"),
         "a": gdata.Leaf("int", 1)
-    }, ["key2"])
+    })
 ])
 
 y2b = gdata.List(["name"], [
     gdata.Container({
+        "name": gdata.Leaf("string", "key1"),
         "b": gdata.Leaf("int", 1)
-    }, ["key1"])
+    })
 ])
 
 actor aborted_create_tester2(done: action(?bool, ?Exception)->None):
@@ -370,21 +398,21 @@ nested_tree = gdata.Container({
             "name": gdata.Leaf("str", "k1"),
             "nested-list": gdata.List(["id"], [
                 gdata.Container({
-                    "id": gdata.Leaf("str", "k1"),
+                    "id": gdata.Leaf("str", "k1-k1"),
                     "a": gdata.Leaf("int", 1)
-                }, ["k1-k1"])
+                })
             ])
         # This is the key attribute for the top-list list element, and it must remain in the output.
-        }, ["k1"]),
+        }),
         gdata.Container({
             "name": gdata.Leaf("str", "k2"),
             "nested-list": gdata.List(["id"], [
                 gdata.Container({
-                    "id": gdata.Leaf("str", "k2"),
+                    "id": gdata.Leaf("str", "k2-k1"),
                     "a": gdata.Leaf("int", 2)
-                }, ["k2-k1"])
+                })
             ])
-        }, ["k2"])
+        })
     ])
 })
 

--- a/src/test_ttt_transform.act
+++ b/src/test_ttt_transform.act
@@ -10,12 +10,14 @@ y1 = gdata.Container({
     "a": gdata.Leaf("int", 1),
     "l1": gdata.List(["name"], [
         gdata.Container({
+            "name": gdata.Leaf("string", "k1"),
             "n1": gdata.Leaf("int", 1),
             "n2": gdata.Leaf("int", 2)
-        }, ["k1"]),
+        }),
         gdata.Container({
+            "name": gdata.Leaf("string", "k4"),
             "n4": gdata.Leaf("int", 4)
-        }, ["k4"])
+        })
     ])
 })
 y1_transp = {
@@ -25,26 +27,30 @@ y1_transp = {
     "l1": {
         'src': gdata.List(["name"], [
             gdata.Container({
+                "name": gdata.Leaf("string", "k1"),
                 "n1": gdata.Leaf("int", 1),
                 "n2": gdata.Leaf("int", 2)
-            }, ["k1"]),
+            }),
             gdata.Container({
+                "name": gdata.Leaf("string", "k4"),
                 "n4": gdata.Leaf("int", 4)
-            }, ["k4"])
+            })
         ])
     }
 }
 y1_transp_l1 = {
     "k1": {
         'src': gdata.Container({
+            "name": gdata.Leaf("string", "k1"),
             "n1": gdata.Leaf("int", 1),
             "n2": gdata.Leaf("int", 2)
-        }, ["k1"])
+        })
     },
     "k4": {
         'src': gdata.Container({
+            "name": gdata.Leaf("string", "k4"),
             "n4": gdata.Leaf("int", 4)
-        }, ["k4"])
+        })
     }
 }
 y1_transp_l1_k1 = {
@@ -53,6 +59,9 @@ y1_transp_l1_k1 = {
     },
     "n2": {
         'src': gdata.Leaf("int", 2)
+    },
+    "name": {
+        'src': gdata.Leaf("string", "k1")
     }
 }
 y2 = gdata.Container({
@@ -60,12 +69,14 @@ y2 = gdata.Container({
     "c": gdata.Leaf("int", 3),
     "l1": gdata.List(["name"], [
         gdata.Container({
+            "name": gdata.Leaf("string", "k1"),
             "n2": gdata.Leaf("int", 2)
-        }, ["k1"]),
+        }),
         gdata.Container({
+            "name": gdata.Leaf("string", "k2"),
             "n1": gdata.Leaf("int", 1),
             "n3": gdata.Leaf("int", 3)
-        }, ["k2"])
+        })
     ]),
     "d": gdata.LeafList("string", ["a", "b", "c"])
 })
@@ -75,16 +86,19 @@ merge_y1_y2 = gdata.Container({
     "c": gdata.Leaf("int", 3),
     "l1": gdata.List(["name"], [
         gdata.Container({
+            "name": gdata.Leaf("string", "k1"),
             "n1": gdata.Leaf("int", 1),
             "n2": gdata.Leaf("int", 2)
-        }, ["k1"]),
+        }),
         gdata.Container({
+            "name": gdata.Leaf("string", "k2"),
             "n1": gdata.Leaf("int", 1),
             "n3": gdata.Leaf("int", 3)
-        }, ["k2"]),
+        }),
         gdata.Container({
+            "name": gdata.Leaf("string", "k4"),
             "n4": gdata.Leaf("int", 4)
-        }, ["k4"])
+        })
     ]),
     "d": gdata.LeafList("string", ["a", "b", "c"])
 })
@@ -106,36 +120,42 @@ def _test_transpose_absent():
     in1 = {
         "srcA": gdata.List(["id"], [
             gdata.Container({
+                "id": gdata.Leaf("string", "k1"),
                 "x": gdata.Leaf("int", 1)
-            }, ["k1"]),
+            }),
             gdata.Container({
+                "id": gdata.Leaf("string", "k2"),
                 "x": gdata.Leaf("int", 2)
-            }, ["k2"]),
+            }),
         ]),
         "srcB": gdata.Absent(),
         "srcC": gdata.List(["id"], [
             gdata.Container({
+                "id": gdata.Leaf("string", "k2"),
                 "x": gdata.Leaf("int", 2)
-            }, ["k2"])
+            })
         ])
     }
     out1 = ttt.transpose(in1)
     exp1 = {
         "k1": {
             "srcA": gdata.Container({
+                "id": gdata.Leaf("string", "k1"),
                 "x": gdata.Leaf("int", 1),
-            }, ["k1"])
+            })
         },
         ttt.WILDKEY: {
             "srcB": gdata.Absent()
         },
         "k2": {
             "srcA": gdata.Container({
+                "id": gdata.Leaf("string", "k2"),
                 "x": gdata.Leaf("int", 2),
-            }, ["k2"]),
+            }),
             "srcC": gdata.Container({
+                "id": gdata.Leaf("string", "k2"),
                 "x": gdata.Leaf("int", 2),
-            }, ["k2"])
+            })
         }
     }
     testing.assertEqual(out1, exp1)
@@ -166,7 +186,9 @@ def _test_patch():
         'srcB': gdata.Container({
             "b": gdata.Leaf("int", 0),
             'l1': gdata.List(["name"], [
-                gdata.Absent(["k2"])
+                gdata.Absent({
+                    "name": gdata.Leaf("string", "k2")
+                })
             ]),
             'd': gdata.Absent()
         })
@@ -181,8 +203,9 @@ def _test_patch():
             "c": gdata.Leaf("int", 3),
             "l1": gdata.List(["name"], [
                 gdata.Container({
+                    "name": gdata.Leaf("string", "k1"),
                     "n2": gdata.Leaf("int", 2)
-                }, ["k1"])
+                })
             ])
         })
     }
@@ -224,12 +247,14 @@ actor basic_commit_tester(done: action(?bool, ?Exception)->None):
                     'c': gdata.Leaf("int", 3),
                     'l1': gdata.List(['name'], [
                         gdata.Container({
+                            "name": gdata.Leaf("string", "k1"),
                             'n2': gdata.Leaf("int", 2)
-                        }, ['k1']),
+                        }),
                         gdata.Container({
+                            "name": gdata.Leaf("string", "k2"),
                             'n1': gdata.Leaf("int", 1),
                             'n3': gdata.Leaf("int", 3)
-                        }, ['k2'])
+                        })
                     ]),
                     'd': gdata.LeafList("string", ['a', 'c'])
                 })
@@ -320,8 +345,9 @@ y0 = gdata.Container({
     "a": gdata.Leaf("int", 0),
     "l1": gdata.List(["name"], [
         gdata.Container({
+            "name": gdata.Leaf("string", "k4"),
             "n4": gdata.Leaf("int", 0)
-        }, ["k4"])
+        })
     ]),
     "d": gdata.LeafList("string", ["a", "b"])
 })


### PR DESCRIPTION
This is a continuation of work started in https://github.com/orchestron-orchestrator/acton-yang/pull/164, with the aim of removing the `gdata.Container.key` attribute. I will iterate on the code that keeps track of list element keys for non-transform elements, because I really dislike having to provide key leaf types to `ttt.List`, but this is good enough for now ...