### PR TITLE
Adapt to comprehensions in Acton

### DIFF
--- a/build.act.json
+++ b/build.act.json
@@ -2,13 +2,13 @@
     "dependencies": {
         "netconf": {
             "repo_url": "https://github.com/orchestron-orchestrator/netconf.git",
-            "url": "https://github.com/orchestron-orchestrator/netconf/archive/b79ab30b7ca566a96fe5c22ecba598b533dc6c0b.zip",
-            "hash": "122072e980ad13c28deaa0ec5c9873bd28a97fa0ffa498c8e1b2091d88045faf9ecc"
+            "url": "https://github.com/orchestron-orchestrator/netconf/archive/97fdf4a643b10f2da2f9ca1b2678735fea643b32.zip",
+            "hash": "12203f4291b96a1ce2a8ba313eb39bc2a29991314a4a1e9ce518fe20676b0d6fd428"
         },
         "yang": {
             "repo_url": "https://github.com/orchestron-orchestrator/acton-yang.git",
-            "url": "https://github.com/orchestron-orchestrator/acton-yang/archive/4b34cb1a696b821675851948beec09b14f54084f.zip",
-            "hash": "1220133bf734ed6a1e10f75d913ea336a468890612f9c3a91c90cb8c7cf7082ba12f"
+            "url": "https://github.com/orchestron-orchestrator/acton-yang/archive/5f71eddd410a9c10948d562fcf6bb9c4ff264a53.zip",
+            "hash": "1220d85911cdb3034c5a6cb1c9f32f80dd7c1171bb2a04b55fc57cfc4a937ac3e1ec"
         }
     },
     "zig_dependencies": {}

--- a/gen_dmc/build.act.json
+++ b/gen_dmc/build.act.json
@@ -2,8 +2,8 @@
     "dependencies": {
         "yang": {
             "repo_url": "https://github.com/orchestron-orchestrator/acton-yang.git",
-            "url": "https://github.com/orchestron-orchestrator/acton-yang/archive/4b34cb1a696b821675851948beec09b14f54084f.zip",
-            "hash": "1220133bf734ed6a1e10f75d913ea336a468890612f9c3a91c90cb8c7cf7082ba12f"
+            "url": "https://github.com/orchestron-orchestrator/acton-yang/archive/5f71eddd410a9c10948d562fcf6bb9c4ff264a53.zip",
+            "hash": "1220d85911cdb3034c5a6cb1c9f32f80dd7c1171bb2a04b55fc57cfc4a937ac3e1ec"
         }
     },
     "zig_dependencies": {}

--- a/src/orchestron/build.act
+++ b/src/orchestron/build.act
@@ -35,12 +35,8 @@ class SysSpec(object):
         return self.compile().gen_app(fc, output_dir)
 
     def compile(self):
-        compiled_layers = []
-        for l in self.layers:
-            compiled_layers.append(CompiledLayer(yang.compile(l.models), l.name))
-        compiled_dev_types = []
-        for dev_type in self.device_types:
-            compiled_dev_types.append(CompiledDeviceType(yang.compile(dev_type.models), dev_type.name))
+        compiled_layers = [CompiledLayer(yang.compile(l.models), l.name) for l in self.layers]
+        compiled_dev_types = [CompiledDeviceType(yang.compile(dev_type.models), dev_type.name) for dev_type in self.device_types]
         return CompiledSysSpec(self.name, compiled_layers, compiled_dev_types)
 
 class CompiledSysSpec(object):
@@ -53,9 +49,7 @@ class CompiledSysSpec(object):
     def __init__(self, name: str, layers: list[CompiledLayer], device_types: list[CompiledDeviceType]):
         self.name = name
         self.layers = layers + [CompiledLayer(yang.compile([oyang.device]))]
-        self.dev_types = {}
-        for dev_type in device_types:
-            self.dev_types[dev_type.name] = dev_type
+        self.dev_types = {dev_type.name: dev_type for dev_type in device_types}
 
     def gen_app(self, fc: file.FileCap, output_dir: str):
         tttsrc = "# WARNING WARNING WARNING WARNING WARNING\n"
@@ -215,12 +209,7 @@ class Layer(object):
         """
         rfc = file.ReadFileCap(fc)
         fs = file.FS(fc)
-        models = []
-
-        for f in fs.listdir(dir):
-            if f.endswith(".yang"):
-                rf = file.ReadFile(rfc, f"{dir}/{f}")
-                models.append(rf.read().decode())
+        models = [file.ReadFile(rfc, f"{dir}/{f}").read().decode() for f in fs.listdir(dir) if f.endswith(".yang")]
         return Layer(models, name)
 
 class _CompiledLayerBase(object):
@@ -281,10 +270,5 @@ class DeviceType(object):
         """
         rfc = file.ReadFileCap(fc)
         fs = file.FS(fc)
-        models = []
-
-        for f in fs.listdir(dir):
-            if f.endswith(".yang"):
-                rf = file.ReadFile(rfc, f"{dir}/{f}")
-                models.append(rf.read().decode())
+        models = [file.ReadFile(rfc, f"{dir}/{f}").read().decode() for f in fs.listdir(dir) if f.endswith(".yang")]
         return DeviceType(name, models)

--- a/src/orchestron/device.act
+++ b/src/orchestron/device.act
@@ -603,11 +603,11 @@ actor NetconfDriver(dev: Device, log_handler: logging.Handler, wcap: ?WorldCap):
 
 def hash_modset(modset: dict[str, ModCap]) -> str:
     # TODO: use a better hash function
-    big_string = ""
-    for m in sorted(modset.keys()):
-        mod = modset[m]
-        big_string += str(mod)
-    return str(hash(big_string))
+    # We use map here instead of a list comprehension to avoid creating the
+    # intermediate list of strings. Ideally we could achieve the same with a
+    # generator expression.
+    modset_str = map(lambda m: str(modset[m]), sorted(modset.keys()))
+    return str(hash("".join(modset_str)))
 
 def modset_eq(a: dict[str, ModCap], b: dict[str, ModCap]) -> bool:
     if len(a) != len(b):

--- a/src/orchestron/ttt.act
+++ b/src/orchestron/ttt.act
@@ -6,10 +6,7 @@ from orchestron.device_meta_config import orchestron_rfs__device_entry as Device
 import xml, logging
 
 def per_src(cfg_per_src: dict[str, gdata.Node]):
-    res = []
-    for src,cfg in cfg_per_src.items():
-        res.append(f"        '{src}': {cfg.prsrc(4, src)}")
-    return "\n".join(res)
+    return "\n".join([f"        '{src}': {cfg.prsrc(4, src)}" for src,cfg in cfg_per_src.items()])
 
 WILDKEY = ""
 
@@ -303,19 +300,15 @@ class _Container(_Node):
 
     def __init__(self, path, template: dict[str, proc(list[str])->Node], ns):
         self.path = path
-        self.elems = {}
+        self.elems = {key: templ(path + [key]) for key, templ in template.items()}
         self.ns = ns
-        for key,templ in template.items():
-            self.elems[key] = templ(path+[key])
 
     def newtrans(self):
         return ContainerTransaction(self.path, self.elems, self.ns)
 
     def get(self):
         #print('####', '(Container)', self.path, actorid(),'NODE GET', err=True)
-        res = {}
-        for tag,node in self.elems.items():
-            res[tag] = node.get()
+        res = {tag: node.get() for tag, node in self.elems.items()}
         ns = self.ns
         if len(self.path) <= 1 and ns is not None:
             return gdata.Container(res, ns=ns)
@@ -338,8 +331,7 @@ class _ContainerTransaction(_Transaction):
         self.accum = {}
         self.state = None
         self.ns = ns
-        for key,node in contents.items():
-            self.elems[key] = node.newtrans()
+        self.elems = {key: node.newtrans() for key, node in contents.items()}
 
     def configure(self, tid, diff, out, force=False):
         #print('####', tid, '(Container)', self.path, 'configure force:', force, actorid(), err=True)
@@ -461,9 +453,7 @@ class _ContainerTransaction(_Transaction):
 
     def get(self):
         #print('####', '(Container)', self.path, actorid(), 'GET', err=True)
-        res = {}
-        for tag,node in self.elems.items():
-            res[tag] = node.get()
+        res = {tag: node.get() for tag, node in self.elems.items()}
         ns = self.ns
         if len(self.path) <= 1 and ns is not None:
             return gdata.Container(res, ns=ns)
@@ -504,7 +494,6 @@ actor ListState(path, template: proc(list[str]) -> Node):
     var provisional = set()
 
     def acquire(tid: str, keys: ?set[str]):
-        result = {}
         if keys is not None:
             keys1 = keys
             new = keys - set(elems.keys())
@@ -516,9 +505,8 @@ actor ListState(path, template: proc(list[str]) -> Node):
             keys1 = set(elems.keys())
             #print('====', tid, path, 'acquire all keys:', keys1, actorid(), err=True)
         active[tid] = keys1
-        for k in keys1:
-            result[k] = elems[k]
-        return result
+
+        return {k: elems[k] for k in keys1}
 
     def release(tid: str, ok: bool, deletes: set[str]):
         #print('====', tid, path, 'release', ok, 'deletes:', deletes, 'provisional:', provisional, err=True)


### PR DESCRIPTION
This PR updates the orchestron codebase to use Acton's new comprehension syntax where appropriate.

Part of the ecosystem lift for comprehensions: actonlang/acton#2286

## Changes

- Convert dict-building loops to dict comprehensions
- Convert list-building loops to list comprehensions  
- Combine iteration and string formatting using comprehensions
- Simplify collection transformations and filtering patterns

All tests pass after these changes.