### PR TITLE
Remove unnecessary import for staticmethod ref

### DIFF
--- a/src/orchestron/build.act
+++ b/src/orchestron/build.act
@@ -126,11 +126,10 @@ class CompiledSysSpec(object):
 
             modname = "{self.name}.devices.{dev_type.name}"
             syssrc += "import {modname}\n"
-            syssrc += "from {modname} import root as {dev_type.name}_root\n"
             syssrc_devtypes += """    "{dev_type.name}": odev.DeviceType(name="{dev_type.name}",
             schema_namespaces={modname}.schema_namespaces,
             root={modname}.root,
-            from_gdata={dev_type.name}_root.from_gdata,
+            from_gdata={modname}.root.from_gdata,
             from_xml={modname}.from_xml
         ),
 """


### PR DESCRIPTION
We no longer need to directly import a class containing a static method to create a reference to a static method.