### PR TITLE
[CI]: Add REUSE compliance workflow

### DIFF
--- a/.github/workflows/reuse-compliance.yml
+++ b/.github/workflows/reuse-compliance.yml
@@ -1,0 +1,32 @@
+# SPDX-FileCopyrightText: 2022 Free Software Foundation Europe e.V. <https://fsfe.org>, 2024 Deutsche Telekom AG
+#
+# SPDX-License-Identifier: CC0-1.0
+
+name: REUSE Compliance Check
+
+on:
+  push:
+    branches:
+      - master
+  
+  pull_request:
+    branches:
+      - master
+
+  schedule:
+    # Weekly on Saturdays at 1:30AM
+    - cron: '30 1 * * 6'
+
+# Set default permission for all jobs to none
+permissions: {}
+
+jobs:
+  test-reuse-compliance:
+    runs-on: ubuntu-22.04
+    
+    steps:
+      - name: "Checkout Repository"
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      
+      - name: "Run REUSE Compliance Check"
+        uses: fsfe/reuse-action@bb774aa972c2a89ff34781233d275075cbddf542 # v5.0.0


### PR DESCRIPTION
This `PR` adds the **REUSE** compliance worklow and verifies whether the repository conforms to the **REUSE** standard.

The **REUSE** workflow runs on all ``opened PR`` and ``pushes`` to the default branch, which is the ``main`` branch.

The ``PR`` is part of issue #129.