### PR TITLE
Use is not None for non-narrowing checks

### DIFF
--- a/src/orchestron/device.act
+++ b/src/orchestron/device.act
@@ -489,7 +489,7 @@ actor MockDriver(dev: Device, schema: DeviceSchema, log_handler: logging.Handler
             old_dmcg = dmc.to_gdata()
             new_dmcg = new_dmc.to_gdata()
             if old_dmcg is not None and new_dmcg is not None:
-                if yang.gdata.diff(old_dmcg, new_dmcg) != None:
+                if yang.gdata.diff(old_dmcg, new_dmcg) is not None:
                     _log.debug("Device.set_dmc: ignoring new device meta-config identical to current device meta-config")
                     return
         _log.debug("MockAdapter.set_dmc", {"new_dmc": new_dmc.to_gdata().to_json()})
@@ -639,7 +639,7 @@ actor NetconfDriver(dev: Device, schema: DeviceSchema, log_handler: logging.Hand
             old_dmcg = dmc.to_gdata()
             new_dmcg = new_dmc.to_gdata()
             if old_dmcg is not None and new_dmcg is not None:
-                if yang.gdata.diff(old_dmcg, new_dmcg) != None:
+                if yang.gdata.diff(old_dmcg, new_dmcg) is not None:
                     _log.debug("Device.set_dmc: ignoring new device meta-config identical to current device meta-config")
                     return
 


### PR DESCRIPTION
This reverts commit d9d09edfe8fe7bfb5df45d88ada49d90a7de5f51.