### PR TITLE
Rename Device -> DeviceMgr & DeviceRegistry

### DIFF
--- a/src/orchestron/build.act
+++ b/src/orchestron/build.act
@@ -60,7 +60,7 @@ class CompiledSysSpec(object):
         tttsrc += "import orchestron.ttt as ttt\n"
         tttsrc += "import yang.adata\n"
         tttsrc += "import yang.gdata\n\n"
-        tttsrc_getlayers = "def get_layers(dev_mgr: odev.DeviceManager, log_handler: ?logging.Handler=None):\n"
+        tttsrc_getlayers = "def get_layers(dev_registry: odev.DeviceRegistry, log_handler: ?logging.Handler=None):\n"
         # for idx, layer in reversed(enumerate(self.layers)):
         layers_len = len(self.layers)
         idx = layers_len
@@ -105,7 +105,7 @@ class CompiledSysSpec(object):
                 print(f"+ Layer {idx} TTT(?) unchanged")
 
             lowerlayer = f"layer{idx+1}" if idx < layers_len -1 else "None"
-            tttsrc_getlayers += f"    layer{idx} = ttt.Layer('{lname}', {self.name}.layers.t_{idx}.get_ttt({lowerlayer}, dev_mgr, log_handler), {lowerlayer})\n"
+            tttsrc_getlayers += f"    layer{idx} = ttt.Layer('{lname}', {self.name}.layers.t_{idx}.get_ttt({lowerlayer}, dev_registry, log_handler), {lowerlayer})\n"
 
             loose_name = f"{output_dir}/{self.name}/layers/y_{idx}_loose.act"
             if _maybe_write_file(fc, loose_name, layer.root.prdaclass(loose=True)):

--- a/src/orchestron/device.act
+++ b/src/orchestron/device.act
@@ -69,7 +69,7 @@ class DeviceType(object):
     ## Adapter type, i.e. the DeviceAdapter subclass to use
     # TODO: why is @property needed here?
     @property
-    adapter_type: proc(Device, DeviceSchema, logging.Handler, ?WorldCap) -> DeviceAdapter
+    adapter_type: proc(DeviceMgr, DeviceSchema, logging.Handler, ?WorldCap) -> DeviceAdapter
 
     schema: DeviceSchema
 
@@ -133,8 +133,8 @@ extension ModCap(Eq):
         return self.name == other.name and self.namespace == other.namespace and revision_eq and self.feature == other.feature
 
 
-actor DeviceManager(dev_types: dict[str, DeviceType]={}, wcap: ?WorldCap=None, log_handler: logging.Handler):
-    """Device Manager keeps track of all devices and hands out references to
+actor DeviceRegistry(dev_types: dict[str, DeviceType]={}, wcap: ?WorldCap=None, log_handler: logging.Handler):
+    """Device Registry keeps track of all devices and hands out references to
     them based on name.
 
     There must only be a single Device instance per device, i.e. the same device
@@ -148,9 +148,9 @@ actor DeviceManager(dev_types: dict[str, DeviceType]={}, wcap: ?WorldCap=None, l
 
     var reconf_cb: action(str) -> None = _dummy_reconf
 
-    def get(name: str) -> Device:
+    def get(name: str) -> DeviceMgr:
         if name not in devices:
-            devices[name] = Device(dev_types, wcap, name, log_handler, reconf_cb)
+            devices[name] = DeviceMgr(dev_types, wcap, name, log_handler, reconf_cb)
         dev = devices[name]
         return dev
 
@@ -168,25 +168,21 @@ def truncate_conf(conf: ?yang.gdata.Node) -> str:
         return sc
     return r"{}"
 
-actor Device(dev_types: dict[str, DeviceType]={}, wcap: ?WorldCap=None, name: str, log_handler: logging.Handler, on_reconf: action(str) -> None):
-    """Device
+actor DeviceMgr(dev_types: dict[str, DeviceType]={}, wcap: ?WorldCap=None, name: str, log_handler: logging.Handler, on_reconf: action(str) -> None):
+    """Device Manager manages a device and represents that device, as an
+    abstract device, in the system. Platform specific handling is implemented in
+    the DeviceAdapter, i.e.  in subclasses of DeviceAdapter, like NetconfDriver
+    and MockAdapter.
 
-    This is the Orchestron Device, it represents an abstract device in the
-    system. Platform specific handling is implemented in the DeviceAdapter, i.e.
-    in subclasses of DeviceAdapter, like NetconfDriver and MockAdapter.
-
-    Device is used for the Device-actor whereas 'device' denotes the actual
-    device that exists somewhere across the network.
-
-    The Device actor sits between the TTT transaction engine and devices out in
+    The DeviceMgr sits between the TTT transaction engine and devices out in
     the real world. All changes from TTT are accepted, they are by definition
     the intended target configuration for the device, thus the TTT API is fairly
-    simple. Configuration is fed from TTT to Device asynchronously (nothing can
-    go wrong) together with a transaction id (tid). If a TTT transaction wants
-    to await the configuration to reach the device, that is possible via the
-    wait_complete(tid). The device configuration interaction is serial, which
-    means that we are either idling or have configuration in-transit to the
-    device. If new configuration is received from TTT while we have
+    simple. Configuration is fed from TTT to DeviceMgr asynchronously (nothing
+    can go wrong) together with a transaction id (tid). If a TTT transaction
+    wants to await the configuration to reach the device, that is possible via
+    the wait_complete(tid). The device configuration interaction is serial,
+    which means that we are either idling or have configuration in-transit to
+    the device. If new configuration is received from TTT while we have
     configuration in-transit to the device, the new configuration is queued up
     and the associated transactions added to pending_txids. Once acknowledgement
     is received from the device, and thus the in-transit commit has concluded,
@@ -194,7 +190,6 @@ actor Device(dev_types: dict[str, DeviceType]={}, wcap: ?WorldCap=None, name: st
     device.
 
     The device interaction is entirely asynchronous.
-
     """
     _log_handler = logging.Handler(name)
     _log_handler.set_handler(log_handler)
@@ -202,7 +197,7 @@ actor Device(dev_types: dict[str, DeviceType]={}, wcap: ?WorldCap=None, name: st
     _log = logging.Logger(_log_handler)
 
     mock = True if wcap is None else False
-    _log.debug("Device starting up", {"name": name, "mock": mock})
+    _log.debug("DeviceMgr starting up", {"name": name, "mock": mock})
 
     # Orchestron's intended target configuration, that we want on the device.
     var target_conf: ?yang.gdata.Node = None
@@ -269,27 +264,27 @@ actor Device(dev_types: dict[str, DeviceType]={}, wcap: ?WorldCap=None, name: st
 
     def set_dmc(new_dmc: DeviceMetaConfig) -> None:
         old_type = str(dmc.type) if dmc is not None else str(None)
-        _log.debug("Device.set_dmc", {"old_type": old_type, "new_dmc": json.encode(json.decode(new_dmc.to_gdata().to_json()), pretty=False)})
+        _log.debug("DeviceMgr.set_dmc", {"old_type": old_type, "new_dmc": json.encode(json.decode(new_dmc.to_gdata().to_json()), pretty=False)})
 
         if mock:
-            _log.debug("Device.set_dmc: mock device")
+            _log.debug("DeviceMgr.set_dmc: mock device")
         else:
             new_dmc_type = new_dmc.type
             if new_dmc_type is not None:
                 if old_type != str(new_dmc.type):
-                    _log.debug("Device type has changed, using new adapter", {"old_type": old_type, "new_type": new_dmc.type})
+                    _log.debug("DeviceMgr type has changed, using new adapter", {"old_type": old_type, "new_type": new_dmc.type})
 
                     device_type = dev_types.get(new_dmc_type)
                     if device_type is not None:
                         adapter = device_type.adapter_type(self, device_type.schema, _log_handler, wcap)
-                        _log.info("Device.set_dmc: using adapter", {"adapter": adapter})
+                        _log.info("DeviceMgr.set_dmc: using adapter", {"adapter": adapter})
                         adapter.set_dmc(new_dmc)
                     else:
-                        _log.warning("Device.set_dmc: configured device type not available in system", {"device_type": new_dmc_type})
+                        _log.warning("DeviceMgr.set_dmc: configured device type not available in system", {"device_type": new_dmc_type})
                 else:
-                    _log.debug("Device.set_dmc: device type unchanged, not changing adapter")
+                    _log.debug("DeviceMgr.set_dmc: device type unchanged, not changing adapter")
             else:
-                _log.debug("Device.set_dmc: no device type configured, not changing adapter")
+                _log.debug("DeviceMgr.set_dmc: no device type configured, not changing adapter")
 
         adapter.set_dmc(new_dmc)
         adapter.get_config(_get_config_done)
@@ -301,14 +296,14 @@ actor Device(dev_types: dict[str, DeviceType]={}, wcap: ?WorldCap=None, name: st
         """
         if error is not None:
             if isinstance(error, NotConnectedError):
-                _log.debug("Device._transaction_done: Device not connected, backing off, waiting for reconnect")
+                _log.debug("DeviceMgr._transaction_done: Device not connected, backing off, waiting for reconnect")
                 pending_txids.update(current_txids)
                 current_txids = set()
             else:
                 if isinstance(error, ConfigError):
-                    _log.debug("Device._transaction_done: Configuration failed, bad config", {"error": error})
+                    _log.debug("DeviceMgr._transaction_done: Configuration failed, bad config", {"error": error})
                 else:
-                    _log.debug("Device._transaction_done: Unhandled error", {"error": error})
+                    _log.debug("DeviceMgr._transaction_done: Unhandled error", {"error": error})
 
                 # TODO: should we signal failure to uptream transactions? or just retry in some way?
                 for tid,callback in callbacks.items():
@@ -338,12 +333,12 @@ actor Device(dev_types: dict[str, DeviceType]={}, wcap: ?WorldCap=None, name: st
 
     def _send_config():
         if len(current_txids) > 0:
-            _log.debug("Device._send_config: there is currently an outstanding configuration, skipping", {"txids": current_txids})
+            _log.debug("DeviceMgr._send_config: there is currently an outstanding configuration, skipping", {"txids": current_txids})
         else:
             if target_conf is not None:
                 current_txids = pending_txids
                 pending_txids = set()
-                _log.debug("Device._send_config: sending intended target configuration", {"txids": current_txids})
+                _log.debug("DeviceMgr._send_config: sending intended target configuration", {"txids": current_txids})
                 adapter.configure(_transaction_done, target_conf)
             else:
                 _log.debug("_send_config: target_conf not set")
@@ -352,23 +347,23 @@ actor Device(dev_types: dict[str, DeviceType]={}, wcap: ?WorldCap=None, name: st
         pending_txids.add(tid)
         if new_conf is not None and conf_modset_id is not None:
             if conf_modset_id != modset_id:
-                _log.debug("Device.configure: modset_id mismatch, ignoring configuration", {"conf_modset_id": str(conf_modset_id), "modset_id": str(modset_id)})
+                _log.debug("DeviceMgr.configure: modset_id mismatch, ignoring configuration", {"conf_modset_id": str(conf_modset_id), "modset_id": str(modset_id)})
                 return
-            _log.debug("Device.configure: received new intended configuration", {"tid": tid, "new_conf": truncate_conf(new_conf)})
+            _log.debug("DeviceMgr.configure: received new intended configuration", {"tid": tid, "new_conf": truncate_conf(new_conf)})
             target_conf = new_conf
             _send_config()
         elif new_conf is None and conf_modset_id is None:
-            _log.debug("Device.configure: transaction registered intent to configure but awaiting reconf", {"tid": tid})
+            _log.debug("DeviceMgr.configure: transaction registered intent to configure but awaiting reconf", {"tid": tid})
         else:
-            _log.debug("Device.configure: invalid input", {"conf_modset_id": str(conf_modset_id), "new_conf": truncate_conf(new_conf), "tid": tid})
+            _log.debug("DeviceMgr.configure: invalid input", {"conf_modset_id": str(conf_modset_id), "new_conf": truncate_conf(new_conf), "tid": tid})
 
 
     def wait_complete(tid: str, done: action(value)->None):
         if tid not in current_txids | pending_txids:
-            _log.debug("Device.wait_complete: transaction id not found, calling done", {"tid": tid})
+            _log.debug("DeviceMgr.wait_complete: transaction id not found, calling done", {"tid": tid})
             done(True) # Assume tid is very old and has already completed, thus respond immediately
         else:
-            _log.debug("Device.wait_complete: waiting for transaction to complete", {"tid": tid})
+            _log.debug("DeviceMgr.wait_complete: waiting for transaction to complete", {"tid": tid})
             callbacks[tid] = done
 
     def get_capabilities():
@@ -379,12 +374,12 @@ actor Device(dev_types: dict[str, DeviceType]={}, wcap: ?WorldCap=None, name: st
 
     def _get_config_done(new_running_conf: ?yang.gdata.Node, error: ?Exception):
         if error is not None:
-            _log.error("Device._get_config_done: {str(error)}")
+            _log.error("DeviceMgr._get_config_done: {str(error)}")
         if new_running_conf is not None:
             #if running_conf is not None:
             #    conf_diff = diff.diff(xml.encode(running_conf), xml.encode(new_running_conf))
             #    if conf_diff != "":
-            #        _log.warning("Device._get_config_done: Running config diff detected", {"diff": conf_diff})
+            #        _log.warning("DeviceMgr._get_config_done: Running config diff detected", {"diff": conf_diff})
             running_conf = new_running_conf
 
     def get_running_config():
@@ -400,7 +395,7 @@ class DeviceAdapter(object):
     _log_handler: logging.Handler
     _wcap: ?WorldCap
 
-    def __init__(self, dev: Device, schema: DeviceSchema, log_handler, wcap):
+    def __init__(self, dev: DeviceMgr, schema: DeviceSchema, log_handler, wcap):
         self._dev = dev
         self._schema = schema
         self._log_handler = log_handler
@@ -448,7 +443,7 @@ class NoAdapter(DeviceAdapter):
 class MockAdapter(DeviceAdapter):
     """Mock device adapter
     """
-    def __init__(self, dev: Device, schema: DeviceSchema, log_handler, wcap: ?WorldCap):
+    def __init__(self, dev: DeviceMgr, schema: DeviceSchema, log_handler, wcap: ?WorldCap):
         self._dev = dev
         self._schema = schema
         self._log_handler = log_handler
@@ -474,7 +469,7 @@ class MockAdapter(DeviceAdapter):
         return self._driver.get_config(done)
 
 
-actor MockDriver(dev: Device, schema: DeviceSchema, log_handler: logging.Handler, wcap: ?WorldCap):
+actor MockDriver(dev: DeviceMgr, schema: DeviceSchema, log_handler: logging.Handler, wcap: ?WorldCap):
     _log = logging.Logger(log_handler)
     _log.info("MockDriver starting up")
 
@@ -547,7 +542,7 @@ actor MockDriver(dev: Device, schema: DeviceSchema, log_handler: logging.Handler
 
 class NetconfAdapter(DeviceAdapter):
 
-    def __init__(self, dev: Device, schema: DeviceSchema, log_handler, wcap: ?WorldCap):
+    def __init__(self, dev: DeviceMgr, schema: DeviceSchema, log_handler, wcap: ?WorldCap):
         self._dev = dev
         self._schema = schema
         self._log_handler = log_handler
@@ -571,7 +566,7 @@ class NetconfAdapter(DeviceAdapter):
         self._driver.get_config(done)
 
 
-actor NetconfDriver(dev: Device, schema: DeviceSchema, log_handler: logging.Handler, wcap: ?WorldCap):
+actor NetconfDriver(dev: DeviceMgr, schema: DeviceSchema, log_handler: logging.Handler, wcap: ?WorldCap):
     """NETCONF device adapter
     """
     _log = logging.Logger(log_handler)

--- a/src/orchestron/ttt.act
+++ b/src/orchestron/ttt.act
@@ -959,9 +959,9 @@ class TransformFunction(object):
 
 ################# RFSTransform ###################
 
-def RFSTransform(function, dev_mgr: odev.DeviceManager, act: ?(proc(proc(?yang.adata.MNode) -> None) -> ?proc(gdata.Node, ?gdata.Node) -> None)=None, lower: ?Layer=None, log_handler: ?logging.Handler=None) -> proc(list[str], ?Layer)->Node:
+def RFSTransform(function, dev_registry: odev.DeviceRegistry, act: ?(proc(proc(?yang.adata.MNode) -> None) -> ?proc(gdata.Node, ?gdata.Node) -> None)=None, lower: ?Layer=None, log_handler: ?logging.Handler=None) -> proc(list[str], ?Layer)->Node:
     proc def _create_rfs_transform_node(path, lower):
-        rfs_transform = _RFSTransform(path, function, dev_mgr, lower, log_handler)
+        rfs_transform = _RFSTransform(path, function, dev_registry, lower, log_handler)
         node = Node(rfs_transform)
         if act is not None:
             rfs_transform.init_dynstate(node, act)
@@ -970,32 +970,32 @@ def RFSTransform(function, dev_mgr: odev.DeviceManager, act: ?(proc(proc(?yang.a
 
 
 class _RFSTransform(_TransformBase):
-    def __init__(self, path, function, dev_mgr, lower, log_handler):
+    def __init__(self, path, function, dev_registry, lower, log_handler):
         self.path = path
-        self.transaction = RFSTransaction(path, function, dev_mgr, lower, log_handler)
+        self.transaction = RFSTransaction(path, function, dev_registry, lower, log_handler)
 
     proc def init_dynstate(self, node, act):
         self.transaction.init_dynstate(node, act)
 
-def RFSTransaction(path, function, dev_mgr, lower, log_handler):
-    return Transaction(_RFSTransaction(path, function, dev_mgr, lower, log_handler))
+def RFSTransaction(path, function, dev_registry, lower, log_handler):
+    return Transaction(_RFSTransaction(path, function, dev_registry, lower, log_handler))
 
 class _RFSTransaction(_TransformTransactionBase):
     function: RFSFunction
     devname: str
-    dev: odev.Device
+    dev: odev.DeviceMgr
     memory: ?gdata.Node
     dynstate: ?gdata.Node
     node: ?Node
     lower: ?Layer
 
-    def __init__(self, path, function: proc(?logging.Handler) -> RFSFunction, dev_mgr: odev.DeviceManager, lower: ?Layer, log_handler):
+    def __init__(self, path, function: proc(?logging.Handler) -> RFSFunction, dev_registry: odev.DeviceRegistry, lower: ?Layer, log_handler):
         _TransformTransactionBase.__init__(self, path)
         self.function = function(log_handler)
         if len(path) < 3:
             raise ValueError(f"RFSTransform {path}: path length < 3")
         self.devname = path[-3]
-        self.dev = dev_mgr.get(self.devname)
+        self.dev = dev_registry.get(self.devname)
         self.lower = lower
 
     def compute(self, tid, merged, out):
@@ -1096,24 +1096,24 @@ class RFSFunction(object):
 
 ################# Device #####################
 
-def Device(dev_mgr: odev.DeviceManager, log_handler: ?logging.Handler=None) -> proc(list[str], ?Layer)->Node:
-    return lambda path, _lower: Node(_Device(path, dev_mgr, log_handler))
+def Device(dev_registry: odev.DeviceRegistry, log_handler: ?logging.Handler=None) -> proc(list[str], ?Layer)->Node:
+    return lambda path, _lower: Node(_Device(path, dev_registry, log_handler))
 
 class _Device(_TransformBase):
-    def __init__(self, path, dev_mgr, log_handler):
+    def __init__(self, path, dev_registry, log_handler):
         self.path = path
-        self.transaction = DeviceTransaction(path, dev_mgr, log_handler)
+        self.transaction = DeviceTransaction(path, dev_registry, log_handler)
 
-def DeviceTransaction(path, dev_mgr, log_handler):
-    return Transaction(_DeviceTransaction(path, dev_mgr, log_handler))
+def DeviceTransaction(path, dev_registry, log_handler):
+    return Transaction(_DeviceTransaction(path, dev_registry, log_handler))
 
 class _DeviceTransaction(_TransformTransactionBase):
-    dev: odev.Device
+    dev: odev.DeviceMgr
     logger: logging.Logger
 
-    def __init__(self, path, dev_mgr: odev.DeviceManager, log_handler):
+    def __init__(self, path, dev_registry: odev.DeviceRegistry, log_handler):
         _TransformTransactionBase.__init__(self, path)
-        self.dev = dev_mgr.get(path[-1])
+        self.dev = dev_registry.get(path[-1])
         self.logger = logging.Logger(log_handler)
 
     def compute(self, tid, merged, out):
@@ -1132,24 +1132,24 @@ class _DeviceTransaction(_TransformTransactionBase):
 
 ################# DeviceConfig #####################
 
-def DeviceConfig(dev_mgr: odev.DeviceManager, log_handler: ?logging.Handler=None) -> proc(list[str], ?Layer)->Node:
-    return lambda path, _lower: Node(_DeviceConfig(path, dev_mgr, log_handler))
+def DeviceConfig(dev_registry: odev.DeviceRegistry, log_handler: ?logging.Handler=None) -> proc(list[str], ?Layer)->Node:
+    return lambda path, _lower: Node(_DeviceConfig(path, dev_registry, log_handler))
 
 class _DeviceConfig(_TransformBase):
-    def __init__(self, path, dev_mgr, log_handler):
+    def __init__(self, path, dev_registry, log_handler):
         self.path = path
-        self.transaction = DeviceConfigTransaction(path, dev_mgr, log_handler)
+        self.transaction = DeviceConfigTransaction(path, dev_registry, log_handler)
 
-def DeviceConfigTransaction(path, dev_mgr, log_handler):
-    return Transaction(_DeviceConfigTransaction(path, dev_mgr, log_handler))
+def DeviceConfigTransaction(path, dev_registry, log_handler):
+    return Transaction(_DeviceConfigTransaction(path, dev_registry, log_handler))
 
 class _DeviceConfigTransaction(_TransformTransactionBase):
-    dev: odev.Device
+    dev: odev.DeviceMgr
     logger: logging.Logger
 
-    def __init__(self, path, dev_mgr: odev.DeviceManager, log_handler):
+    def __init__(self, path, dev_registry: odev.DeviceRegistry, log_handler):
         _TransformTransactionBase.__init__(self, path)
-        self.dev = dev_mgr.get(path[-1])
+        self.dev = dev_registry.get(path[-1])
         self.logger = logging.Logger(log_handler)
 
     def compute(self, tid, merged, out):

--- a/src/orchestron/ttt_gen.act
+++ b/src/orchestron/ttt_gen.act
@@ -187,18 +187,18 @@ def dschema_to_tttsrc(sn: schema.DNode, indent=0, set_ns=True) -> TTTSrc:
         modeled_input = {input_class}.from_gdata(gdata_input){wrapper_extra_models}
         {wrapper_return}
 """)
-                            return TTTSrc(src="ttt.List(ttt.RFSTransform({transform}, dev_mgr, {transform_actor_ctor}, lower, log_handler), {repr(sn.key)}, {repr(get_key_types(sn))}{nsq(sn)})", input_classes=input_classes, state_classes=state_classes, deserializers=deserializers, imports=imports, defs=defs, base_defs=base_defs, act_defs=act_defs)
+                            return TTTSrc(src="ttt.List(ttt.RFSTransform({transform}, dev_registry, {transform_actor_ctor}, lower, log_handler), {repr(sn.key)}, {repr(get_key_types(sn))}{nsq(sn)})", input_classes=input_classes, state_classes=state_classes, deserializers=deserializers, imports=imports, defs=defs, base_defs=base_defs, act_defs=act_defs)
                         raise ValueError("Unknown extension name: {ext.name}")
                     else:
                         raise ValueError("Missing argument to orchestron:transform. Add path to transform as arg.")
                 elif ext.name == "device":
                     if extarg is not None:
                         raise ValueError("Extraneous argument to orchestron:device. Remove argument.")
-                    return TTTSrc(src="ttt.List(ttt.Device(dev_mgr, log_handler), {repr(sn.key)}, {repr(get_key_types(sn))}{nsq(sn)})", input_classes=input_classes, state_classes=state_classes, deserializers=deserializers, imports=imports, defs=defs, base_defs=base_defs, act_defs=act_defs)
+                    return TTTSrc(src="ttt.List(ttt.Device(dev_registry, log_handler), {repr(sn.key)}, {repr(get_key_types(sn))}{nsq(sn)})", input_classes=input_classes, state_classes=state_classes, deserializers=deserializers, imports=imports, defs=defs, base_defs=base_defs, act_defs=act_defs)
                 elif ext.name == "device-config":
                     if extarg is not None:
                         raise ValueError("Extraneous argument to orchestron:device-config. Remove argument.")
-                    return TTTSrc(src="ttt.List(ttt.DeviceConfig(dev_mgr, log_handler), {repr(sn.key)}, {repr(get_key_types(sn))}{nsq(sn)})", input_classes=input_classes, state_classes=state_classes, deserializers=deserializers, imports=imports, defs=defs, base_defs=base_defs, act_defs=act_defs)
+                    return TTTSrc(src="ttt.List(ttt.DeviceConfig(dev_registry, log_handler), {repr(sn.key)}, {repr(get_key_types(sn))}{nsq(sn)})", input_classes=input_classes, state_classes=state_classes, deserializers=deserializers, imports=imports, defs=defs, base_defs=base_defs, act_defs=act_defs)
 
         # List without an extension
         children_res = children_to_tttsrc(sn)
@@ -255,7 +255,7 @@ def ttt_prsrc(sn: schema.DNode, input_yang_module: str, output_yang_module: ?str
     for sc in ts.state_classes:
         ttt_src += "from %s import %s\n" % (input_yang_module, sc)
     ttt_src += "\n"
-    ttt_src += "def get_ttt(lower: ?ttt.Layer, dev_mgr: odev.DeviceManager, log_handler: ?logging.Handler=None) -> proc(list[str],?ttt.Layer)->ttt.Node:\n"
+    ttt_src += "def get_ttt(lower: ?ttt.Layer, dev_registry: odev.DeviceRegistry, log_handler: ?logging.Handler=None) -> proc(list[str],?ttt.Layer)->ttt.Node:\n"
     ttt_src += f"    r = {ts.src}\n    return r\n"
     if len(ts.act_defs) > 0:
         ttt_src += "\n"

--- a/src/test_ttt_callbacks.act
+++ b/src/test_ttt_callbacks.act
@@ -13,15 +13,15 @@ from orchestron.device_meta_config import \
 ########################
 
 actor reconf(t: testing.AsyncT):
-    dev_mgr = odev.DeviceManager(log_handler=t.log_handler)
+    dev_registry = odev.DeviceRegistry(log_handler=t.log_handler)
 
     def reconf_cb(dev):
         #print("Reconfiguring", dev)
         t.success()
         
     dmc = DeviceMetaConfig("k1", Credentials("admin", "admin"), mock=Mock(["cisco-ios-xr"]))
-    dev_mgr.on_reconf(reconf_cb)
-    dev_mgr.get("k1").set_dmc(dmc)
+    dev_registry.on_reconf(reconf_cb)
+    dev_registry.get("k1").set_dmc(dmc)
 
 
 ########################
@@ -42,8 +42,8 @@ cfg2 = gdata.List(["name"], [
 ])
 
 actor reconf2(t: testing.AsyncT):
-    dev_mgr = odev.DeviceManager(log_handler=t.log_handler)
-    stack = ttt.Layer("devices", ttt.List(ttt.DeviceConfig(dev_mgr), ["name"], ["string"]), None)
+    dev_registry = odev.DeviceRegistry(log_handler=t.log_handler)
+    stack = ttt.Layer("devices", ttt.List(ttt.DeviceConfig(dev_registry), ["name"], ["string"]), None)
     
     var devs = set()
     
@@ -53,13 +53,13 @@ actor reconf2(t: testing.AsyncT):
         if devs == {"k1", "k2"}:
             t.success()
         
-    dev_mgr.on_reconf(reconf_cb)
+    dev_registry.on_reconf(reconf_cb)
     sess = stack.newsession()
     
     def cont1(_r):
         dmc = DeviceMetaConfig("k1", Credentials("admin", "admin"), mock=Mock(["cisco-ios-xr"]))
-        dev_mgr.get("k1").set_dmc(dmc)
-        dev_mgr.get("k2").set_dmc(dmc)
+        dev_registry.get("k1").set_dmc(dmc)
+        dev_registry.get("k2").set_dmc(dmc)
     
     sess.edit_config(cfg2, cont1)
 
@@ -103,22 +103,22 @@ def rfs_for_device(dev):
     })
 
 actor complete(t: testing.AsyncT):
-    dev_mgr = odev.DeviceManager(log_handler=t.log_handler)
-    stack = ttt.Layer("rfs", ttt.Container({"rfs": ttt.List(ttt.Container({"base": ttt.List(ttt.RFSTransform(Fun, dev_mgr), ["id"], ["string"])}), ["name"], ["string"])}),
-            ttt.Layer("devices", ttt.Container({"devices": ttt.Container({"device": ttt.List(ttt.DeviceConfig(dev_mgr), ["name"], ["string"])})}),
+    dev_registry = odev.DeviceRegistry(log_handler=t.log_handler)
+    stack = ttt.Layer("rfs", ttt.Container({"rfs": ttt.List(ttt.Container({"base": ttt.List(ttt.RFSTransform(Fun, dev_registry), ["id"], ["string"])}), ["name"], ["string"])}),
+            ttt.Layer("devices", ttt.Container({"devices": ttt.Container({"device": ttt.List(ttt.DeviceConfig(dev_registry), ["name"], ["string"])})}),
             None))
 
     def reconf_cb(dev):
         cfg = rfs_for_device(dev)
         stack.edit_config(cfg, force=True)
         
-    dev_mgr.on_reconf(reconf_cb)
+    dev_registry.on_reconf(reconf_cb)
     
     def cont1(_r):
         dmc1 = DeviceMetaConfig("k1", Credentials("admin", "admin"), mock=Mock(["cisco-ios-xr"]))
         dmc2 = DeviceMetaConfig("k2", Credentials("admin", "admin"), mock=Mock(["cisco-ios-xr"]))
-        k1 = dev_mgr.get("k1").set_dmc(dmc1)
-        k2 = dev_mgr.get("k2").set_dmc(dmc2)
+        k1 = dev_registry.get("k1").set_dmc(dmc1)
+        k2 = dev_registry.get("k2").set_dmc(dmc2)
     
     def complete_cb(_r):
         t.success()

--- a/test/golden/test_ttt_gen/odev
+++ b/test/golden/test_ttt_gen/odev
@@ -12,6 +12,6 @@ import yang.gdata
 
 
 
-def get_ttt(lower: ?ttt.Layer, dev_mgr: odev.DeviceManager, log_handler: ?logging.Handler=None) -> proc(list[str],?ttt.Layer)->ttt.Node:
-    r = ttt.Container({"devices": ttt.Container({"device": ttt.List(ttt.DeviceConfig(dev_mgr, log_handler), ['name'], ['string'])}, ns='http://orchestron.org/yang/orchestron-device.yang', module='orchestron-device')})
+def get_ttt(lower: ?ttt.Layer, dev_registry: odev.DeviceRegistry, log_handler: ?logging.Handler=None) -> proc(list[str],?ttt.Layer)->ttt.Node:
+    r = ttt.Container({"devices": ttt.Container({"device": ttt.List(ttt.DeviceConfig(dev_registry, log_handler), ['name'], ['string'])}, ns='http://orchestron.org/yang/orchestron-device.yang', module='orchestron-device')})
     return r

--- a/test/golden/test_ttt_gen/ttt_gen_cfs_ttt
+++ b/test/golden/test_ttt_gen/ttt_gen_cfs_ttt
@@ -12,6 +12,6 @@ import yang.gdata
 import respnet.cfs
 
 
-def get_ttt(lower: ?ttt.Layer, dev_mgr: odev.DeviceManager, log_handler: ?logging.Handler=None) -> proc(list[str],?ttt.Layer)->ttt.Node:
+def get_ttt(lower: ?ttt.Layer, dev_registry: odev.DeviceRegistry, log_handler: ?logging.Handler=None) -> proc(list[str],?ttt.Layer)->ttt.Node:
     r = ttt.Container({"c1": ttt.Container({"foo": ttt.List(ttt.Container({"bar": ttt.List(ttt.Transform(respnet.cfs.Foobar, None, lower, log_handler), ['name'], ['string'])}), ['name'], ['string'])}, ns='http://example.com/foo', module='foo')})
     return r

--- a/test/golden/test_ttt_gen/ttt_gen_rfs_ttt
+++ b/test/golden/test_ttt_gen/ttt_gen_rfs_ttt
@@ -12,6 +12,6 @@ import yang.gdata
 import respnet.rfs
 
 
-def get_ttt(lower: ?ttt.Layer, dev_mgr: odev.DeviceManager, log_handler: ?logging.Handler=None) -> proc(list[str],?ttt.Layer)->ttt.Node:
-    r = ttt.Container({"device": ttt.List(ttt.Device(dev_mgr, log_handler), ['name'], ['string'], ns='http://orchestron.org/yang/orchestron-rfs.yang', module='orchestron-rfs'), "rfs": ttt.List(ttt.Container({"backbone-interface": ttt.List(ttt.RFSTransform(respnet.rfs.BBInterface, dev_mgr, None, lower, log_handler), ['name'], ['string'], ns='http://example.com/foo', module='foo')}), ['name'], ['string'], ns='http://orchestron.org/yang/orchestron-rfs.yang', module='orchestron-rfs')})
+def get_ttt(lower: ?ttt.Layer, dev_registry: odev.DeviceRegistry, log_handler: ?logging.Handler=None) -> proc(list[str],?ttt.Layer)->ttt.Node:
+    r = ttt.Container({"device": ttt.List(ttt.Device(dev_registry, log_handler), ['name'], ['string'], ns='http://orchestron.org/yang/orchestron-rfs.yang', module='orchestron-rfs'), "rfs": ttt.List(ttt.Container({"backbone-interface": ttt.List(ttt.RFSTransform(respnet.rfs.BBInterface, dev_registry, None, lower, log_handler), ['name'], ['string'], ns='http://example.com/foo', module='foo')}), ['name'], ['string'], ns='http://orchestron.org/yang/orchestron-rfs.yang', module='orchestron-rfs')})
     return r


### PR DESCRIPTION
It's hard to talk about the Device-actor since device is such a generic word. We are now renaming it to DeviceMgr, as it manages a single device. What we used to call the DeviceManager has now been renamed to DeviceRegistry

Fixes #148 