### PR TITLE
Update deps

### DIFF
--- a/build.act.json
+++ b/build.act.json
@@ -2,13 +2,13 @@
     "dependencies": {
         "netconf": {
             "repo_url": "https://github.com/orchestron-orchestrator/netconf.git",
-            "url": "https://github.com/orchestron-orchestrator/netconf/archive/d2ed2caa95ebc8d8d83696e4631263e5e5854f8a.zip",
-            "hash": "12200330c0cc2023fe4e72fd7fc982c419041658b475225b02f2cf894920c7739322"
+            "url": "https://github.com/orchestron-orchestrator/netconf/archive/ed86f9e4821e8e1f3c0962b1390446cbcf10915a.zip",
+            "hash": "1220186ef708781f79f31f8eaa38086b2129e1bc0c84c9260d98252702ff0cd6ac6b"
         },
         "yang": {
             "repo_url": "https://github.com/orchestron-orchestrator/acton-yang.git",
-            "url": "https://github.com/orchestron-orchestrator/acton-yang/archive/70600dfd3a266850dc9ded12b27fd296517f3565.zip",
-            "hash": "1220b8a977610c19e16f4369f6631f087b917b5a16b4d99e96f564f2e195b586cae4"
+            "url": "https://github.com/orchestron-orchestrator/acton-yang/archive/6ae98ebfaa4827cbf456af3816a1952fdaeca55c.zip",
+            "hash": "1220ba2758d7a45dc1593f0c4cdb0aee8b7dee746cc6ff66dd42aded98df5a3f3f29"
         }
     },
     "zig_dependencies": {}

--- a/gen_dmc/build.act.json
+++ b/gen_dmc/build.act.json
@@ -2,8 +2,8 @@
     "dependencies": {
         "yang": {
             "repo_url": "https://github.com/orchestron-orchestrator/acton-yang.git",
-            "url": "https://github.com/orchestron-orchestrator/acton-yang/archive/70600dfd3a266850dc9ded12b27fd296517f3565.zip",
-            "hash": "1220b8a977610c19e16f4369f6631f087b917b5a16b4d99e96f564f2e195b586cae4"
+            "url": "https://github.com/orchestron-orchestrator/acton-yang/archive/6ae98ebfaa4827cbf456af3816a1952fdaeca55c.zip",
+            "hash": "1220ba2758d7a45dc1593f0c4cdb0aee8b7dee746cc6ff66dd42aded98df5a3f3f29"
         }
     },
     "zig_dependencies": {}

--- a/src/orchestron/build.act
+++ b/src/orchestron/build.act
@@ -35,8 +35,8 @@ class SysSpec(object):
         return self.compile().gen_app(fc, output_dir)
 
     def compile(self):
-        compiled_layers = [CompiledLayer(yang.compile(l.models), l.name) for l in self.layers]
-        compiled_dev_types = [CompiledDeviceType(yang.compile(dev_type.models), dev_type.name) for dev_type in self.device_types]
+        compiled_layers = [CompiledLayer(yang.compile(l.models), l.models, l.name) for l in self.layers]
+        compiled_dev_types = [CompiledDeviceType(yang.compile(dev_type.models), dev_type.models, dev_type.name) for dev_type in self.device_types]
         return CompiledSysSpec(self.name, compiled_layers, compiled_dev_types)
 
 class CompiledSysSpec(object):
@@ -48,7 +48,7 @@ class CompiledSysSpec(object):
     layers: list[CompiledLayer]
     def __init__(self, name: str, layers: list[CompiledLayer], device_types: list[CompiledDeviceType]):
         self.name = name
-        self.layers = layers + [CompiledLayer(yang.compile([oyang.device]))]
+        self.layers = layers + [CompiledLayer(yang.compile([oyang.device]), [oyang.device])]
         self.dev_types = {dev_type.name: dev_type for dev_type in device_types}
 
     def gen_app(self, fc: file.FileCap, output_dir: str):
@@ -76,8 +76,7 @@ class CompiledSysSpec(object):
     #        elif idx == len(layers) - 1:
     #            name = "src/y_rfs.act"
 
-            layer_adata = layer.root.prdaclass()
-            if _maybe_write_file(fc, name, layer_adata):
+            if _maybe_write_file(fc, name, layer.print()):
                 print(f"+ Layer {idx} adata changed")
             else:
                 print(f"+ Layer {idx} adata unchanged")
@@ -108,7 +107,7 @@ class CompiledSysSpec(object):
             tttsrc_getlayers += f"    layer{idx} = ttt.Layer('{lname}', {self.name}.layers.t_{idx}.get_ttt({lowerlayer}, dev_registry, log_handler), {lowerlayer})\n"
 
             loose_name = f"{output_dir}/{self.name}/layers/y_{idx}_loose.act"
-            if _maybe_write_file(fc, loose_name, layer.root.prdaclass(loose=True)):
+            if _maybe_write_file(fc, loose_name, layer.print(loose=True)):
                 print(f"+ Layer {idx} loose adata changed")
             else:
                 print(f"+ Layer {idx} loose adata unchanged")
@@ -117,9 +116,8 @@ class CompiledSysSpec(object):
         syssrc_devtypes = ""
         for dev_type in self.dev_types.values():
             print(f"Generating device type {dev_type.name}")
-            dev_tree_adata = dev_type.root.prdaclass(gen_json=False, loose=True)
             name = f"{output_dir}/{self.name}/devices/{dev_type.name}.act"
-            if _maybe_write_file(fc, name, dev_tree_adata):
+            if _maybe_write_file(fc, name, dev_type.print(loose=True, gen_json=False)):
                 print(f"+ Device type {dev_type.name} adata changed")
             else:
                 print(f"+ Device type {dev_type.name} adata unchanged")
@@ -226,15 +224,28 @@ class Layer(object):
 
 class _CompiledLayerBase(object):
     root: yang.schema.DRoot
+    src: list[str]
+
+    def print(self, loose=False, gen_json=True):
+        """Print the Acton (adata) classes for the layer
+
+        This prints the entire contents of the Acton module representing a
+        single layer in the application. The module includes generated adata
+        classes, XML and JSON deserializers and the schema info. The schema is
+        used by the XML and JSON schema-driven deserializers.
+        """
+        return self.root.prdaclass(schema_yang=self.src, loose=loose, gen_json=gen_json)
 
 class CompiledLayer(_CompiledLayerBase):
-    def __init__(self, root: yang.schema.DRoot, name: ?str=None):
+    def __init__(self, root: yang.schema.DRoot, src: list[str], name: ?str=None):
         self.root = root
+        self.src = src
         self.name = name
 
 class CompiledDeviceType(_CompiledLayerBase):
-    def __init__(self, root: yang.schema.DRoot, name: str):
+    def __init__(self, root: yang.schema.DRoot, src: list[str], name: str):
         self.root = root
+        self.src = src
         self.name = name
 
 def apply_schema_transforms_to_dir(fc: file.FileCap, dir: str, transforms: list[SchemaTransformChain]=[]) -> None:

--- a/src/orchestron/device.act
+++ b/src/orchestron/device.act
@@ -656,6 +656,7 @@ actor NetconfDriver(dev: DeviceMgr, schema: DeviceSchema, init_dmc: DeviceMetaCo
             conn_state = CONNECTING
             _log.debug(f"Setting up NETCONF client... {address} {port} {username} {password}")
             c = netconf.Client(wcap, address, port, username, password,
+                               skip_host_key_check=True,
                                on_connect=_on_connect,
                                on_notif=_on_notif,
                                log_handler=log_handler)

--- a/src/orchestron/device_meta_config.act
+++ b/src/orchestron/device_meta_config.act
@@ -1,8 +1,10 @@
 import base64
 import json
 import xml
+import yang
 import yang.adata
 import yang.gdata
+import yang.gen3
 from yang.identity import complete_and_validate_identityref
 from yang.identityref import Identityref, PartialIdentityref
 from yang.schema import DIdentity


### PR DESCRIPTION
- netconf: skip_host_key_check defaults to False
- acton-yang: schema-driven (gen3) parsers

We now Include YANG source in generated layer modules. This will allow us to use the schema-as-data gen3 parsers, sometimes in future.