### PR TITLE
Connect when initializing NetconfAdapter

### DIFF
--- a/src/orchestron/device.act
+++ b/src/orchestron/device.act
@@ -1073,6 +1073,8 @@ actor NetconfDriver(dev: DeviceMgr, schema: DeviceSchema, init_dmc: DeviceMetaCo
     def get_config():
         return running_conf
 
+    _connect(dmc)
+
 
 def hash_modset(modset: dict[str, ModCap]) -> str:
     # TODO: use a better hash function


### PR DESCRIPTION
Now that we are injecting the initial DMC, it means the first set_dmc call we get will have the same config as the initial DMC and since I just fixed the comparison logic, we ended up never connecting.. until now!