### PR TITLE
[CI] Add OpenSSF Scorecard workflow and badge to README

### DIFF
--- a/.github/workflows/openssf-scorecard.yml
+++ b/.github/workflows/openssf-scorecard.yml
@@ -1,0 +1,73 @@
+# This workflow generates an OpenSSF scorecard report, and uploads the report
+# (i) as an artifact to the actions tab, and (ii) to GitHub's code scanning dashboard
+# Note: This workflow file is slightly adpated version of
+# https://github.com/ossf/scorecard/blob/99b664e5d18f6774ef63dd1e7acb9f255c6285de/.github/workflows/scorecard-analysis.yml
+#
+# SPDX-FileCopyrightText: 2020 OpenSSF Scorecard Authors, 2024 Deutsche Telekom AG
+#
+# SPDX-License-Identifier: CC0-1.0
+
+name: OpenSSF Scorecard
+on:
+  push:
+    # Only the default branch is supported.
+    branches:
+      - main
+
+  pull_request:
+    branches:
+      - main
+      
+  schedule:
+    # Weekly on Saturdays.
+    - cron:  '30 1 * * 6'
+
+
+permissions:
+  contents: read
+
+
+jobs:
+  analysis:
+    name: OpenSSF Scorecard
+    runs-on: ubuntu-24.04
+    permissions:
+      # Needed for Code scanning upload
+      security-events: write
+      # Needed for GitHub OIDC token if publish_results is true
+      id-token: write
+ 
+    steps:
+      - name: "Checkout code"
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
+
+
+      - name: "Run analysis"
+        uses: ossf/scorecard-action@62b2cac7ed8198b15735ed49ab1e5cf35480ba46 # v2.4.0
+        with:
+          results_file: results.sarif
+          results_format: sarif
+          # Scorecard team runs a weekly scan of public GitHub repos,
+          # see https://github.com/ossf/scorecard#public-data.
+          # Setting `publish_results: true` helps us scale by leveraging your workflow to
+          # extract the results instead of relying on our own infrastructure to run scans.
+          publish_results: true
+
+      # Upload the results as artifacts (optional). Commenting out will disable
+      # uploads of run results in SARIF format to the repository Actions tab.
+      # https://docs.github.com/en/actions/advanced-guides/storing-workflow-data-as-artifacts
+      - name: "Upload artifact"
+        uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4.4.3
+        with:
+          name: SARIF file
+          path: results.sarif
+          retention-days: 5
+
+      # Upload the results to GitHub's code scanning dashboard (optional).
+      # Commenting out will disable upload of results to our repo's Code Scanning dashboard
+      - name: "Upload to code-scanning"
+        uses: github/codeql-action/upload-sarif@4f3212b61783c3c68e8309a0f18a699764811cda # v3.27.1
+        with:
+          sarif_file: results.sarif

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 </p>
 
 [![REUSE Compliance Check](https://github.com/orchestron-orchestrator/orchestron/actions/workflows/reuse-compliance.yml/badge.svg)](https://github.com/orchestron-orchestrator/orchestron/actions/workflows/reuse-compliance.yml)
+[![OpenSSF Scorecard Score](https://api.scorecard.dev/projects/github.com/orchestron-orchestrator/orchestron/badge)](https://scorecard.dev/viewer/?uri=github.com/orchestron-orchestrator/orchestron/badge)
 
 Orchestron is a platform for the development of robust network orchestration systems based on model-driven declarative transforms. It does the heavy lifting so you can focus on building automation that makes sense. With native support for streaming telemetry, Orchestron enables you to build reactive closed loop automation.
 


### PR DESCRIPTION
This `PR` adds the ``OpenSSF Scorecard`` workflow to the ``CI`` pipeline, and also adds its badge.

The ``Open Source Security Foundation (OpenSSF)`` recommends to use this scorecard to evaluate how well an [OSS software is doing](https://best.openssf.org/developers).
This ``PR`` is part of an effort that adds open source best practices to the repository, in this case on best practices in security.