### PR TITLE
Use new NETCONF error handling API

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ build: src/orchestron/device_meta_config.act
 
 .PHONY: build-ldep
 build-ldep: src/orchestron/device_meta_config.act
-	$(MAKE) build DEP_OVERRIDES="--dep yang=../acton-yang"
+	$(MAKE) build DEP_OVERRIDES="--dep yang=../acton-yang --dep netconf=../netconf"
 
 .PHONY: gen
 gen: src/orchestron/device_meta_config.act

--- a/build.act.json
+++ b/build.act.json
@@ -2,8 +2,8 @@
     "dependencies": {
         "netconf": {
             "repo_url": "https://github.com/orchestron-orchestrator/netconf.git",
-            "url": "https://github.com/orchestron-orchestrator/netconf/archive/e0b1bec5e37cdd6299340b57edcee1255e87b211.zip",
-            "hash": "1220bee6c05f68b81fc58e05010c4400ace1d8b698c2a88d72469d699cf82427fd35"
+            "url": "https://github.com/orchestron-orchestrator/netconf/archive/1f4868b43ca04083341b8e61c994f147be7d7568.zip",
+            "hash": "1220cb0b40e0a3b42778f94bc256b8054f72009619d7ffa79cdf0b2921bc4f6f05ba"
         },
         "yang": {
             "repo_url": "https://github.com/orchestron-orchestrator/acton-yang.git",

--- a/src/orchestron/device.act
+++ b/src/orchestron/device.act
@@ -888,10 +888,13 @@ actor NetconfDriver(dev: DeviceMgr, schema: DeviceSchema, init_dmc: DeviceMetaCo
                 _log.debug("Device.configure: fetching current config from running")
                 c.get_config(on_fetched, "running")
 
-        def on_fetched(c: netconf.Client, r: ?xml.Node):
-            _log.debug("Device.configure.on_fetched", {"r": r.encode() if r is not None else "None"})
-            if r is not None:
-                # TODO: inspect returned value for ok/errors
+        def on_fetched(c: netconf.Client, r: ?xml.Node, error: ?netconf.NetconfError):
+            _log.debug("Device.configure.on_fetched", {"r": r.encode() if r is not None else "None", "error": error})
+            if error is not None:
+                _log.error("Device.configure: error fetching config", {"error": error})
+                # TODO: should be a more specific (transient?) error
+                abort(Exception("Failed to fetch config: " + str(error.error_message)))
+            elif r is not None:
                 current = schema.from_xml(r.children[0])
                 if current is not None:
                     _log.debug("Device.configure: computing diff")
@@ -917,50 +920,38 @@ actor NetconfDriver(dev: DeviceMgr, schema: DeviceSchema, init_dmc: DeviceMetaCo
                 _log.error("Device.configure: device disconnected during get-config")
                 abort(NotConnectedError())
 
-        def on_edited(c: netconf.Client, r: ?xml.Node):
-            _log.debug("Device.configure.on_edited", {"r": r.encode() if r is not None else "None"})
-            if r is not None:
-                # TODO: inspect returned value for ok/errors
+        def on_edited(c: netconf.Client, error: ?netconf.NetconfError):
+            _log.debug("Device.configure.on_edited", {"error": error})
+            if error is not None:
+                _log.error("Device.configure: edit-config error", {"error": error})
+                abort(ConfigError("Failed to edit config: " + str(error.error_message), conf=new_conf, target_conf=new_conf))
+            else:
                 if target_datastore() == "candidate":
                     _log.debug("Device.configure: committing to candidate")
                     c.commit(on_committed)
                 else:
                     _log.debug("Device.configure: edit-config complete (writable-running)")
                     complete(c)
-            else:
-                _log.error("Device.configure: device disconnected during edit-config")
-                abort(NotConnectedError())
 
-        def on_committed(c: netconf.Client, r: ?xml.Node):
-            _log.debug("Device.configure.on_committed", {"r": r.encode() if r is not None else "None"})
-            if r is not None:
-                # Check for errors in commit response
-                has_error = False
+        def on_committed(c: netconf.Client, error: ?netconf.NetconfError):
+            _log.debug("Device.configure.on_committed", {"error": error})
+            if error is not None:
+                _log.error("Device.configure: commit error", {"error": error})
+                # Check error tag to determine type
                 error_tag = None
-                for child in r.children:
-                    if child.tag == "rpc-error":
-                        has_error = True
-                        _log.error("Device.configure: commit error", {"error": child.encode()})
-                        # Extract error-tag to determine the type of error
-                        for error_child in child.children:
-                            if error_child.tag == "error-tag":
-                                error_tag = error_child.text
-                                break
-                        break
+                rpc_error = error.rpc_error
+                if rpc_error is not None and len(rpc_error) > 0:
+                    error_tag = rpc_error[0].error_tag
 
-                if has_error:
-                    _log.debug("Device.configure: discarding changes after failed commit")
-                    # Check if the error is due to locked datastore
-                    if error_tag == "in-use":
-                        c.discard_changes(lambda c, r: abort(LockedError("Datastore is locked")))
-                    else:
-                        c.discard_changes(lambda c, r: abort(ConfigError("Commit failed", conf=new_conf, target_conf=new_conf)))
+                _log.debug("Device.configure: discarding changes after failed commit")
+                # Check if the error is due to locked datastore
+                if error_tag == "in-use":
+                    c.discard_changes(lambda c, e: abort(LockedError("Datastore is locked")))
                 else:
-                    _log.debug("Device.configure: commit successful")
-                    complete(c)
+                    c.discard_changes(lambda c, e: abort(ConfigError("Commit failed: " + str(error.error_message), conf=new_conf, target_conf=new_conf)))
             else:
-                _log.error("Device.configure: device disconnected during commit")
-                abort(NotConnectedError())
+                _log.debug("Device.configure: commit successful")
+                complete(c)
 
         def complete(c: netconf.Client):
             """Successfully complete the transaction"""
@@ -1021,7 +1012,7 @@ actor NetconfDriver(dev: DeviceMgr, schema: DeviceSchema, init_dmc: DeviceMetaCo
             # TODO: feels redundant to refetch whole config here from device,
             # running_conf should really be target_conf at this point - keeping this for now though
             if client is not None and error is None:
-                client.get_config(_on_get_config)
+                client.get_config(lambda c, r, e: _on_get_config(c, r, e, None))
 
         # Start the transaction by locking the datastore(s)
         # Lock running if it's writable (to prevent others from directly editing it)
@@ -1097,9 +1088,13 @@ actor NetconfDriver(dev: DeviceMgr, schema: DeviceSchema, init_dmc: DeviceMetaCo
     def is_nokia_srl():
         return "srl_nokia-aaa" in modset
 
-    def _on_get_config(c, r, cb: ?action(?yang.gdata.Node, ?Exception) -> None=None):
-        _log.debug("Device._on_get_config")
-        if r is not None:
+    def _on_get_config(c, r, error: ?netconf.NetconfError, cb: ?action(?yang.gdata.Node, ?Exception) -> None=None):
+        _log.debug("Device._on_get_config", {"error": error})
+        if error is not None:
+            _log.error("Device._on_get_config: error", {"error": error.error_message})
+            if cb is not None:
+                cb(None, ValueError("Failed to get config: " + str(error.error_message)))
+        elif r is not None:
             _log.debug("Device._on_get_config: r is not None")
             if r.tag == "rpc-reply" and len(r.children) == 1 and r.children[0].tag == "data":
                 _log.debug("Device._on_get_config", {"r": r.encode()})
@@ -1116,7 +1111,7 @@ actor NetconfDriver(dev: DeviceMgr, schema: DeviceSchema, init_dmc: DeviceMetaCo
     def fetch_config(done: ?action(?yang.gdata.Node, ?Exception) -> None) -> None:
         _log.debug("Device._fetch_config")
         if client is not None:
-            client.get_config(lambda c, r: _on_get_config(c, r, done))
+            client.get_config(lambda c, r, e: _on_get_config(c, r, e, done))
 
     def get_config():
         return running_conf

--- a/src/orchestron/test_device.act
+++ b/src/orchestron/test_device.act
@@ -139,7 +139,7 @@ actor _test_netconf_double_commit(t: testing.EnvT):
     without first establishing a new session.
     """
     log = logging.Logger(t.log_handler)
-    
+
     var adapter: ?orchestron.device.NetconfAdapter = None
     var first_config_sent = False
     var second_config_sent = False
@@ -190,7 +190,7 @@ actor _test_netconf_double_commit(t: testing.EnvT):
         t.success()
     else:
         log.info("Testing double commit issue with NETCONF")
-        
+
         # Create DeviceMgr and NetconfAdapter
         dev_types = {}
         dev = orchestron.device.DeviceMgr(dev_types, t.env.auth, "test-device", t.log_handler, on_reconf)
@@ -324,8 +324,10 @@ actor _test_netconf_adapter(t: testing.EnvT):
                 log.info("Getting current config to check banner state")
                 c.get_config(on_setup_get_config, datastore="running")
 
-        def on_setup_get_config(c: netconf.Client, r: ?xml.Node):
-            if r is not None:
+        def on_setup_get_config(c: netconf.Client, r: ?xml.Node, error: ?netconf.NetconfError):
+            if error is not None:
+                t.failure(error)
+            elif r is not None:
                 config_xml = r.encode()
                 # Extract current banner if it exists
                 if "<banner" in config_xml and "</banner>" in config_xml:
@@ -362,24 +364,13 @@ actor _test_netconf_adapter(t: testing.EnvT):
                 log.error("Failed to get initial config")
                 t.failure(ValueError("Failed to get initial config"))
 
-        def on_setup_edit_config(c: netconf.Client, r: ?xml.Node):
-            if r is not None:
-                # Check for errors
-                has_error = False
-                for child in r.children:
-                    if child.tag == "rpc-error":
-                        has_error = True
-                        log.error("Failed to reset config", {"error": child.encode()})
-
-                if not has_error:
-                    log.info("Configuration reset successful")
-                    c.close(on_setup_close)
-                else:
-                    log.error("Failed to reset configuration")
-                    t.failure(ValueError("Failed to reset configuration"))
+        def on_setup_edit_config(c: netconf.Client, error: ?netconf.NetconfError):
+            if error is not None:
+                log.error("Failed to reset config", {"error": error.error_message})
+                t.failure(error)
             else:
-                log.error("No response from edit-config")
-                t.failure(ValueError("No response from edit-config"))
+                log.info("Configuration reset successful")
+                c.close(on_setup_close)
 
         def on_setup_close():
             log.info("Setup complete, starting NetconfAdapter test")
@@ -455,8 +446,10 @@ actor _test_netconf_adapter(t: testing.EnvT):
                 # Get the running config
                 c.get_config(on_verify_get_config, datastore="running")
 
-        def on_verify_get_config(c: netconf.Client, r: ?xml.Node):
-            if r is not None:
+        def on_verify_get_config(c: netconf.Client, r: ?xml.Node, error: ?netconf.NetconfError):
+            if error is not None:
+                t.failure(error)
+            elif r is not None:
                 log.info("Retrieved device configuration for verification", {"conf": r.encode()})
                 config_xml = r.encode()
 


### PR DESCRIPTION
Update all callbacks signatures to now properly include the ?NetconfError parameter. Custom error parsing code has been replaced with the standardized error handling from the NETCONF client.

@plajjan PTAL at the error types returned in the `configure()` dance.