### PR TITLE
Proceed with transform.on_conf in RFSTransform

### DIFF
--- a/src/orchestron/ttt.act
+++ b/src/orchestron/ttt.act
@@ -1074,7 +1074,7 @@ class _RFSTransaction(_TransformTransactionBase):
         if self.running:
             output = self.output
             if output is not None:
-                if not (isinstance(output, gdata.Container) and not output.presence):
+                if not (isinstance(output, gdata.Container) and not output.presence and len(output.children) == 0):
                     self.function.on_conf(self.get(), self.memory)
 
 class DeviceInfo(object):


### PR DESCRIPTION
If the output of the RFS transform function is valid (non-empty container), then proceed to call on_conf in the transform actor.