### PR TITLE
Add DeviceMgr.rpc_xml

### DIFF
--- a/build.act.json
+++ b/build.act.json
@@ -7,8 +7,8 @@
         },
         "yang": {
             "repo_url": "https://github.com/orchestron-orchestrator/acton-yang.git",
-            "url": "https://github.com/orchestron-orchestrator/acton-yang/archive/a18921e846bf6052b56a4d0b6626b9695e0765d5.zip",
-            "hash": "1220510d7926862416ab97cb512a6ff728c0193065132db40b57f90eab440f77b0ee"
+            "url": "https://github.com/orchestron-orchestrator/acton-yang/archive/070f2fd42a6d7432f37381e4d0a5d4943289cecc.zip",
+            "hash": "12205ab967e96648639d3559d0b578000a5f702d3132a9f50489b82882e709a0a3fd"
         }
     },
     "zig_dependencies": {}

--- a/gen_dmc/build.act.json
+++ b/gen_dmc/build.act.json
@@ -2,8 +2,8 @@
     "dependencies": {
         "yang": {
             "repo_url": "https://github.com/orchestron-orchestrator/acton-yang.git",
-            "url": "https://github.com/orchestron-orchestrator/acton-yang/archive/a18921e846bf6052b56a4d0b6626b9695e0765d5.zip",
-            "hash": "1220510d7926862416ab97cb512a6ff728c0193065132db40b57f90eab440f77b0ee"
+            "url": "https://github.com/orchestron-orchestrator/acton-yang/archive/070f2fd42a6d7432f37381e4d0a5d4943289cecc.zip",
+            "hash": "12205ab967e96648639d3559d0b578000a5f702d3132a9f50489b82882e709a0a3fd"
         }
     },
     "zig_dependencies": {}

--- a/src/orchestron/device.act
+++ b/src/orchestron/device.act
@@ -477,6 +477,9 @@ actor DeviceMgr(dev_types: dict[str, DeviceType]={}, wcap: ?WorldCap=None, name:
     def get_schema():
         return schema
 
+    def rpc_xml(cb: action(?xml.Node, ?Exception) -> None, xml_rpc: xml.Node):
+        adapter.rpc_xml(cb, xml_rpc)
+
 
 class DeviceAdapter(object):
     """Abstract base class for Device Adapters
@@ -505,6 +508,8 @@ class DeviceAdapter(object):
 
     get_config: proc() -> ?yang.gdata.Node
 
+    rpc_xml: proc(cb: action(?xml.Node, ?Exception) -> None, xml_rpc: xml.Node) -> None
+
 
 class NoAdapter(DeviceAdapter):
     def __init__(self, dev: DeviceMgr, schema: DeviceSchema, log_handler, wcap):
@@ -531,6 +536,9 @@ class NoAdapter(DeviceAdapter):
         pass
 
     def get_config(self):
+        pass
+
+    def rpc_xml(self, cb: action(?xml.Node, ?Exception) -> None, xml_rpc: xml.Node) -> None:
         pass
 
 
@@ -564,6 +572,9 @@ class MockAdapter(DeviceAdapter):
 
     def get_config(self):
         return self._driver.get_config()
+
+    def rpc_xml(self, cb: action(?xml.Node, ?Exception) -> None, xml_rpc: xml.Node) -> None:
+        return self._driver.rpc_xml(cb, xml_rpc)
 
 
 actor MockDriver(dev: DeviceMgr, schema: DeviceSchema, log_handler: logging.Handler, wcap: ?WorldCap):
@@ -639,6 +650,9 @@ actor MockDriver(dev: DeviceMgr, schema: DeviceSchema, log_handler: logging.Hand
     def get_config():
         return running_conf
 
+    def rpc_xml(cb: action(?xml.Node, ?Exception) -> None, xml_rpc: xml.Node) -> None:
+        cb(xml.Node("ok"), None)
+
 
 class NetconfAdapter(DeviceAdapter):
 
@@ -672,6 +686,9 @@ class NetconfAdapter(DeviceAdapter):
         """Close the connection to the device
         """
         self._driver.close(on_close)
+
+    def rpc_xml(self, cb: action(?xml.Node, ?Exception) -> None, xml_rpc: xml.Node) -> None:
+        return self._driver.rpc_xml(cb, xml_rpc)
 
 
 actor NetconfDriver(dev: DeviceMgr, schema: DeviceSchema, init_dmc: DeviceMetaConfig, log_handler: logging.Handler, wcap: ?WorldCap):
@@ -1116,7 +1133,31 @@ actor NetconfDriver(dev: DeviceMgr, schema: DeviceSchema, init_dmc: DeviceMetaCo
     def get_config():
         return running_conf
 
+    def rpc_xml(cb: action(?xml.Node, ?Exception) -> None, xml_rpc: xml.Node) -> None:
+        def rpc_reply(c, r: ?xml.Node, error: ?netconf.NetconfError):
+            _log.debug("Device.rpc_xml.rpc_reply", {"r": r, "error": error})
+            cb(r, error)
+
+        _log.debug("Device.rpc_xml", {"xml_rpc": xml_rpc})
+        if client is not None:
+            client.rpc(xml_rpc, rpc_reply)
+
     _connect(dmc)
+
+
+class DeviceTreeProvider(yang.gdata.TreeProvider):
+    dev: DeviceMgr
+
+    def __init__(self, dev: DeviceMgr):
+        self.dev = dev
+
+    # TODO: remove this, standardize on gdata
+    proc def rpc_xml(self, cb: action(?xml.Node, ?Exception) -> None, xml_rpc: xml.Node):
+        self.dev.rpc_xml(cb, xml_rpc)
+
+    proc def rpc(self, cb: action(?yang.gdata.Node, ?Exception) -> None, rpc_input: yang.gdata.Node):
+        pass
+        # self.dev.rpc(cb, rpc_input)
 
 
 def hash_modset(modset: dict[str, ModCap]) -> str:


### PR DESCRIPTION
Ideally this would be DeviceMgr.rpc, but until we have the schema-driven parsers up and running with schemas fetched from the device, we just work with XMLs.