### PR TITLE
Add txid, config queue with review + approval, config log and a web UI

### DIFF
--- a/gen_dmc/src/oyang.act
+++ b/gen_dmc/src/oyang.act
@@ -86,6 +86,12 @@ rfs = r"""module orchestron-rfs {
       }
     }
 
+    leaf approval-required {
+      description "Require approval of each individual configuration change to this device";
+      type boolean;
+      default "false";
+    }
+
     container mock {
       leaf-list preset {
         type enumeration {

--- a/gen_dmc/src/oyang.act
+++ b/gen_dmc/src/oyang.act
@@ -116,11 +116,16 @@ rfs = r"""module orchestron-rfs {
         }
       }
     }
+
     container debug {
       leaf connection {
         type boolean;
         default "false";
       }
+    }
+
+    container state {
+      config false;
     }
   }
 

--- a/src/orchestron/device.act
+++ b/src/orchestron/device.act
@@ -275,20 +275,20 @@ actor DeviceMgr(dev_types: dict[str, DeviceType]={}, wcap: ?WorldCap=None, name:
     # i.e. target_conf.
     var target_conf: ?yang.gdata.Node = None
 
-    # current_txids are the ids of the transactions that are currently
+    # current_tids are the ids of the transactions that are currently
     # in-transit, which also means that we can determine if we have an
-    # outstanding transaction by checking len(current_txids) > 0.
-    var current_txids = set()
+    # outstanding transaction by checking len(current_tids) > 0.
+    var current_tids = set()
     # reconf is a special kind of operation, where an initial transaction
     # intends to configure devices but those devices have no known modset and
     # thus the RFS transforms cannot produce device configuration. It is still
     # valid to await completion of such a transaction and the intent means "we
     # want to await that the RFS transform intended (future) output has reached
     # the device". Those transactions register for the future reconf and we keep
-    # track of those in reconf_txids. The next successfuly sent configuration to
-    # the device will call the reconf_txids on completion so they in turn can
+    # track of those in reconf_tids. The next successfuly sent configuration to
+    # the device will call the reconf_tids on completion so they in turn can
     # notify their clients that the configuration now has reached the devices.
-    var reconf_txids = set()
+    var reconf_tids = set()
 
 
     # The last successfully sent diff. We use this to detect and break infinite
@@ -352,8 +352,8 @@ actor DeviceMgr(dev_types: dict[str, DeviceType]={}, wcap: ?WorldCap=None, name:
         configure method with the current target configuration.
         """
         # Check if we already have a transaction in progress
-        if len(current_txids) > 0:
-            _log.debug("DeviceMgr._send_config: there is currently an outstanding configuration, skipping", {"txids": current_txids})
+        if len(current_tids) > 0:
+            _log.debug("DeviceMgr._send_config: there is currently an outstanding configuration, skipping", {"current_tids": current_tids})
             return
 
         last_confq = None
@@ -370,7 +370,7 @@ actor DeviceMgr(dev_types: dict[str, DeviceType]={}, wcap: ?WorldCap=None, name:
             if error is not None:
                 if isinstance(error, NotConnectedError):
                     _log.debug("Device not connected, no need to retry - waiting for reconnect")
-                    current_txids = set()
+                    current_tids = set()
 
                 elif isinstance(error, PermanentError):
                     _log.debug("Permanent error pushing configuration to device", {"error": error})
@@ -378,7 +378,7 @@ actor DeviceMgr(dev_types: dict[str, DeviceType]={}, wcap: ?WorldCap=None, name:
                         _log.debug("Configuration failed due to bad config", {"error": error})
 
                     # Got a permanent error, giving up
-                    for tid in current_txids:
+                    for tid in current_tids:
                         cb = callbacks.get(tid)
                         if cb is not None:
                             cb(error)
@@ -386,13 +386,13 @@ actor DeviceMgr(dev_types: dict[str, DeviceType]={}, wcap: ?WorldCap=None, name:
 
                     # TODO: uh, what else? we need to bubble up this sort of error state to an operator somehow
 
-                    if len(confq) > len(current_txids):
+                    if len(confq) > len(current_tids):
                         _log.debug("New intended configuration available, retrying with latest config")
-                        current_txids = set()
+                        current_tids = set()
                         _send_config()
                     else:
                         _log.debug("No new intended configuration available, no point in retrying with same conf")
-                        current_txids = set()
+                        current_tids = set()
 
                 elif isinstance(error, TransientError):
                     _log.debug("Transient error", {"error": error})
@@ -400,42 +400,42 @@ actor DeviceMgr(dev_types: dict[str, DeviceType]={}, wcap: ?WorldCap=None, name:
                         _log.debug("DeviceAdapter busy, ignoring this error as adapter will trigger us once it is done with current operation")
                         return
 
-                    if len(confq) > len(current_txids):
+                    if len(confq) > len(current_tids):
                         _log.debug("New intended configuration available, retrying with latest config")
-                        current_txids = set()
+                        current_tids = set()
                         _send_config()
                     else:
                         retry_in = 1
                         _log.debug("No new intended configuration available. Scheduling retry of current config", {"retry_in": retry_in})
-                        current_txids = set()
+                        current_tids = set()
                         after retry_in: _send_config()
 
                 else:
                     _log.debug("Unhandled error", {"error": error})
                     # Uh, this is indicative of programmer error and we should fix it, but let's do naive retry as well
-                    current_txids = set()
+                    current_tids = set()
                     after 1: _send_config()
 
             else:
-                _log.debug("Configuration successfully applied on device, calling callbacks...", {"txids": current_txids})
+                _log.debug("Configuration successfully applied on device, calling callbacks...", {"current_tids": current_tids})
                 target_conf = send_conf
-                # Update running_conf with the result from the device (which has the new txid)
+                # Update running_conf with the result from the device (which has the new devicetxid)
                 if resulting_config is not None:
-                    _log.debug("Updating running_conf with new txid", {"txid": resulting_config.txid})
+                    _log.debug("Updating running_conf with new device txid", {"device_txid": resulting_config.txid})
                     running_conf = resulting_config
                 else:
                     _log.warning("No resulting_config returned from adapter, using target_conf")
                     running_conf = target_conf
 
                 last_sent_diff = new_diff
-                for tid in current_txids:
+                for tid in current_tids:
                     cb = callbacks.get(tid)
                     if cb is not None:
                         cb(True)
                         del callbacks[tid]
-                    reconf_txids.discard(tid)
+                    reconf_tids.discard(tid)
                     del confq[tid]
-                current_txids = set()
+                current_tids = set()
                 if len(confq) > 0:
                     _log.debug("Configuration changed during in-progress transaction, running again...")
                     _send_config()
@@ -450,9 +450,9 @@ actor DeviceMgr(dev_types: dict[str, DeviceType]={}, wcap: ?WorldCap=None, name:
                         _log.info("Reconciliation loop detected, target diff is same as last diff sent, stopping", {"diff": config_diff})
                         return
                 # Actually send the configuration
-                current_txids.update(confq.keys())
-                current_txids.update(reconf_txids)
-                _log.debug("DeviceMgr._send_config: sending intended target configuration", {"txids": current_txids, "diff": config_diff})
+                current_tids.update(confq.keys())
+                current_tids.update(reconf_tids)
+                _log.debug("DeviceMgr._send_config: sending intended target configuration", {"current_tids": current_tids, "diff": config_diff})
                 adapter.configure(lambda e, c: on_configured(e, c, config_diff, send_conf, running_conf), config_diff, send_conf, running_conf)
             else:
                 _log.debug("DeviceMgr.configure: no diff between running and target config, nothing to do", {"pending_tids": confq.keys()})
@@ -478,7 +478,7 @@ actor DeviceMgr(dev_types: dict[str, DeviceType]={}, wcap: ?WorldCap=None, name:
             _send_config()
         elif new_conf is None and conf_modset_id is None:
             _log.debug("DeviceMgr.configure: transaction registered intent to configure but awaiting reconf", {"tid": tid})
-            reconf_txids.add(tid)
+            reconf_tids.add(tid)
         else:
             _log.debug("DeviceMgr.configure: invalid input", {"conf_modset_id": str(conf_modset_id), "new_conf": truncate_conf(new_conf), "tid": tid})
 
@@ -528,7 +528,7 @@ actor DeviceMgr(dev_types: dict[str, DeviceType]={}, wcap: ?WorldCap=None, name:
         adapter.fetch_config(on_fetch_config_done)
 
     def wait_complete(tid: str, done: action(value) -> None):
-        if tid not in current_txids | set(confq.keys()) | reconf_txids:
+        if tid not in current_tids | set(confq.keys()) | reconf_tids:
             _log.debug("DeviceMgr.wait_complete: transaction id not found, calling done", {"tid": tid})
             done(True) # Assume tid is very old and has already completed, thus respond immediately
         else:
@@ -576,7 +576,7 @@ class DeviceAdapter(object):
     ## :param done: callback to call when the configuration is done
     ## :param new_diff: the diff to apply (computed by DeviceMgr)
     ## :param new_conf: the new configuration to apply
-    ## :param running_conf: the current running configuration (with txid)
+    ## :param running_conf: the current running configuration (with device txid)
     configure: proc(done: action(?Exception, ?yang.gdata.Node) -> None, new_diff: yang.gdata.Node, new_conf: yang.gdata.Node, running_conf: ?yang.gdata.Node) -> None
 
     get_capabilities: proc() -> list[str]

--- a/src/orchestron/device.act
+++ b/src/orchestron/device.act
@@ -277,8 +277,6 @@ actor DeviceMgr(dev_types: dict[str, DeviceType]={}, wcap: ?WorldCap=None, name:
     # loops in the device config reconciliation loop
     var last_sent_diff: ?yang.gdata.Node = None
 
-    var reconfigure_id = 0
-
     # TTT transactions can optionally request, through wait_complete(tid, cb), to
     # wait until configuration has been committed to the device. We keep track
     # of those callbacks keyed by tid.
@@ -460,30 +458,6 @@ actor DeviceMgr(dev_types: dict[str, DeviceType]={}, wcap: ?WorldCap=None, name:
             _log.debug("DeviceMgr.configure: transaction registered intent to configure but awaiting reconf", {"tid": tid})
         else:
             _log.debug("DeviceMgr.configure: invalid input", {"conf_modset_id": str(conf_modset_id), "new_conf": truncate_conf(new_conf), "tid": tid})
-
-    def reconfigure(cb: ?action(?Exception) -> None):
-        """Reconfigure the device with the current target configuration
-
-        This can be called in order to ensure that the device is configured
-        in accordance with the current target configuration. While configuration
-        changes from within Orchestron naturally trigger configuration of the
-        device, it is possible that the device drifts out of sync, for example
-        due to manual changes on the device. Calling reconfigure() will push
-        the current target configuration to the device again.
-        """
-        def cb_wrapper(result: value):
-            if cb is not None:
-                if isinstance(result, Exception):
-                    cb(result)
-                else:
-                    cb(None)
-
-        reconfigure_id += 1
-        new_tid = "reconfigure-{reconfigure_id}"
-        pending_txids.add(new_tid)
-        _send_config()
-        if cb is not None:
-            wait_complete(new_tid, cb_wrapper)
 
     def resync():
         """Ensure our view of the device running configuration is in sync with the real device

--- a/src/orchestron/device.act
+++ b/src/orchestron/device.act
@@ -665,8 +665,18 @@ actor DeviceMgr(dev_types: dict[str, DeviceType]={}, wcap: ?WorldCap=None, name:
                         sync_diff = gdata_diff(running_conf, new_conf)
                         conf_log.append(LogItem("Fetched configuration from device", sync_diff, None))
                         running_conf = new_conf
-                        _log.debug("DeviceMgr._on_update_config: got new running config, reconfiguring device", {"new_txid": new_txid})
-                        _send_config()
+
+                        if dmc.approval_required and target_conf is not None:
+                            _log.debug("DeviceMgr.wait_complete: device requires approval, adding new config item to queue")
+                            conf_item = ConfigItem("resync", target_conf, modset_id)
+                            new_confq = {conf_item.tid: conf_item}
+                            for d, c in confq.items():
+                                new_confq[d] = c
+                            confq = new_confq
+                            _update_approval_state()
+                        else:
+                            _log.debug("DeviceMgr._on_update_config: got new running config, reconfiguring device", {"new_txid": new_txid})
+                            _send_config()
                     else:
                         _log.debug("DeviceMgr._on_update_config: got same config but with differing txid", {"new_txid": new_txid, "old_txid": running_conf_txid})
 

--- a/src/orchestron/device.act
+++ b/src/orchestron/device.act
@@ -209,6 +209,12 @@ def truncate_conf(conf: ?yang.gdata.Node) -> str:
         return sc
     return r"{}"
 
+class ConfigItem():
+    def __init__(self, tid: str, conf: yang.gdata.Node, modset_id: ?str):
+        self.tid = tid
+        self.conf = conf
+        self.modset_id = modset_id
+
 actor DeviceMgr(dev_types: dict[str, DeviceType]={}, wcap: ?WorldCap=None, name: str, log_handler: logging.Handler, on_reconf: action(str) -> None):
     """Device Manager manages a device and represents that device, as an
     abstract device, in the system. Platform specific handling is implemented in
@@ -224,11 +230,10 @@ actor DeviceMgr(dev_types: dict[str, DeviceType]={}, wcap: ?WorldCap=None, name:
     the wait_complete(tid). The device configuration interaction is serial,
     which means that we are either idling or have configuration in-transit to
     the device. If new configuration is received from TTT while we have
-    configuration in-transit to the device, the new configuration is queued up
-    and the associated transactions added to pending_txids. Once acknowledgement
-    is received from the device, and thus the in-transit commit has concluded,
-    the pending transactions, represented by target_conf, can be pushed to the
-    device.
+    configuration in-transit to the device, the new configuration and their
+    associated tid is queued up in confq. Once acknowledgement is received from
+    the device, and thus the in-transit commit has concluded, the pending
+    configurations in confq, can be pushed to the device.
 
     The device interaction is entirely asynchronous.
     """
@@ -255,15 +260,17 @@ actor DeviceMgr(dev_types: dict[str, DeviceType]={}, wcap: ?WorldCap=None, name:
     var modset: dict[str, ModCap] = {}
     var modset_id: ?str = None
 
+
+    # New configuration received from the transaction engine via the
+    # DeviceMgr.configure() method are stored in a configuration queue, which
+    # uses ConfigItem to track the configuration including the associated tid
+    # and modset_id. Any new configuration is appended and we consume the queue
+    # when sending configuration to the device.
+    var confq: dict[str, ConfigItem] = {}
     # current_txids are the ids of the transactions that are currently
     # in-transit, which also means that we can determine if we have an
     # outstanding transaction by checking len(current_txids) > 0.
     var current_txids = set()
-    # pending_txids are the ids of the transactions that are pending, which
-    # means these transactions arrived while we already had configuration
-    # in-transit to the device. When len(pending_txids) > 0, we need to
-    # send the latest configuration after the current transaction is done.
-    var pending_txids = set()
     var reconf_txids = set()
     # Note how target_conf always only reflects the very latest configuration
     # that we received from the TTT transaction engine. When the device is ready
@@ -359,7 +366,7 @@ actor DeviceMgr(dev_types: dict[str, DeviceType]={}, wcap: ?WorldCap=None, name:
 
                     # TODO: uh, what else? we need to bubble up this sort of error state to an operator somehow
 
-                    if len(pending_txids) > len(current_txids):
+                    if len(confq) > len(current_txids):
                         _log.debug("New intended configuration available, retrying with latest config")
                         current_txids = set()
                         _send_config()
@@ -373,7 +380,7 @@ actor DeviceMgr(dev_types: dict[str, DeviceType]={}, wcap: ?WorldCap=None, name:
                         _log.debug("DeviceAdapter busy, ignoring this error as adapter will trigger us once it is done with current operation")
                         return
 
-                    if len(pending_txids) > len(current_txids):
+                    if len(confq) > len(current_txids):
                         _log.debug("New intended configuration available, retrying with latest config")
                         current_txids = set()
                         _send_config()
@@ -405,10 +412,10 @@ actor DeviceMgr(dev_types: dict[str, DeviceType]={}, wcap: ?WorldCap=None, name:
                     if cb is not None:
                         cb(True)
                         del callbacks[tid]
-                    pending_txids.discard(tid)
                     reconf_txids.discard(tid)
+                    del confq[tid]
                 current_txids = set()
-                if len(pending_txids) > 0:
+                if len(confq) > 0:
                     _log.debug("Configuration changed during in-progress transaction, running again...")
                     _send_config()
 
@@ -416,6 +423,9 @@ actor DeviceMgr(dev_types: dict[str, DeviceType]={}, wcap: ?WorldCap=None, name:
         if len(current_txids) > 0:
             _log.debug("DeviceMgr._send_config: there is currently an outstanding configuration, skipping", {"txids": current_txids})
             return
+
+        for id, ci in confq.items():
+            target_conf = ci.conf
 
         # Check if there is an actual diff right now
         if running_conf is not None and target_conf is not None:
@@ -427,18 +437,18 @@ actor DeviceMgr(dev_types: dict[str, DeviceType]={}, wcap: ?WorldCap=None, name:
                         _log.info("Reconciliation loop detected, target diff is same as last diff sent, stopping", {"diff": config_diff})
                         return
                 # Actually send the configuration
-                current_txids.update(pending_txids)
+                current_txids.update(confq.keys())
                 current_txids.update(reconf_txids)
                 _log.debug("DeviceMgr._send_config: sending intended target configuration", {"txids": current_txids, "diff": config_diff})
                 adapter.configure(lambda e, c: on_configured(e, c, config_diff, target_conf, running_conf), config_diff, target_conf, running_conf)
             else:
-                _log.debug("DeviceMgr.configure: no diff between running and target config, nothing to do", {"txids": pending_txids})
-                for tid in pending_txids:
+                _log.debug("DeviceMgr.configure: no diff between running and target config, nothing to do", {"pending_tids": confq.keys()})
+                for tid in confq.keys():
                     cb = callbacks.get(tid)
                     if cb is not None:
                         cb(True)
                         del callbacks[tid]
-                pending_txids = set()
+                confq = {}
         else:
             if running_conf is None:
                 _log.debug("No running config, cannot compute diff")
@@ -451,8 +461,7 @@ actor DeviceMgr(dev_types: dict[str, DeviceType]={}, wcap: ?WorldCap=None, name:
                 _log.debug("DeviceMgr.configure: modset_id mismatch, ignoring configuration", {"conf_modset_id": str(conf_modset_id), "modset_id": str(modset_id)})
                 return
             _log.debug("DeviceMgr.configure: received new intended configuration", {"tid": tid, "new_conf": truncate_conf(new_conf)})
-            pending_txids.add(tid)
-            target_conf = new_conf
+            confq[tid] = ConfigItem(tid, new_conf, modset_id)
             _send_config()
         elif new_conf is None and conf_modset_id is None:
             _log.debug("DeviceMgr.configure: transaction registered intent to configure but awaiting reconf", {"tid": tid})
@@ -505,8 +514,8 @@ actor DeviceMgr(dev_types: dict[str, DeviceType]={}, wcap: ?WorldCap=None, name:
         _log.debug("DeviceMgr.resync: starting resync", {"local_device_txid": running_conf.txid if running_conf is not None else None})
         adapter.fetch_config(on_fetch_config_done)
 
-    def wait_complete(tid: str, done: action(value)->None):
-        if tid not in current_txids | pending_txids | reconf_txids:
+    def wait_complete(tid: str, done: action(value) -> None):
+        if tid not in current_txids | set(confq.keys()) | reconf_txids:
             _log.debug("DeviceMgr.wait_complete: transaction id not found, calling done", {"tid": tid})
             done(True) # Assume tid is very old and has already completed, thus respond immediately
         else:

--- a/src/orchestron/device.act
+++ b/src/orchestron/device.act
@@ -3,6 +3,7 @@ import hash.wyhash as wyhash
 import json
 import logging
 import testing
+import time
 import xml
 
 import yang
@@ -245,6 +246,12 @@ class ConfigItem(object):
         self.modset_id = modset_id
         self.approved = None
 
+class LogItem():
+    def __init__(self, event: str, conf_diff: ?yang.gdata.Node, modset_id: ?str):
+        self.ts = time.now()
+        self.event = event
+        self.conf_diff = conf_diff
+
 actor DeviceMgr(dev_types: dict[str, DeviceType]={}, wcap: ?WorldCap=None, name: str, log_handler: logging.Handler, on_reconf: action(str) -> None, registry: ?DeviceRegistry=None):
     """Device Manager manages a device and represents that device, as an
     abstract device, in the system. Platform specific handling is implemented in
@@ -334,6 +341,7 @@ actor DeviceMgr(dev_types: dict[str, DeviceType]={}, wcap: ?WorldCap=None, name:
     # When we transition this we also register and / unregister with
     # DeviceRegistry through _update_approval_state()
     var needs_approval = False
+    var conf_log: list[LogItem] = []
 
     def _update_approval_state():
         if not dmc.approval_required:
@@ -549,6 +557,10 @@ actor DeviceMgr(dev_types: dict[str, DeviceType]={}, wcap: ?WorldCap=None, name:
                 # device's running to this new resulting config.
                 running_conf = resulting_config
 
+                conf_log.append(LogItem("sent", new_diff, None))
+                for _ in range(max([0, len(conf_log)-20])):
+                    del conf_log[0]
+
                 last_sent_diff = new_diff
                 for tid in current_tids:
                     cb = callbacks.get(tid)
@@ -644,6 +656,14 @@ actor DeviceMgr(dev_types: dict[str, DeviceType]={}, wcap: ?WorldCap=None, name:
 
                 if txid_updated:
                     if running_conf != new_conf:
+                        # TODO: yang.gdata.diff doesn't handle None as first argument, it trivially could & should
+                        def gdata_diff(a: ?yang.gdata.Node, b: yang.gdata.Node) -> ?yang.gdata.Node:
+                            if a is not None:
+                                return yang.gdata.diff(a, b)
+                            else:
+                                return b
+                        sync_diff = gdata_diff(running_conf, new_conf)
+                        conf_log.append(LogItem("Fetched configuration from device", sync_diff, None))
                         running_conf = new_conf
                         _log.debug("DeviceMgr._on_update_config: got new running config, reconfiguring device", {"new_txid": new_txid})
                         _send_config()
@@ -752,6 +772,9 @@ actor DeviceMgr(dev_types: dict[str, DeviceType]={}, wcap: ?WorldCap=None, name:
         if dmc.approval_required:
             return confq
         return {}
+
+    def get_conf_log():
+        return conf_log
 
 
 

--- a/src/orchestron/device.act
+++ b/src/orchestron/device.act
@@ -183,6 +183,8 @@ actor DeviceRegistry(dev_types: dict[str, DeviceType]={}, wcap: ?WorldCap=None, 
     """
     var devices = {}
 
+    var devices_needing_approval = {}
+
     action def _dummy_reconf(name: str):
         # Dummy reconf callback, used to avoid None
         pass
@@ -191,12 +193,37 @@ actor DeviceRegistry(dev_types: dict[str, DeviceType]={}, wcap: ?WorldCap=None, 
 
     def get(name: str) -> DeviceMgr:
         if name not in devices:
-            devices[name] = DeviceMgr(dev_types, wcap, name, log_handler, reconf_cb)
+            devices[name] = DeviceMgr(dev_types, wcap, name, log_handler, reconf_cb, self)
         dev = devices[name]
         return dev
 
+    def list():
+        return devices.keys()
+
     def on_reconf(on_reconf: action(str) -> None):
         reconf_cb = on_reconf
+
+    def register_needs_approval(name: str):
+        """Register that a device has pending configurations needing approval"""
+        dev = devices.get(name)
+        if dev is not None:
+            devices_needing_approval[name] = dev
+
+    def unregister_needs_approval(name: str):
+        """Unregister a device from needing approval
+
+        For example when all configs are approved or rejected or approval-required has been disabled
+        """
+        del devices_needing_approval[name]
+
+    def get_devices_needing_approval() -> dict[str, DeviceMgr]:
+        """Get devices that have pending approvals
+
+        Returns a dictionary mapping device name to DeviceMgr instance
+        for devices that currently need approval. Clients can then
+        directly query each DeviceMgr for details.
+        """
+        return devices_needing_approval
 
 def truncate_conf(conf: ?yang.gdata.Node) -> str:
     """Truncate the configuration to a short string for logging
@@ -209,13 +236,16 @@ def truncate_conf(conf: ?yang.gdata.Node) -> str:
         return sc
     return r"{}"
 
-class ConfigItem():
+class ConfigItem(object):
+    approved: ?bool
+
     def __init__(self, tid: str, conf: yang.gdata.Node, modset_id: ?str):
         self.tid = tid
         self.conf = conf
         self.modset_id = modset_id
+        self.approved = None
 
-actor DeviceMgr(dev_types: dict[str, DeviceType]={}, wcap: ?WorldCap=None, name: str, log_handler: logging.Handler, on_reconf: action(str) -> None):
+actor DeviceMgr(dev_types: dict[str, DeviceType]={}, wcap: ?WorldCap=None, name: str, log_handler: logging.Handler, on_reconf: action(str) -> None, registry: ?DeviceRegistry=None):
     """Device Manager manages a device and represents that device, as an
     abstract device, in the system. Platform specific handling is implemented in
     the DeviceAdapter, i.e.  in subclasses of DeviceAdapter, like NetconfDriver
@@ -300,6 +330,44 @@ actor DeviceMgr(dev_types: dict[str, DeviceType]={}, wcap: ?WorldCap=None, name:
     # of those callbacks keyed by tid.
     var callbacks: dict[str, action(value)->None] = {}
 
+    # Track whether we currently have config items in confq that need approval.
+    # When we transition this we also register and / unregister with
+    # DeviceRegistry through _update_approval_state()
+    var needs_approval = False
+
+    def _update_approval_state():
+        if not dmc.approval_required:
+            if needs_approval:
+                needs_approval = False
+                if registry is not None:
+                    registry.unregister_needs_approval(name)
+            return
+
+        # Check if there are any items in confq that need approval
+        has_pending_approval = False
+        for id, ci in confq.items():
+            if ci.approved is None:
+                has_pending_approval = True
+                break
+
+        # Update state and notify registry if state changed
+        if has_pending_approval and not needs_approval:
+            needs_approval = True
+            if registry is not None:
+                registry.register_needs_approval(name)
+        elif not has_pending_approval and needs_approval:
+            needs_approval = False
+            if registry is not None:
+                registry.unregister_needs_approval(name)
+
+    def get_device_txid() -> str:
+        """Get the device txid from our view of the device's running config"""
+        if running_conf is not None:
+            rc_txid = running_conf.txid
+            if rc_txid is not None:
+                return rc_txid
+        return ""
+
     def on_modset_update(new_modset: dict[str, ModCap]):
         _log.debug("Modset updated", {"new_modset": new_modset})
         on_reconf(name)
@@ -343,7 +411,19 @@ actor DeviceMgr(dev_types: dict[str, DeviceType]={}, wcap: ?WorldCap=None, name:
 
         adapter.set_dmc(new_dmc)
 
+        if dmc is not None and new_dmc is not None:
+            old_dmcg = dmc.to_gdata()
+            new_dmcg = new_dmc.to_gdata()
+            if old_dmcg is not None and new_dmcg is not None:
+                if yang.gdata.diff(old_dmcg, new_dmcg) is not None:
+                    # Configuration that affects our behavior, like
+                    # approval-required might have changed, so attempt to
+                    # send the configuration again
+                    after 0: _send_config()
+
         dmc = new_dmc
+        _update_approval_state()
+
 
     def _send_config():
         """Send configuration to the device adapter
@@ -357,9 +437,40 @@ actor DeviceMgr(dev_types: dict[str, DeviceType]={}, wcap: ?WorldCap=None, name:
             return
 
         last_confq = None
+        # Track which tids we'll process if we actually send config
+        pending_tids = []
+        # We want to grab as much approved configuration as possible. To be
+        # considered, all items from the head of the queue must have an approval
+        # status. Any item without an approval status stops the processing.
+        # Note however how we skip past items that are rejected if a later item
+        # is approved. This is initially surprising since we deal with
+        # cumulative configurations, but it does make sense since the later
+        # transaction might have negated the earlier rejected configuration.
         for id, ci in confq.items():
-            last_confq = ci.conf
+            ci_approved = ci.approved
+            if dmc.approval_required:
+                ci_approved = ci.approved
+                if ci_approved is not None:
+                    if ci_approved:
+                        pending_tids.append(ci.tid)
+                        last_confq = ci.conf
+                    else:
+                        _log.debug("DeviceMgr._send_config: configuration not approved, skipping", {"confq_id": id, "tid": ci.tid})
+                else:
+                    _log.debug("DeviceMgr._send_config: configuration requires approval, stopping", {"confq_id": id, "tid": ci.tid})
+                    break
+            else:
+                pending_tids.append(ci.tid)
+                last_confq = ci.conf
         send_conf = last_confq if last_confq is not None else target_conf
+        if len(pending_tids) > 0:
+            # got work to do, pass and continue further
+            pass
+        else:
+            if dmc.approval_required and len(confq) > 0:
+                # there must be something pending approval
+                _log.debug("DeviceMgr._send_config: device requires approval and we have pending configuration needing approval")
+            return
 
         def on_configured(error: ?Exception, resulting_config, new_diff):
             """Handle transaction completion
@@ -399,6 +510,17 @@ actor DeviceMgr(dev_types: dict[str, DeviceType]={}, wcap: ?WorldCap=None, name:
                     if isinstance(error, BusyError):
                         _log.debug("DeviceAdapter busy, ignoring this error as adapter will trigger us once it is done with current operation")
                         return
+                    if isinstance(error, TxidMismatchError):
+                        _log.debug("Device txid mismatch, re-syncing device")
+                        # Clear approval state so we can re-approve the configuration
+                        for tid in current_tids:
+                            ci = confq.get(tid)
+                            if ci is not None:
+                                ci.approved = None
+                        current_tids = set()
+                        _update_approval_state()
+                        resync()
+                        return
 
                     if len(confq) > len(current_tids):
                         _log.debug("New intended configuration available, retrying with latest config")
@@ -436,6 +558,7 @@ actor DeviceMgr(dev_types: dict[str, DeviceType]={}, wcap: ?WorldCap=None, name:
                     reconf_tids.discard(tid)
                     del confq[tid]
                 current_tids = set()
+                _update_approval_state()
                 if len(confq) > 0:
                     _log.debug("Configuration changed during in-progress transaction, running again...")
                     _send_config()
@@ -450,18 +573,20 @@ actor DeviceMgr(dev_types: dict[str, DeviceType]={}, wcap: ?WorldCap=None, name:
                         _log.info("Reconciliation loop detected, target diff is same as last diff sent, stopping", {"diff": send_diff})
                         return
                 # Actually send the configuration
-                current_tids.update(confq.keys())
+                current_tids = set(pending_tids)
                 current_tids.update(reconf_tids)
                 _log.debug("DeviceMgr._send_config: sending intended target configuration", {"current_tids": current_tids, "diff": send_diff})
                 adapter.configure(lambda e, c: on_configured(e, c, send_diff), send_diff, send_conf, running_conf)
             else:
-                _log.debug("DeviceMgr.configure: no diff between running and target config, nothing to do", {"pending_tids": confq.keys()})
-                for tid in confq.keys():
+                _log.debug("DeviceMgr.configure: no diff between running and target config, nothing to do", {"pending_tids": pending_tids})
+                # No diff, so complete the pending transactions immediately
+                for tid in pending_tids:
                     cb = callbacks.get(tid)
                     if cb is not None:
                         cb(True)
                         del callbacks[tid]
-                confq = {}
+                    del confq[tid]
+                _update_approval_state()
         else:
             if running_conf is None:
                 _log.debug("No running config, cannot compute diff")
@@ -475,6 +600,7 @@ actor DeviceMgr(dev_types: dict[str, DeviceType]={}, wcap: ?WorldCap=None, name:
                 return
             _log.debug("DeviceMgr.configure: received new intended configuration", {"tid": tid, "new_conf": truncate_conf(new_conf)})
             confq[tid] = ConfigItem(tid, new_conf, modset_id)
+            _update_approval_state()
             _send_config()
         elif new_conf is None and conf_modset_id is None:
             _log.debug("DeviceMgr.configure: transaction registered intent to configure but awaiting reconf", {"tid": tid})
@@ -528,6 +654,7 @@ actor DeviceMgr(dev_types: dict[str, DeviceType]={}, wcap: ?WorldCap=None, name:
         adapter.fetch_config(on_fetch_config_done)
 
     def wait_complete(tid: str, done: action(value) -> None):
+        _log.debug("DeviceMgr.wait_complete: confq", {"confq": list(confq.keys())})
         if tid not in current_tids | set(confq.keys()) | reconf_tids:
             _log.debug("DeviceMgr.wait_complete: transaction id not found, calling done", {"tid": tid})
             done(True) # Assume tid is very old and has already completed, thus respond immediately
@@ -555,12 +682,77 @@ actor DeviceMgr(dev_types: dict[str, DeviceType]={}, wcap: ?WorldCap=None, name:
         """
         adapter.fetch_config(done)
 
-
     def get_schema():
         return schema
 
     def rpc_xml(cb: action(?xml.Node, ?Exception) -> None, xml_rpc: xml.Node):
         adapter.rpc_xml(cb, xml_rpc)
+
+    def list_confq():
+        return confq
+
+    def get_confq(id: str) -> (ci: ConfigItem, running_conf: yang.gdata.Node):
+        _log.debug("DeviceMgr.get_confq: checking confq for id", {"id": id, "confq": list(confq.keys())})
+        if len(confq) == 0:
+            raise ValueError("Configuration queue is empty")
+        first_key = next(confq.keys())
+
+        if id == first_key:
+            if running_conf is not None:
+                return (ci=confq[first_key], running_conf=running_conf)
+            else:
+                raise ValueError("No device running configuration available for diffing")
+
+        # non-head item
+        previous_ci = None
+        for tid, ci in confq.items():
+            if tid == id and previous_ci is not None:
+                return (ci=confq[first_key], running_conf=previous_ci.conf)
+            previous_ci = ci
+        raise ValueError("No such configuration id ({id}) in queue")
+
+    def set_confq_approval(id: str, device_txid: str, approved: bool):
+        _log.debug("DeviceMgr.set_confq_approval: setting approval", {"id": id, "approved": approved})
+        _log.debug("DeviceMgr.set_confq_approval: checking confq for id", {"id": id, "confq": list(confq.keys())})
+        if len(confq) == 0:
+            raise ValueError("Configuration queue is empty")
+        first_key = next(confq.keys())
+        if id != first_key:
+            raise ValueError("Configuration id not at head of queue")
+
+        if device_txid != get_device_txid():
+            raise ValueError("Device txid does not match current device txid")
+
+        if approved:
+            _log.debug("DeviceMgr.set_confq_approval: approving configuration", {"id": id})
+            ci = confq[first_key]
+            ci.approved = True
+        else:
+            # TODO: ideally we would allow setting approval on non-head items.
+            # Each non-head item woud be presented as a diff between the
+            # previous item in the queue and that item. This is valid as long as
+            # the previous items get approved and applied without txid
+            # mismatches. If we get a txid mismatch, we have to clear all
+            # pending items as any approval is basically voided. I think we need
+            # a log of events on each ConfigItem to convey this to the user
+            # though, otherwise it is too confusing that an approved item suddenly
+            # goes back to unapproved.
+            _log.debug("DeviceMgr.set_confq_approval: rejecting configuration", {"id": id})
+            del confq[first_key]
+        _update_approval_state()
+        if approved:
+            _send_config()
+
+    def get_pending_approvals() -> dict[str, ConfigItem]:
+        """Get list of configuration items in approval queue
+
+        Returns all items in the queue when approval is required.
+        This includes pending (None), approved (True), and rejected (False) items.
+        """
+        if dmc.approval_required:
+            return confq
+        return {}
+
 
 
 class DeviceAdapter(object):

--- a/src/orchestron/device.act
+++ b/src/orchestron/device.act
@@ -361,7 +361,7 @@ actor DeviceMgr(dev_types: dict[str, DeviceType]={}, wcap: ?WorldCap=None, name:
             last_confq = ci.conf
         send_conf = last_confq if last_confq is not None else target_conf
 
-        def on_configured(error: ?Exception, resulting_config, new_diff, new_config, old_config):
+        def on_configured(error: ?Exception, resulting_config, new_diff):
             """Handle transaction completion
 
             This callback is called when the adapter finishes the configuration
@@ -418,14 +418,14 @@ actor DeviceMgr(dev_types: dict[str, DeviceType]={}, wcap: ?WorldCap=None, name:
 
             else:
                 _log.debug("Configuration successfully applied on device, calling callbacks...", {"current_tids": current_tids})
+                # Since we successfuly sent the configuration from the confq to
+                # the device, we updated target_conf so any later resync /
+                # reconfigurations will use the latest target configuration
                 target_conf = send_conf
-                # Update running_conf with the result from the device (which has the new devicetxid)
-                if resulting_config is not None:
-                    _log.debug("Updating running_conf with new device txid", {"device_txid": resulting_config.txid})
-                    running_conf = resulting_config
-                else:
-                    _log.warning("No resulting_config returned from adapter, using target_conf")
-                    running_conf = target_conf
+                # The device adapters gives us back the resulting config on the
+                # device, including an updated txid. We update our view of the
+                # device's running to this new resulting config.
+                running_conf = resulting_config
 
                 last_sent_diff = new_diff
                 for tid in current_tids:
@@ -443,17 +443,17 @@ actor DeviceMgr(dev_types: dict[str, DeviceType]={}, wcap: ?WorldCap=None, name:
         # Check if there is an actual diff right now
         if running_conf is not None and send_conf is not None:
             send_conf2 = config_fixer(running_conf, send_conf)
-            config_diff = yang.gdata.diff(running_conf, send_conf2) if send_conf2 is not None else None
-            if config_diff is not None:
+            send_diff = yang.gdata.diff(running_conf, send_conf2) if send_conf2 is not None else None
+            if send_diff is not None:
                 if last_sent_diff is not None:
-                    if config_diff == last_sent_diff:
-                        _log.info("Reconciliation loop detected, target diff is same as last diff sent, stopping", {"diff": config_diff})
+                    if send_diff == last_sent_diff:
+                        _log.info("Reconciliation loop detected, target diff is same as last diff sent, stopping", {"diff": send_diff})
                         return
                 # Actually send the configuration
                 current_tids.update(confq.keys())
                 current_tids.update(reconf_tids)
-                _log.debug("DeviceMgr._send_config: sending intended target configuration", {"current_tids": current_tids, "diff": config_diff})
-                adapter.configure(lambda e, c: on_configured(e, c, config_diff, send_conf, running_conf), config_diff, send_conf, running_conf)
+                _log.debug("DeviceMgr._send_config: sending intended target configuration", {"current_tids": current_tids, "diff": send_diff})
+                adapter.configure(lambda e, c: on_configured(e, c, send_diff), send_diff, send_conf, running_conf)
             else:
                 _log.debug("DeviceMgr.configure: no diff between running and target config, nothing to do", {"pending_tids": confq.keys()})
                 for tid in confq.keys():

--- a/src/orchestron/device.act
+++ b/src/orchestron/device.act
@@ -245,11 +245,6 @@ actor DeviceMgr(dev_types: dict[str, DeviceType]={}, wcap: ?WorldCap=None, name:
     mock = True if wcap is None else False
     _log.debug("DeviceMgr starting up", {"name": name, "mock": mock})
 
-    # Orchestron's intended target configuration, that we want on the device.
-    var target_conf: ?yang.gdata.Node = None
-    # The device's current running configuration, as we know it.
-    var running_conf: ?yang.gdata.Node = None
-
     # The device's meta configuration, like address, credentials, etc.
     var dmc: DeviceMetaConfig = DeviceMetaConfig(name, Credentials("", None))
 
@@ -260,6 +255,8 @@ actor DeviceMgr(dev_types: dict[str, DeviceType]={}, wcap: ?WorldCap=None, name:
     var modset: dict[str, ModCap] = {}
     var modset_id: ?str = None
 
+    # The device's current running configuration, as we know it.
+    var running_conf: ?yang.gdata.Node = None
 
     # New configuration received from the transaction engine via the
     # DeviceMgr.configure() method are stored in a configuration queue, which
@@ -267,19 +264,32 @@ actor DeviceMgr(dev_types: dict[str, DeviceType]={}, wcap: ?WorldCap=None, name:
     # and modset_id. Any new configuration is appended and we consume the queue
     # when sending configuration to the device.
     var confq: dict[str, ConfigItem] = {}
+
+    # target_conf is the last successfully applied configuration of the device
+    # We dequeue configuration from the confq and send to the device. Once that
+    # configuration has been successfully applied to thedevice, we remove it
+    # from the confq and call the associated callbacks for the tids in the
+    # ConfigItem. We also save that config in target_conf, so that if we have
+    # the need to reconfigure the device, like after the running_conf has
+    # updated, we do that with the latest config that we sent to the device,
+    # i.e. target_conf.
+    var target_conf: ?yang.gdata.Node = None
+
     # current_txids are the ids of the transactions that are currently
     # in-transit, which also means that we can determine if we have an
     # outstanding transaction by checking len(current_txids) > 0.
     var current_txids = set()
+    # reconf is a special kind of operation, where an initial transaction
+    # intends to configure devices but those devices have no known modset and
+    # thus the RFS transforms cannot produce device configuration. It is still
+    # valid to await completion of such a transaction and the intent means "we
+    # want to await that the RFS transform intended (future) output has reached
+    # the device". Those transactions register for the future reconf and we keep
+    # track of those in reconf_txids. The next successfuly sent configuration to
+    # the device will call the reconf_txids on completion so they in turn can
+    # notify their clients that the configuration now has reached the devices.
     var reconf_txids = set()
-    # Note how target_conf always only reflects the very latest configuration
-    # that we received from the TTT transaction engine. When the device is ready
-    # to receive configuration (we are connected, have said hello, gotten
-    # capabilities, do not have an outstanding transaction), we will send the
-    # target_conf. A snapshot is taken and sent to the device. We do not keep
-    # that particular version. If later the device failed to commit the
-    # configuration and we need to retry, we will retry with a new
-    # configuration.
+
 
     # The last successfully sent diff. We use this to detect and break infinite
     # loops in the device config reconciliation loop
@@ -341,6 +351,16 @@ actor DeviceMgr(dev_types: dict[str, DeviceType]={}, wcap: ?WorldCap=None, name:
         This function manages the transaction queue and calls the adapter's
         configure method with the current target configuration.
         """
+        # Check if we already have a transaction in progress
+        if len(current_txids) > 0:
+            _log.debug("DeviceMgr._send_config: there is currently an outstanding configuration, skipping", {"txids": current_txids})
+            return
+
+        last_confq = None
+        for id, ci in confq.items():
+            last_confq = ci.conf
+        send_conf = last_confq if last_confq is not None else target_conf
+
         def on_configured(error: ?Exception, resulting_config, new_diff, new_config, old_config):
             """Handle transaction completion
 
@@ -398,6 +418,7 @@ actor DeviceMgr(dev_types: dict[str, DeviceType]={}, wcap: ?WorldCap=None, name:
 
             else:
                 _log.debug("Configuration successfully applied on device, calling callbacks...", {"txids": current_txids})
+                target_conf = send_conf
                 # Update running_conf with the result from the device (which has the new txid)
                 if resulting_config is not None:
                     _log.debug("Updating running_conf with new txid", {"txid": resulting_config.txid})
@@ -419,18 +440,10 @@ actor DeviceMgr(dev_types: dict[str, DeviceType]={}, wcap: ?WorldCap=None, name:
                     _log.debug("Configuration changed during in-progress transaction, running again...")
                     _send_config()
 
-        # Check if we already have a transaction in progress
-        if len(current_txids) > 0:
-            _log.debug("DeviceMgr._send_config: there is currently an outstanding configuration, skipping", {"txids": current_txids})
-            return
-
-        for id, ci in confq.items():
-            target_conf = ci.conf
-
         # Check if there is an actual diff right now
-        if running_conf is not None and target_conf is not None:
-            target_conf2 = config_fixer(running_conf, target_conf)
-            config_diff = yang.gdata.diff(running_conf, target_conf2) if target_conf2 is not None else None
+        if running_conf is not None and send_conf is not None:
+            send_conf2 = config_fixer(running_conf, send_conf)
+            config_diff = yang.gdata.diff(running_conf, send_conf2) if send_conf2 is not None else None
             if config_diff is not None:
                 if last_sent_diff is not None:
                     if config_diff == last_sent_diff:
@@ -440,7 +453,7 @@ actor DeviceMgr(dev_types: dict[str, DeviceType]={}, wcap: ?WorldCap=None, name:
                 current_txids.update(confq.keys())
                 current_txids.update(reconf_txids)
                 _log.debug("DeviceMgr._send_config: sending intended target configuration", {"txids": current_txids, "diff": config_diff})
-                adapter.configure(lambda e, c: on_configured(e, c, config_diff, target_conf, running_conf), config_diff, target_conf, running_conf)
+                adapter.configure(lambda e, c: on_configured(e, c, config_diff, send_conf, running_conf), config_diff, send_conf, running_conf)
             else:
                 _log.debug("DeviceMgr.configure: no diff between running and target config, nothing to do", {"pending_tids": confq.keys()})
                 for tid in confq.keys():
@@ -452,8 +465,8 @@ actor DeviceMgr(dev_types: dict[str, DeviceType]={}, wcap: ?WorldCap=None, name:
         else:
             if running_conf is None:
                 _log.debug("No running config, cannot compute diff")
-            if target_conf is None:
-                _log.debug("No target config, cannot compute diff")
+            if send_conf is None:
+                _log.debug("No send config, cannot compute diff")
 
     def configure(new_conf: ?yang.gdata.Node, conf_modset_id: ?str, tid: str="0"):
         if new_conf is not None and conf_modset_id is not None:

--- a/src/orchestron/device.act
+++ b/src/orchestron/device.act
@@ -343,6 +343,22 @@ actor DeviceMgr(dev_types: dict[str, DeviceType]={}, wcap: ?WorldCap=None, name:
     var needs_approval = False
     var conf_log: list[LogItem] = []
 
+    def get_state():
+        """Get the device state information"""
+        has_running = False
+        has_target = False
+        if running_conf is not None:
+            has_running = True
+        if target_conf is not None:
+            has_target = True
+
+        return (
+            has_running_config=has_running,
+            has_target_config=has_target,
+            queue_length=len(confq),
+            pending_approvals=len(get_pending_approvals())
+        )
+
     def _update_approval_state():
         if not dmc.approval_required:
             if needs_approval:
@@ -375,6 +391,15 @@ actor DeviceMgr(dev_types: dict[str, DeviceType]={}, wcap: ?WorldCap=None, name:
             if rc_txid is not None:
                 return rc_txid
         return ""
+
+    def get_dmc():
+        return dmc
+
+    def get_running_conf():
+        return running_conf
+
+    def get_target_conf():
+        return target_conf
 
     def on_modset_update(new_modset: dict[str, ModCap]):
         _log.debug("Modset updated", {"new_modset": new_modset})

--- a/src/orchestron/device.act
+++ b/src/orchestron/device.act
@@ -342,7 +342,6 @@ actor DeviceMgr(dev_types: dict[str, DeviceType]={}, wcap: ?WorldCap=None, name:
             if error is not None:
                 if isinstance(error, NotConnectedError):
                     _log.debug("Device not connected, no need to retry - waiting for reconnect")
-                    pending_txids.update(current_txids)
                     current_txids = set()
 
                 elif isinstance(error, PermanentError):
@@ -351,21 +350,20 @@ actor DeviceMgr(dev_types: dict[str, DeviceType]={}, wcap: ?WorldCap=None, name:
                         _log.debug("Configuration failed due to bad config", {"error": error})
 
                     # Got a permanent error, giving up
-                    for tid,callback in callbacks.items():
-                        if tid in current_txids:
-                            callback(error)
+                    for tid in current_txids:
+                        cb = callbacks.get(tid)
+                        if cb is not None:
+                            cb(error)
                             del callbacks[tid]
 
                     # TODO: uh, what else? we need to bubble up this sort of error state to an operator somehow
 
-                    if len(pending_txids) > 0:
+                    if len(pending_txids) > len(current_txids):
                         _log.debug("New intended configuration available, retrying with latest config")
-                        pending_txids.update(current_txids)
                         current_txids = set()
                         _send_config()
                     else:
                         _log.debug("No new intended configuration available, no point in retrying with same conf")
-                        pending_txids.update(current_txids)
                         current_txids = set()
 
                 elif isinstance(error, TransientError):
@@ -374,22 +372,19 @@ actor DeviceMgr(dev_types: dict[str, DeviceType]={}, wcap: ?WorldCap=None, name:
                         _log.debug("DeviceAdapter busy, ignoring this error as adapter will trigger us once it is done with current operation")
                         return
 
-                    if len(pending_txids) > 0:
+                    if len(pending_txids) > len(current_txids):
                         _log.debug("New intended configuration available, retrying with latest config")
-                        pending_txids.update(current_txids)
                         current_txids = set()
                         _send_config()
                     else:
                         retry_in = 1
                         _log.debug("No new intended configuration available. Scheduling retry of current config", {"retry_in": retry_in})
-                        pending_txids.update(current_txids)
                         current_txids = set()
                         after retry_in: _send_config()
 
                 else:
                     _log.debug("Unhandled error", {"error": error})
                     # Uh, this is indicative of programmer error and we should fix it, but let's do naive retry as well
-                    pending_txids.update(current_txids)
                     current_txids = set()
                     after 1: _send_config()
 
@@ -404,10 +399,12 @@ actor DeviceMgr(dev_types: dict[str, DeviceType]={}, wcap: ?WorldCap=None, name:
                     running_conf = target_conf
 
                 last_sent_diff = new_diff
-                for tid,callback in callbacks.items():
-                    if tid in current_txids:
-                        callback(True)
+                for tid in current_txids:
+                    cb = callbacks.get(tid)
+                    if cb is not None:
+                        cb(True)
                         del callbacks[tid]
+                    pending_txids.discard(tid)
                 current_txids = set()
                 if len(pending_txids) > 0:
                     _log.debug("Configuration changed during in-progress transaction, running again...")
@@ -428,15 +425,15 @@ actor DeviceMgr(dev_types: dict[str, DeviceType]={}, wcap: ?WorldCap=None, name:
                         _log.info("Reconciliation loop detected, target diff is same as last diff sent, stopping", {"diff": config_diff})
                         return
                 # Actually send the configuration
-                current_txids = pending_txids
-                pending_txids = set()
+                current_txids.update(pending_txids)
                 _log.debug("DeviceMgr._send_config: sending intended target configuration", {"txids": current_txids, "diff": config_diff})
                 adapter.configure(lambda e, c: on_configured(e, c, config_diff, target_conf, running_conf), config_diff, target_conf, running_conf)
             else:
                 _log.debug("DeviceMgr.configure: no diff between running and target config, nothing to do", {"txids": pending_txids})
-                for tid,callback in callbacks.items():
-                    if tid in pending_txids:
-                        callback(True)
+                for tid in pending_txids:
+                    cb = callbacks.get(tid)
+                    if cb is not None:
+                        cb(True)
                         del callbacks[tid]
                 pending_txids = set()
         else:

--- a/src/orchestron/device.act
+++ b/src/orchestron/device.act
@@ -480,7 +480,6 @@ actor DeviceMgr(dev_types: dict[str, DeviceType]={}, wcap: ?WorldCap=None, name:
         # cumulative configurations, but it does make sense since the later
         # transaction might have negated the earlier rejected configuration.
         for id, ci in confq.items():
-            ci_approved = ci.approved
             if dmc.approval_required:
                 ci_approved = ci.approved
                 if ci_approved is not None:
@@ -496,14 +495,15 @@ actor DeviceMgr(dev_types: dict[str, DeviceType]={}, wcap: ?WorldCap=None, name:
                 pending_tids.append(ci.tid)
                 last_confq = ci.conf
         send_conf = last_confq if last_confq is not None else target_conf
-        if len(pending_tids) > 0:
-            # got work to do, pass and continue further
-            pass
-        else:
-            if dmc.approval_required and len(confq) > 0:
-                # there must be something pending approval
-                _log.debug("DeviceMgr._send_config: device requires approval and we have pending configuration needing approval")
-            return
+        if dmc.approval_required:
+            if len(pending_tids) > 0:
+                # got work to do, pass and continue further
+                pass
+            else:
+                if len(confq) > 0:
+                    # there must be something pending approval
+                    _log.debug("DeviceMgr._send_config: no pending work as config queue items pend approval")
+                return
 
         def on_configured(error: ?Exception, resulting_config, new_diff):
             """Handle transaction completion

--- a/src/orchestron/device.act
+++ b/src/orchestron/device.act
@@ -264,6 +264,7 @@ actor DeviceMgr(dev_types: dict[str, DeviceType]={}, wcap: ?WorldCap=None, name:
     # in-transit to the device. When len(pending_txids) > 0, we need to
     # send the latest configuration after the current transaction is done.
     var pending_txids = set()
+    var reconf_txids = set()
     # Note how target_conf always only reflects the very latest configuration
     # that we received from the TTT transaction engine. When the device is ready
     # to receive configuration (we are connected, have said hello, gotten
@@ -405,6 +406,7 @@ actor DeviceMgr(dev_types: dict[str, DeviceType]={}, wcap: ?WorldCap=None, name:
                         cb(True)
                         del callbacks[tid]
                     pending_txids.discard(tid)
+                    reconf_txids.discard(tid)
                 current_txids = set()
                 if len(pending_txids) > 0:
                     _log.debug("Configuration changed during in-progress transaction, running again...")
@@ -426,6 +428,7 @@ actor DeviceMgr(dev_types: dict[str, DeviceType]={}, wcap: ?WorldCap=None, name:
                         return
                 # Actually send the configuration
                 current_txids.update(pending_txids)
+                current_txids.update(reconf_txids)
                 _log.debug("DeviceMgr._send_config: sending intended target configuration", {"txids": current_txids, "diff": config_diff})
                 adapter.configure(lambda e, c: on_configured(e, c, config_diff, target_conf, running_conf), config_diff, target_conf, running_conf)
             else:
@@ -443,16 +446,17 @@ actor DeviceMgr(dev_types: dict[str, DeviceType]={}, wcap: ?WorldCap=None, name:
                 _log.debug("No target config, cannot compute diff")
 
     def configure(new_conf: ?yang.gdata.Node, conf_modset_id: ?str, tid: str="0"):
-        pending_txids.add(tid)
         if new_conf is not None and conf_modset_id is not None:
             if conf_modset_id != modset_id:
                 _log.debug("DeviceMgr.configure: modset_id mismatch, ignoring configuration", {"conf_modset_id": str(conf_modset_id), "modset_id": str(modset_id)})
                 return
             _log.debug("DeviceMgr.configure: received new intended configuration", {"tid": tid, "new_conf": truncate_conf(new_conf)})
+            pending_txids.add(tid)
             target_conf = new_conf
             _send_config()
         elif new_conf is None and conf_modset_id is None:
             _log.debug("DeviceMgr.configure: transaction registered intent to configure but awaiting reconf", {"tid": tid})
+            reconf_txids.add(tid)
         else:
             _log.debug("DeviceMgr.configure: invalid input", {"conf_modset_id": str(conf_modset_id), "new_conf": truncate_conf(new_conf), "tid": tid})
 
@@ -502,7 +506,7 @@ actor DeviceMgr(dev_types: dict[str, DeviceType]={}, wcap: ?WorldCap=None, name:
         adapter.fetch_config(on_fetch_config_done)
 
     def wait_complete(tid: str, done: action(value)->None):
-        if tid not in current_txids | pending_txids:
+        if tid not in current_txids | pending_txids | reconf_txids:
             _log.debug("DeviceMgr.wait_complete: transaction id not found, calling done", {"tid": tid})
             done(True) # Assume tid is very old and has already completed, thus respond immediately
         else:

--- a/src/orchestron/device_meta_config.act
+++ b/src/orchestron/device_meta_config.act
@@ -101,6 +101,12 @@ def src_yang():
       }
     }
 
+    leaf approval-required {
+      description "Require approval of each individual configuration change to this device";
+      type boolean;
+      default "false";
+    }
+
     container mock {
       leaf-list preset {
         type enumeration {
@@ -1036,6 +1042,7 @@ class orchestron_rfs__device__initial_credentials(yang.adata.MNode):
 
 
 
+
 class orchestron_rfs__device__mock__module_entry(yang.adata.MNode):
     name: str
     namespace: str
@@ -1232,10 +1239,11 @@ class orchestron_rfs__device_entry(yang.adata.MNode):
     address: orchestron_rfs__device__address
     credentials: orchestron_rfs__device__credentials
     initial_credentials: orchestron_rfs__device__initial_credentials
+    approval_required: bool
     mock: orchestron_rfs__device__mock
     debug: orchestron_rfs__device__debug
 
-    mut def __init__(self, name: str, credentials: orchestron_rfs__device__credentials, description: ?str, type: ?str, address: list[orchestron_rfs__device__address_entry]=[], initial_credentials: list[orchestron_rfs__device__initial_credentials_entry]=[], mock: ?orchestron_rfs__device__mock=None, debug: ?orchestron_rfs__device__debug=None):
+    mut def __init__(self, name: str, credentials: orchestron_rfs__device__credentials, description: ?str, type: ?str, address: list[orchestron_rfs__device__address_entry]=[], initial_credentials: list[orchestron_rfs__device__initial_credentials_entry]=[], approval_required: ?bool=None, mock: ?orchestron_rfs__device__mock=None, debug: ?orchestron_rfs__device__debug=None):
         self._ns = 'http://orchestron.org/yang/orchestron-rfs.yang'
         self.name = name
         self.description = description
@@ -1243,6 +1251,7 @@ class orchestron_rfs__device_entry(yang.adata.MNode):
         self.address = orchestron_rfs__device__address(elements=address)
         self.credentials = credentials
         self.initial_credentials = orchestron_rfs__device__initial_credentials(elements=initial_credentials)
+        self.approval_required = approval_required if approval_required is not None else False
         self.mock = mock if mock is not None else orchestron_rfs__device__mock()
         self.debug = debug if debug is not None else orchestron_rfs__device__debug()
 
@@ -1266,6 +1275,9 @@ class orchestron_rfs__device_entry(yang.adata.MNode):
         _initial_credentials = self.initial_credentials
         if _initial_credentials is not None:
             children['initial-credentials'] = _initial_credentials.to_gdata()
+        _approval_required = self.approval_required
+        if _approval_required is not None:
+            children['approval-required'] = yang.gdata.Leaf('boolean', _approval_required)
         _mock = self.mock
         if _mock is not None:
             children['mock'] = _mock.to_gdata()
@@ -1276,7 +1288,7 @@ class orchestron_rfs__device_entry(yang.adata.MNode):
 
     @staticmethod
     mut def from_gdata(n: yang.gdata.Node) -> orchestron_rfs__device_entry:
-        return orchestron_rfs__device_entry(name=n.get_str('name'), description=n.get_opt_str('description'), type=n.get_opt_str('type'), address=orchestron_rfs__device__address.from_gdata(n.get_opt_list('address')), credentials=orchestron_rfs__device__credentials.from_gdata(n.get_cnt('credentials')), initial_credentials=orchestron_rfs__device__initial_credentials.from_gdata(n.get_opt_list('initial-credentials')), mock=orchestron_rfs__device__mock.from_gdata(n.get_opt_cnt('mock')), debug=orchestron_rfs__device__debug.from_gdata(n.get_opt_cnt('debug')))
+        return orchestron_rfs__device_entry(name=n.get_str('name'), description=n.get_opt_str('description'), type=n.get_opt_str('type'), address=orchestron_rfs__device__address.from_gdata(n.get_opt_list('address')), credentials=orchestron_rfs__device__credentials.from_gdata(n.get_cnt('credentials')), initial_credentials=orchestron_rfs__device__initial_credentials.from_gdata(n.get_opt_list('initial-credentials')), approval_required=n.get_opt_bool('approval-required'), mock=orchestron_rfs__device__mock.from_gdata(n.get_opt_cnt('mock')), debug=orchestron_rfs__device__debug.from_gdata(n.get_opt_cnt('debug')))
 
     def prsrc(self, self_name='ad', top=True, list_element=False):
         res = []
@@ -1311,6 +1323,9 @@ class orchestron_rfs__device_entry(yang.adata.MNode):
             list_elem = 'initial_credentials_element = {self_name}.initial_credentials.create({repr(_element.username)}, {repr(_element.password)}, {repr(_element.key)})'
             res.append(list_elem)
             res.extend(_element.prsrc('initial_credentials_element', False, list_element=True).splitlines())
+        _approval_required = self.approval_required
+        if _approval_required is not None:
+            leaves.append('{self_name}.approval_required = {repr(_approval_required)}')
         _mock = self.mock
         if _mock is not None:
             res.extend(_mock.prsrc('{self_name}.mock', False).splitlines())

--- a/src/orchestron/device_meta_config.act
+++ b/src/orchestron/device_meta_config.act
@@ -131,11 +131,16 @@ def src_yang():
         }
       }
     }
+
     container debug {
       leaf connection {
         type boolean;
         default "false";
       }
+    }
+
+    container state {
+      config false;
     }
   }
 

--- a/src/orchestron/yang.act
+++ b/src/orchestron/yang.act
@@ -86,6 +86,12 @@ rfs = r"""module orchestron-rfs {
       }
     }
 
+    leaf approval-required {
+      description "Require approval of each individual configuration change to this device";
+      type boolean;
+      default "false";
+    }
+
     container mock {
       leaf-list preset {
         type enumeration {

--- a/src/orchestron/yang.act
+++ b/src/orchestron/yang.act
@@ -116,11 +116,16 @@ rfs = r"""module orchestron-rfs {
         }
       }
     }
+
     container debug {
       leaf connection {
         type boolean;
         default "false";
       }
+    }
+
+    container state {
+      config false;
     }
   }
 


### PR DESCRIPTION
This adds a configuration queue in the DeviceMgr such that when new configuration is received from TTT, it is placed on the queue instead of being sent directly to the device. There is a new `approval-required` configuration flag on the device, which controls the behavior of what happens next. If approval is disabled (the default), the configuration is directly picked up from the queue, conceptually consuming all items on the queue, though in practice we just grab the last item since it is the total configuration. All tids are collected from this for calling callbacks later.

When approval is enabled, we grab as many items from the queue as possible, including all approved items and stopping at any rejected or pending items. We don't immediately consume the items from the queue, instead we keep track of what items we are pushing to the device through the DeviceAdapter and when it succeeds, we actually consume them from the queue.

There is a small web UI added that can be used to look at the approval queue as well as the config log. The config log is written to when we successfully send configuration to the device as well as when we fetch config from the device. It stores the diff.

Fixes #156 

Fixes #198 