### PR TITLE
Switch minisys to use gen3 parser for NB API

### DIFF
--- a/minisys/src/mini.act
+++ b/minisys/src/mini.act
@@ -8,8 +8,10 @@ import xml
 
 import orchestron.device as odev
 import orchestron.ttt as ttt
+import yang
 import yang.adata
 import yang.gdata
+import yang.gen3
 
 import mini.layers
 import mini.layers.y_0_loose as cfs_layer
@@ -67,6 +69,10 @@ actor main(env):
     logh_dev.set_handler(logh)
 
     log = logging.Logger(logh)
+
+    print("Compiling schema...")
+    top_schema = yang.compile(mini.layers.y_0.src_yang())
+    print("Schema compile done")
 
     dev_registry = odev.DeviceRegistry(mini.sysspec.device_types, env.cap, logh_dev)
     cfs = mini.layers.get_layers(dev_registry, logh_ttt)
@@ -435,7 +441,7 @@ actor main(env):
         elif request.method == "DELETE":
             p = split_restconf_path(request.path)
             if p[0] == "restconf":
-                input_config = mini.layers.y_0.from_json_path({}, p[1:], "remove")
+                input_config = yang.gen3.from_json_path(top_schema, {}, p[1:], "remove", loose=True)
                 session = cfs.newsession()
                 session.edit_config(input_config, config_done)
                 return
@@ -450,11 +456,11 @@ actor main(env):
                 if request.headers.get("content-type") == "application/yang-data+json":
                     json_in = json.decode(request.body.decode())
                     p = split_restconf_path(request.path)[1:]
-                    input_config = mini.layers.y_0.from_json_path(json_in, p)
+                    input_config = yang.gen3.from_json_path(top_schema, json_in, p, loose=True)
                 elif request.headers.get("content-type") == "application/yang-data+xml":
                     try:
                         xml_in = xml.decode(request.body.decode())
-                        input_config = cfs_layer.from_xml(xml_in)
+                        input_config = yang.gen3.from_xml(top_schema, xml_in, loose=True)
                     except Exception as e:
                         respond(400, {}, "Error parsing XML: {e}")
                         return
@@ -535,7 +541,7 @@ actor main(env):
             config = configs.pop(0)
             # Grab the first config
             log.info("Applying config file...", {"config_file": config.filename})
-            input_config = cfs_layer.from_xml(config.config)
+            input_config = yang.gen3.from_xml(top_schema, config.config, loose=True)
             session.edit_config(input_config, None, lambda result: _conf_file_done(config, result))
         except IndexError:
             log.info("All config files applied")


### PR DESCRIPTION
The gen3 parser has better loose parsing, so for RESTCONF DELETE, we now do proper loose mode. The old parser would barf if there were, for example, mandatory leaves under a list entry when trying to delete the list entry.