### PR TITLE
Convert dynstate to gdata before TTT

### DIFF
--- a/minisys/src/mini/layers/t_0.act
+++ b/minisys/src/mini/layers/t_0.act
@@ -6,7 +6,6 @@ import logging
 
 import orchestron.device as odev
 import orchestron.ttt as ttt
-import yang.adata
 import yang.gdata
 
 import mini.cfs

--- a/minisys/src/mini/layers/t_1.act
+++ b/minisys/src/mini/layers/t_1.act
@@ -6,7 +6,6 @@ import logging
 
 import orchestron.device as odev
 import orchestron.ttt as ttt
-import yang.adata
 import yang.gdata
 
 import mini.rfs

--- a/minisys/src/mini/layers/t_2.act
+++ b/minisys/src/mini/layers/t_2.act
@@ -6,7 +6,6 @@ import logging
 
 import orchestron.device as odev
 import orchestron.ttt as ttt
-import yang.adata
 import yang.gdata
 
 

--- a/src/orchestron/ttt.act
+++ b/src/orchestron/ttt.act
@@ -158,8 +158,8 @@ actor Transaction(impl: _Transaction):
     def init_dynstate(node: Node, act: proc(TransformActorParams) -> ?proc(gdata.Node, ?gdata.Node) -> None):
         impl.init_dynstate(node, act, update_dynstate)
 
-    def update_dynstate(dynstate: ?yang.adata.MNode):
-        impl.update_dynstate(dynstate.to_gdata() if dynstate is not None else None)
+    def update_dynstate(dynstate: ?gdata.Node):
+        impl.update_dynstate(dynstate)
 
 class _Transaction(object):
     path: list[str]
@@ -172,7 +172,7 @@ class _Transaction(object):
     wait_complete_cont : proc(actself: Transaction, res: value) -> None
     get: proc() -> gdata.Node
 
-    proc def init_dynstate(self, node: Node, act: proc(TransformActorParams) -> ?proc(gdata.Node, ?gdata.Node) -> None, update_dynstate: proc(?yang.adata.MNode)->None):
+    proc def init_dynstate(self, node: Node, act: proc(TransformActorParams) -> ?proc(gdata.Node, ?gdata.Node) -> None, update_dynstate: proc(?gdata.Node)->None):
         pass
 
     proc def update_dynstate(self, dynstate: ?gdata.Node) -> None:
@@ -878,7 +878,7 @@ class _TransformTransactionBase(_Transaction):
 
 
 class TransformActorParams:
-    def __init__(self, update_dynstate: proc(?yang.adata.MNode) -> None, dev: ?odev.DeviceMgr):
+    def __init__(self, update_dynstate: proc(?gdata.Node) -> None, dev: ?odev.DeviceMgr):
         self.update_dynstate = update_dynstate
         self.dev = dev
 
@@ -969,7 +969,7 @@ class TransformFunction(object):
     def transform_xml(self, cfg, memory, dynstate):
         return gdata.Container(), None
 
-    proc def init_dynstate(self, act: proc(TransformActorParams) -> ?proc(gdata.Node, ?gdata.Node) -> None, update_dynstate: proc(?yang.adata.MNode)->None):
+    proc def init_dynstate(self, act: proc(TransformActorParams) -> ?proc(gdata.Node, ?gdata.Node) -> None, update_dynstate: proc(?gdata.Node)->None):
         self._on_conf = act(TransformActorParams(update_dynstate, None))
 
     proc def on_conf(self, conf: gdata.Node, memory: ?gdata.Node):
@@ -1113,7 +1113,7 @@ class RFSFunction(object):
     def transform_xml(self, cfg, di, memory, dynstate):
         return (gdata.Container(), None)
 
-    proc def init_dynstate(self, act: proc(TransformActorParams) -> ?proc(gdata.Node, ?gdata.Node) -> None, update_dynstate: proc(?yang.adata.MNode)->None, dev: odev.DeviceMgr):
+    proc def init_dynstate(self, act: proc(TransformActorParams) -> ?proc(gdata.Node, ?gdata.Node) -> None, update_dynstate: proc(?gdata.Node)->None, dev: odev.DeviceMgr):
         self._on_conf = act(TransformActorParams(update_dynstate, dev))
 
     proc def on_conf(self, conf: gdata.Node, memory: ?gdata.Node):

--- a/src/orchestron/ttt_gen.act
+++ b/src/orchestron/ttt_gen.act
@@ -112,9 +112,8 @@ def dschema_to_tttsrc(sn: schema.DNode, spath: list[schema.DNode], indent=0, set
                             transform_actor_extra_params = ", ttt.expect(params.dev, \"Missing expected DeviceMgr param to {transform_actor_fq}.\")" if ext.name == "rfs-transform" else ""
                             memory_conv = ", %s.from_gdata(m) if m is not None else None" % memory_class if memory_class is not None else ""
                             act_defs.append("""def %s(params: ttt.TransformActorParams) -> ?proc(yang.gdata.Node, ?yang.gdata.Node) -> None:
-    _update_dynstate = params.update_dynstate
     def update_dynstate_type_wrapper(dynstate: ?%s):
-        _update_dynstate(dynstate)
+        params.update_dynstate(dynstate.to_gdata() if dynstate is not None else None)
     act = %s(update_dynstate_type_wrapper%s)
     return proc lambda c, m: act.on_conf(%s.from_gdata(c)%s)
 """ % (transform_actor_ctor, dynstate_class, transform_actor_fq, transform_actor_extra_params, input_class, memory_conv))
@@ -239,7 +238,7 @@ def ttt_prsrc(sn: schema.DNode, input_yang_module: str, output_yang_module: ?str
     ttt_src += "# WARNING WARNING WARNING WARNING WARNING\n\n"
     ttt_src += "import logging\n\n"
     ttt_src += "import orchestron.device as odev\n"
-    ttt_src += "import orchestron.ttt as ttt\nimport yang.adata\nimport yang.gdata\n\n"
+    ttt_src += "import orchestron.ttt as ttt\nimport yang.gdata\n\n"
     ttt_src += "\n".join(list(set(ts.imports))) + "\n\n"
     for sc in ts.state_classes:
         ttt_src += "from %s import %s\n" % (input_yang_module, sc)

--- a/src/test_ttt_gen.act
+++ b/src/test_ttt_gen.act
@@ -56,6 +56,18 @@ ys_rfs = r"""module foo {
       leaf name {
         type string;
       }
+      container dynstate {
+        orchestron:dynstate;
+        leaf enable-polling {
+          type boolean;
+        }
+      }
+      container memory {
+        orchestron:memory;
+        leaf allocated-id {
+          type uint64;
+        }
+      }
     }
   }
 }

--- a/src/test_ttt_transform.act
+++ b/src/test_ttt_transform.act
@@ -651,7 +651,9 @@ class DynstateTransform(ttt.TransformFunction):
 
 actor transform_dynstate(t: testing.AsyncT):
     def DynstateActorCtor(params: ttt.TransformActorParams) -> ?proc(gdata.Node, ?gdata.Node) -> None:
-        act = DynstateActor(params.update_dynstate, t)
+        def update_dynstate_wrapper(dynstate: ?adata.MNode):
+            params.update_dynstate(dynstate.to_gdata() if dynstate is not None else None)
+        act = DynstateActor(update_dynstate_wrapper, t)
         return act.on_conf
 
     router = ttt.Transform(DynstateTransform, DynstateActorCtor) ([], None)

--- a/test/golden/test_ttt_gen/odev
+++ b/test/golden/test_ttt_gen/odev
@@ -6,7 +6,6 @@ import logging
 
 import orchestron.device as odev
 import orchestron.ttt as ttt
-import yang.adata
 import yang.gdata
 
 

--- a/test/golden/test_ttt_gen/ttt_gen_cfs_ttt
+++ b/test/golden/test_ttt_gen/ttt_gen_cfs_ttt
@@ -6,7 +6,6 @@ import logging
 
 import orchestron.device as odev
 import orchestron.ttt as ttt
-import yang.adata
 import yang.gdata
 
 import respnet.cfs

--- a/test/golden/test_ttt_gen/ttt_gen_rfs_base
+++ b/test/golden/test_ttt_gen/ttt_gen_rfs_base
@@ -10,6 +10,8 @@ import yang.gdata
 import yang.gen3
 
 from respnet.layers.y_1 import orchestron_rfs__rfs__backbone_interface_entry
+from respnet.layers.y_1 import orchestron_rfs__rfs__backbone_interface__dynstate
+from respnet.layers.y_1 import orchestron_rfs__rfs__backbone_interface__memory
 from respnet.layers.y_1 import src_dnode
 from  import root as output_root
 
@@ -18,7 +20,7 @@ def o_root():
 
 
 class BBInterface(ttt.RFSFunction):
-    transform: mut(orchestron_rfs__rfs__backbone_interface_entry, ttt.DeviceInfo) -> yang.adata.MNode
+    transform: mut(orchestron_rfs__rfs__backbone_interface_entry, ttt.DeviceInfo, memory: ?orchestron_rfs__rfs__backbone_interface__memory, dynstate: ?orchestron_rfs__rfs__backbone_interface__dynstate) -> (yang.adata.MNode, ?yang.adata.MNode)
 
     @staticmethod
     def input_type():
@@ -30,8 +32,11 @@ class BBInterface(ttt.RFSFunction):
         modeled input and back to gdata
         """
         modeled_input = orchestron_rfs__rfs__backbone_interface_entry.from_gdata(i)
+        modeled_memory = orchestron_rfs__rfs__backbone_interface__memory.from_gdata(memory) if memory is not None else None
+        modeled_dynstate = orchestron_rfs__rfs__backbone_interface__dynstate.from_gdata(dynstate) if dynstate is not None else None
 
-        return self.transform(modeled_input, device_info).to_gdata(), None
+        output, new_memory = self.transform(modeled_input, device_info, modeled_memory, modeled_dynstate)
+        return output.to_gdata(), new_memory.to_gdata() if new_memory is not None else None
 
     mut def transform_xml(self, i: xml.Node, device_info: ttt.DeviceInfo, memory: ?yang.gdata.Node, dynstate: ?yang.gdata.Node) -> (yang.gdata.Node, ?yang.gdata.Node):
         """Wrap the user provided transform method to convert from XML to
@@ -39,5 +44,8 @@ class BBInterface(ttt.RFSFunction):
         """
         gdata_input = yang.gen3.from_data(src_dnode(), i, loose=True, root_path=['orchestron-rfs:rfs', 'foo:backbone-interface'])
         modeled_input = orchestron_rfs__rfs__backbone_interface_entry.from_gdata(gdata_input)
+        modeled_memory = orchestron_rfs__rfs__backbone_interface__memory.from_gdata(memory) if memory is not None else None
+        modeled_dynstate = orchestron_rfs__rfs__backbone_interface__dynstate.from_gdata(dynstate) if dynstate is not None else None
 
-        return self.transform(modeled_input, device_info).to_gdata(), None
+        output, new_memory = self.transform(modeled_input, device_info, modeled_memory, modeled_dynstate)
+        return output.to_gdata(), new_memory.to_gdata() if new_memory is not None else None

--- a/test/golden/test_ttt_gen/ttt_gen_rfs_ttt
+++ b/test/golden/test_ttt_gen/ttt_gen_rfs_ttt
@@ -6,12 +6,20 @@ import logging
 
 import orchestron.device as odev
 import orchestron.ttt as ttt
-import yang.adata
 import yang.gdata
 
 import respnet.rfs
 
+from respnet.layers.y_1 import orchestron_rfs__rfs__backbone_interface_entry
+from respnet.layers.y_1 import orchestron_rfs__rfs__backbone_interface__dynstate
+from respnet.layers.y_1 import orchestron_rfs__rfs__backbone_interface__memory
 
 def get_ttt(lower: ?ttt.Layer, dev_registry: odev.DeviceRegistry, log_handler: ?logging.Handler=None) -> proc(list[str],?ttt.Layer)->ttt.Node:
-    r = ttt.Container({"device": ttt.List(ttt.Device(dev_registry, log_handler), ['name'], ['string'], ns='http://orchestron.org/yang/orchestron-rfs.yang', module='orchestron-rfs'), "rfs": ttt.List(ttt.Container({"backbone-interface": ttt.List(ttt.RFSTransform(respnet.rfs.BBInterface, dev_registry, None, lower, log_handler), ['name'], ['string'], ns='http://example.com/foo', module='foo')}), ['name'], ['string'], ns='http://orchestron.org/yang/orchestron-rfs.yang', module='orchestron-rfs')})
+    r = ttt.Container({"device": ttt.List(ttt.Device(dev_registry, log_handler), ['name'], ['string'], ns='http://orchestron.org/yang/orchestron-rfs.yang', module='orchestron-rfs'), "rfs": ttt.List(ttt.Container({"backbone-interface": ttt.List(ttt.RFSTransform(respnet.rfs.BBInterface, dev_registry, BBInterfaceTransformCtor, lower, log_handler), ['name'], ['string'], ns='http://example.com/foo', module='foo')}), ['name'], ['string'], ns='http://orchestron.org/yang/orchestron-rfs.yang', module='orchestron-rfs')})
     return r
+
+def BBInterfaceTransformCtor(params: ttt.TransformActorParams) -> ?proc(yang.gdata.Node, ?yang.gdata.Node) -> None:
+    def update_dynstate_type_wrapper(dynstate: ?orchestron_rfs__rfs__backbone_interface__dynstate):
+        params.update_dynstate(dynstate.to_gdata() if dynstate is not None else None)
+    act = respnet.rfs.BBInterfaceTransform(update_dynstate_type_wrapper, ttt.expect(params.dev, "Missing expected DeviceMgr param to respnet.rfs.BBInterfaceTransform."))
+    return proc lambda c, m: act.on_conf(orchestron_rfs__rfs__backbone_interface_entry.from_gdata(c), orchestron_rfs__rfs__backbone_interface__memory.from_gdata(m) if m is not None else None)


### PR DESCRIPTION
TTT remains decoupled from transform adata wrappers. With this refactoring we can convert dynstate adata -> gdata with gen3 parser without threading the schema into TTT.