### PR TITLE
Add a required ?u64 parameter annotation

### DIFF
--- a/src/orchestron/device.act
+++ b/src/orchestron/device.act
@@ -548,7 +548,7 @@ actor DeviceMgr(dev_types: dict[str, DeviceType]={}, wcap: ?WorldCap=None, name:
         _log.debug("Modset updated", {"new_modset": new_modset})
         on_reconf(name)
 
-    def on_connect(new_modset: dict[str, ModCap], new_schema_hash):
+    def on_connect(new_modset: dict[str, ModCap], new_schema_hash: ?u64):
         _log.debug("Device connected", {"new_modset": new_modset, "new_schema_hash": new_schema_hash})
         resync()
         if modset_eq(modset, new_modset):


### PR DESCRIPTION
Without it there's nothing in the surrounding group of declarations that suggests the parameter should be anything else than a plain u64. However, another group of declarations further down in the module relies on the parameter being an optional, hence the need for an annotation. The code just happened to work before because of a quirk in the constraint solver.