### PR TITLE
Generate app.layers.schema_for_layer function

### DIFF
--- a/minisys/src/mini.act
+++ b/minisys/src/mini.act
@@ -16,18 +16,9 @@ import yang.json
 import yang.xml
 
 import mini.layers
-import mini.layers.y_0_loose as cfs_layer
 import mini.layers.y_0
-import mini.layers.y_1
-import mini.layers.y_2
-
-import mini.layers.y_0_loose
-import mini.layers.y_1_loose
-import mini.layers.y_2_loose
 
 import mini.sysspec
-
-import testing
 
 class Unreachable(Exception):
     """Exception raised when code is unreachable."""
@@ -45,16 +36,6 @@ def rfs_for_device(dev):
             })
         ])
     })
-
-def schema_for_layer(layer):
-    if layer == 0:
-        return mini.layers.y_0_loose.SRC_DNODE
-    elif layer == 1:
-        return mini.layers.y_1_loose.SRC_DNODE
-    elif layer == 2:
-        return mini.layers.y_2_loose.SRC_DNODE
-    else:
-        raise ValueError("Invalid layer: {layer}")
 
 actor main(env):
     rfcap = file.ReadFileCap(file.FileCap(env.cap))
@@ -433,7 +414,7 @@ actor main(env):
                     if request.headers.get("accept") == "application/yang-data+xml":
                         content = layer_config.to_xmlstr()
                     if request.headers.get("accept") == "application/yang-data+acton-adata":
-                        src_dnode = schema_for_layer(layer_idx)
+                        src_dnode = mini.layers.schema_for_layer(layer_idx)
                         content = yang.data.pradata(src_dnode, layer_config, loose=True)
                     respond(200, {}, content)
                     return

--- a/minisys/src/mini/layers.act
+++ b/minisys/src/mini/layers.act
@@ -10,10 +10,29 @@ import yang.adata
 import yang.gdata
 
 import mini.layers.t_2
+import mini.layers.y_2
 import mini.layers.t_1
+import mini.layers.y_1
 import mini.layers.t_0
+import mini.layers.y_0
+
 def get_layers(dev_registry: odev.DeviceRegistry, log_handler: ?logging.Handler=None):
     layer2 = ttt.Layer('2', mini.layers.t_2.get_ttt(None, dev_registry, log_handler), None)
     layer1 = ttt.Layer('1', mini.layers.t_1.get_ttt(layer2, dev_registry, log_handler), layer2)
     layer0 = ttt.Layer('0', mini.layers.t_0.get_ttt(layer1, dev_registry, log_handler), layer1)
     return layer0
+
+def schema_for_layer(layer):
+    if layer == 2:
+        # Layer 2 is a bit special, in that there is more than one schema:
+        # 1. The device manager, defined in orchestron-device.yang
+        # 2. The device configuration, defined in the devices own YANG models
+        # and selected with the chosen device type.
+        # The contents of layer 2 (gdata) is a combination of both, here we
+        # return the device manager tree.
+        return mini.layers.y_2.SRC_DNODE
+    if layer == 1:
+        return mini.layers.y_1.SRC_DNODE
+    if layer == 0:
+        return mini.layers.y_0.SRC_DNODE
+    raise ValueError('Invalid layer: {layer}')

--- a/src/orchestron/build.act
+++ b/src/orchestron/build.act
@@ -67,27 +67,21 @@ class CompiledSysSpec(object):
         tttsrc += "import yang.adata\n"
         tttsrc += "import yang.gdata\n\n"
         tttsrc_getlayers = "def get_layers(dev_registry: odev.DeviceRegistry, log_handler: ?logging.Handler=None):\n"
-        # for idx, layer in reversed(enumerate(self.layers)):
-        layers_len = len(self.layers)
-        idx = layers_len
-        for layer in reversed(self.layers):
-            idx -= 1
+        tttsrc_schema_for_layer = "def schema_for_layer(layer):\n"
+        for (idx, layer) in reversed(list(enumerate(self.layers))):
             print(f"Generating layer {idx}")
             layer_name = layer.name
             lname = layer_name if layer_name is not None else str(idx)
-            name = f"{output_dir}/{self.name}/layers/y_{lname}.act"
+            y_name = f"{output_dir}/{self.name}/layers/y_{lname}.act"
             modname = f"{self.name}.layers.y_{lname}"
-    #        if idx == 0:
-    #            name = "src/y_cfs.act"
-    #        elif idx == len(layers) - 1:
-    #            name = "src/y_rfs.act"
 
-            if _maybe_write_file(fc, name, layer.print()):
+            if _maybe_write_file(fc, y_name, layer.print()):
                 print(f"+ Layer {idx} adata changed")
             else:
                 print(f"+ Layer {idx} adata unchanged")
 
             tttsrc += f"import {self.name}.layers.t_{idx}\n"
+            tttsrc += f"import {self.name}.layers.y_{idx}\n"
             print(f"Generating base & TTT(?) for layer {idx}")
 
             # Not for the last layer
@@ -109,8 +103,19 @@ class CompiledSysSpec(object):
             else:
                 print(f"+ Layer {idx} TTT(?) unchanged")
 
-            lowerlayer = f"layer{idx+1}" if idx < layers_len -1 else "None"
+            lowerlayer = f"layer{idx+1}" if idx < len(self.layers) - 1 else "None"
             tttsrc_getlayers += f"    layer{idx} = ttt.Layer('{lname}', {self.name}.layers.t_{idx}.get_ttt({lowerlayer}, dev_registry, log_handler), {lowerlayer})\n"
+            tttsrc_schema_for_layer += "    if layer == {idx}:\n"
+            if idx == len(self.layers) - 1:
+                tttsrc_schema_for_layer += """        # Layer {idx} is a bit special, in that there is more than one schema:
+        # 1. The device manager, defined in orchestron-device.yang
+        # 2. The device configuration, defined in the devices own YANG models
+        # and selected with the chosen device type.
+        # The contents of layer {idx} (gdata) is a combination of both, here we
+        # return the device manager tree.
+"""
+
+            tttsrc_schema_for_layer += "        return {self.name}.layers.y_{idx}.SRC_DNODE\n"
 
             loose_name = f"{output_dir}/{self.name}/layers/y_{idx}_loose.act"
             if _maybe_write_file(fc, loose_name, layer.print(loose=True)):
@@ -146,7 +151,9 @@ class CompiledSysSpec(object):
 
         print("Generating app layers.act")
         tttsrc_getlayers += "    return layer0\n"
-        tttsrc += tttsrc_getlayers
+        tttsrc_schema_for_layer += "    raise ValueError('Invalid layer: {{layer}}')"
+        tttsrc += "\n{tttsrc_getlayers}"
+        tttsrc += "\n{tttsrc_schema_for_layer}"
         if _maybe_write_file(fc, f"{output_dir}/{self.name}/layers.act", tttsrc):
             print("+ App layers.act changed")
         else:


### PR DESCRIPTION
The helper function maps the layer index to the compiled schema for that layer. This is then used to convert the layer gdata to adata (other gdata outputs do not require schema).

This is a small step towards a more composable application - previously this function was defined manually for each application. As a neat side effect it also significantly reduces the compile time for _sorespo.act_ from 24s to 11s, with only a small increase for _sorespo/layers.act_ from 0.08s to 1s.

@plajjan is `app/layers.act` module the right location for this?