### PR TITLE
Refactor subscriptions

### DIFF
--- a/Build.act
+++ b/Build.act
@@ -23,8 +23,8 @@ dependencies = {
     ),
     "yang": (
         repo_url="https://github.com/orchestron-orchestrator/acton-yang.git",
-        url="https://github.com/orchestron-orchestrator/acton-yang/archive/97c82cc8937eda9633dcf41eb46ff44a8fac557b.zip",
-        hash="N-V-__8AAGL-IgBo7MaEn9msx-pFYZzI-J6clRZsep9f-Xcz"
+        url="https://github.com/orchestron-orchestrator/acton-yang/archive/cb25e786ac31afa2520d1f52ab8e52ee9f98e2da.zip",
+        hash="N-V-__8AAMDuIgBOq_U5TMaEqanFuY57a_Va1OhydoclDkCK"
     )
 }
 zig_dependencies = {}

--- a/docs/subscriptions.md
+++ b/docs/subscriptions.md
@@ -1,0 +1,146 @@
+# Subscriptions
+
+Subscriptions are declared as a `set[yang.gdata.SubscriptionSpec]` and
+reconciled by `yang.gdata.SubscriptionManager`.
+
+`SubscriptionManager` is the owner-scoped declarative API. It binds:
+
+- one `TreeProvider`
+- one stable owner id
+- one update callback
+
+The callback receives one merged gdata tree for that owner.
+
+The public shape is intentionally small:
+
+```acton
+subs = yang.gdata.SubscriptionManager(
+    dev.tree_provider(),
+    "base-config",
+    on_state,
+)
+
+want = set([
+    yang.gdata.SubscriptionSpec(_system_state_filter(), period=0.05)
+])
+
+subs.declare(want)
+```
+
+## `SubscriptionSpec`
+
+`SubscriptionSpec` contains:
+
+- `filt: ?FNode`
+- `period: ?u64`
+
+There is no explicit subscription mode. The behavior is inferred from
+`period`:
+
+- `period is None`: on-change subscription
+- `period is not None`: periodic subscription
+
+Internally, `period` is normalized to nanoseconds and stored as `?u64`. gNMI
+uses nanoseconds, so we can express that granularity natively.
+
+## Accepted `period` input
+
+The constructor accepts:
+
+- `float`: interpreted as seconds
+- `u64`: interpreted as nanoseconds
+- `int`: interpreted as nanoseconds
+- `None`
+
+Any other type raises `ValueError`.
+
+Examples:
+
+```acton
+# Periodic, 50 ms
+yang.gdata.SubscriptionSpec(filt, period=0.05)
+
+# Periodic, 50,000,000 ns
+yang.gdata.SubscriptionSpec(filt, period=u64(50000000))
+yang.gdata.SubscriptionSpec(filt, period=50000000)
+
+# On-change
+yang.gdata.SubscriptionSpec(filt)
+```
+
+The recommended style is to use `float` seconds for readability unless
+you specifically want to work in raw nanoseconds.
+
+## Declaration Model
+
+`SubscriptionManager` owns one logical subscriber. Each `declare(...)`
+call describes the full desired subscription set for that owner.
+
+- unchanged declarations are a no-op
+- removed subscriptions are removed automatically
+- added subscriptions are created automatically
+
+The update callback receives one merged gdata tree for the owner, not
+one callback per subscription.
+
+## Current NETCONF Limitation
+
+The current `NetconfDriver` only implements periodic subscriptions by
+issuing periodic `<get>` operations. On-change subscriptions are not yet
+implemented there, so a `SubscriptionSpec` with `period=None` will be
+rejected by that driver.
+
+## Internal Model
+
+`SubscriptionManager` is the declarative owner-facing API. Internally,
+Orchestron splits subscriptions into two layers:
+
+- `SubscriptionOwner`: one logical subscriber with one callback and one
+  desired `set[SubscriptionSpec]`
+- `SharedSubscription`: one physical device subscription keyed by the
+  canonical `SubscriptionSpec` and shared by one or more owners
+
+This means two transforms can declare the same `SubscriptionSpec` and
+the device layer will only keep one physical poll running. Each
+`SharedSubscription` tracks its current `latest` subtree and the set of
+owner ids that depend on it.
+
+Each `declare(...)` call is treated as the owner's complete desired
+state. The device layer diffs the previous and new sets, removes dropped
+specs from the owner's membership, creates newly needed shared
+subscriptions, and reuses unchanged ones. The owner does not manage
+handles or explicit cancellation.
+
+## Merged Tree Delivery
+
+The owner callback receives one merged operational tree rather than one
+callback per subscription. Internally, `_merge_subscription_tree(...)`
+walks the owner's desired `SubscriptionSpec` set, looks up the latest
+subtree for each active shared subscription, and patches those subtrees
+together into one gdata tree.
+
+The merge order is made deterministic by sorting the owner's spec set
+before merging. This avoids depending on set iteration order when
+combining overlapping subtrees.
+
+Today the merge starts from an empty `Container({})` and repeatedly
+applies `yang.gdata.patch(...)` for each available subtree. There is a
+TODO in `yang.gdata.patch(...)` to accept `None` as the empty base so
+callers do not need to synthesize that root container.
+
+## Change Detection And Snapshots
+
+After building the merged tree, the device layer compares it to the
+owner's previously delivered merged tree. If the merged tree changed, or
+if an error is being reported, the callback is invoked.
+
+The cached previous tree is currently stored as a detached snapshot, not
+as a direct reference to the last merged tree. The reason is that
+`yang.gdata.Node` is not yet a truly immutable persistent tree. Patch
+and merge operations can still reuse mutable internals, so retaining an
+older tree by reference is not a safe snapshot boundary.
+
+The current workaround is to snapshot the merged tree before caching it.
+That is intentionally conservative. The longer-term fix is to make
+`yang.gdata.Node` properly immutable, likely with Merkle-style structure
+sharing and cheap change detection, so this extra snapshot can go away.

--- a/minisys/src/mini/devices/ietf.act
+++ b/minisys/src/mini/devices/ietf.act
@@ -11425,7 +11425,6 @@ class ietf_system__set_current_datetime__input(yang.adata.MNode):
 
 
 actor rpc_root(tp: yang.gdata.TreeProvider):
-    var tree: ?yang.gdata.Node = root().to_gdata()
     def set_current_datetime(cb: action(?Exception) -> None, inp: ietf_system__set_current_datetime__input):
         rpc_xml = xml.Node('set-current-datetime', nsdefs=[(None, 'urn:ietf:params:xml:ns:yang:ietf-system')])
         if inp is not None:
@@ -11440,27 +11439,5 @@ actor rpc_root(tp: yang.gdata.TreeProvider):
     def system_shutdown(cb: action(?Exception) -> None):
         rpc_xml = xml.Node('system-shutdown', nsdefs=[(None, 'urn:ietf:params:xml:ns:yang:ietf-system')])
         tp.rpc_xml(lambda _, err: cb(err), rpc_xml)
-
-    def subscribe(cb: action(?root, ?Exception) -> None, filt: ?yang.gdata.FNode, opts: yang.gdata.SubscriptionOpts) -> yang.gdata.SubscriptionHandle:
-        def cb_wrap(n: ?yang.gdata.Node, err: ?Exception):
-            if n is not None:
-                prev = tree
-                # TODO: fix yang.gdata.patch() to accept None as old tree
-                base = prev if prev is not None else yang.gdata.Container({})
-                tree2 = yang.gdata.patch(base, n)
-
-                if tree2 is not None:
-                    d = yang.gdata.diff(prev, tree2)
-                    if d is not None:
-                        cb(root.from_gdata(tree2), err)
-                    tree = tree2
-                else:
-                    if prev is not None:
-                        cb(root.from_gdata(None), err)
-                    tree = None
-            else:
-                cb(None, err)
-
-        return tp.subscribe(cb_wrap, filt, opts)
 
 

--- a/minisys/src/mini/rfs.act
+++ b/minisys/src/mini/rfs.act
@@ -18,9 +18,6 @@ NS_IETF_SYSTEM = "urn:ietf:params:xml:ns:yang:ietf-system"
 def _q_sys(name: str) -> gdata.Id:
     return gdata.Id(NS_IETF_SYSTEM, name)
 
-def _ms_to_ns(ms: u64) -> u64:
-    return ms * 1000 * 1000
-
 def unwrap[T](t: ?T) -> T:
     if t is not None:
         return t
@@ -42,23 +39,22 @@ class BaseConfig(base.BaseConfig):
         raise UnsupportedDevice()
 
 actor BaseConfigTransform(update_dynstate: proc(?BaseConfigDynstate)->None, dev: odev.DeviceMgr):
-    var handle: ?yang.gdata.SubscriptionHandle = None
     var dynstate = base.BaseConfig.dynstate_type()()
 
-    def on_update(t: ?ietf_root, err: ?Exception):
+    def on_state(t: ?yang.gdata.Node, err: ?Exception):
         if err is not None:
             print("BaseConfigTransform subscription error: {err}", err=True)
             return
-        dynstate.current_datetime = t?.system_state?.clock?.current_datetime
+        root = ietf_root.from_gdata(t)
+        dynstate.current_datetime = root?.system_state?.clock?.current_datetime
         update_dynstate(dynstate)
 
+    var subs = gdata.SubscriptionManager(dev.tree_provider(), "base-config", on_state)
+
     def on_conf(conf: y1.stratoweave_rfs__rfs__base_config):
-        if handle is not None:
-            return
-        opts = yang.gdata.SubscriptionOpts(yang.gdata.SUB_PERIODIC, period=_ms_to_ns(u64(10)))
-        tp = dev.tree_provider()
-        # TODO: how to pick ietf_dev.rpc_root?? got to look at di.modules, right?
-        handle = ietf_dev.rpc_root(tp).subscribe(on_update, _system_state_filter(), opts)
+        want = set()
+        want.add(gdata.SubscriptionSpec(_system_state_filter(), period=0.01))
+        subs.declare(want)
 
 def _system_state_filter() -> gdata.FNode:
     return gdata.FNode(None, None, [

--- a/src/orchestron/device.act
+++ b/src/orchestron/device.act
@@ -380,18 +380,32 @@ class LogItem():
         self.event = event
         self.conf_diff = conf_diff
 
-class Subscription(object):
-    @property
-    cb: action(?yang.gdata.Node, ?Exception) -> None
-    filt: ?yang.gdata.FNode
-    opts: yang.gdata.SubscriptionOpts
+class SharedSubscription(object):
+    """One physical device subscription shared by one or more owners."""
+    spec: yang.gdata.SubscriptionSpec
+    latest: ?yang.gdata.Node
+    owners: set[str]
     active: bool
 
-    def __init__(self, cb, filt, opts):
-        self.cb = cb
-        self.filt = filt
-        self.opts = opts
+    def __init__(self, spec: yang.gdata.SubscriptionSpec):
+        self.spec = yang.gdata.SubscriptionSpec(spec.filt, period=spec.period)
+        self.latest = None
+        self.owners = set()
         self.active = True
+
+
+class SubscriptionOwner(object):
+    """One declarative subscriber with its desired specs and merged state."""
+    @property
+    cb: action(?yang.gdata.Node, ?Exception) -> None
+    want: set[yang.gdata.SubscriptionSpec]
+    last_merged: ?yang.gdata.Node
+
+    def __init__(self, cb: action(?yang.gdata.Node, ?Exception) -> None, want: set[yang.gdata.SubscriptionSpec], last_merged: ?yang.gdata.Node=None):
+        self.cb = cb
+        self.want = set(want)
+        self.last_merged = last_merged
+
 
 class DeviceTreeProvider(yang.gdata.TreeProvider):
     dev: DeviceMgr
@@ -407,8 +421,11 @@ class DeviceTreeProvider(yang.gdata.TreeProvider):
         pass
         # self.dev.rpc(cb, rpc_input)
 
-    proc def subscribe(self, cb: action(?yang.gdata.Node, ?Exception) -> None, filt: ?yang.gdata.FNode, opts: yang.gdata.SubscriptionOpts) -> yang.gdata.SubscriptionHandle:
-        return self.dev.subscribe(cb, filt, opts)
+    proc def declare_subscriptions(self, owner_id: str, cb: action(?yang.gdata.Node, ?Exception) -> None, want: set[yang.gdata.SubscriptionSpec]):
+        self.dev.declare_subscriptions(owner_id, cb, want)
+
+    proc def remove_subscriptions(self, owner_id: str):
+        self.dev.remove_subscriptions(owner_id)
 
 
 
@@ -968,8 +985,11 @@ actor DeviceMgr(dev_types: dict[str, DeviceType]={}, pcap: ?process.ProcessCap=N
     def rpc_xml(cb: action(?xml.Node, ?Exception) -> None, xml_rpc: xml.Node):
         adapter.rpc_xml(cb, xml_rpc)
 
-    def subscribe(cb: action(?yang.gdata.Node, ?Exception) -> None, filt: ?yang.gdata.FNode, opts: yang.gdata.SubscriptionOpts) -> yang.gdata.SubscriptionHandle:
-        return adapter.subscribe(cb, filt, opts)
+    def declare_subscriptions(owner_id: str, cb: action(?yang.gdata.Node, ?Exception) -> None, want: set[yang.gdata.SubscriptionSpec]):
+        adapter.declare_subscriptions(owner_id, cb, want)
+
+    def remove_subscriptions(owner_id: str):
+        adapter.remove_subscriptions(owner_id)
 
     def tree_provider() -> yang.gdata.TreeProvider:
         return DeviceTreeProvider(self)
@@ -1081,7 +1101,8 @@ class DeviceAdapter(object):
 
     rpc_xml: proc(cb: action(?xml.Node, ?Exception) -> None, xml_rpc: xml.Node) -> None
 
-    subscribe: proc(action(?yang.gdata.Node, ?Exception) -> None, ?yang.gdata.FNode, yang.gdata.SubscriptionOpts) -> yang.gdata.SubscriptionHandle
+    declare_subscriptions: proc(str, action(?yang.gdata.Node, ?Exception) -> None, set[yang.gdata.SubscriptionSpec]) -> None
+    remove_subscriptions: proc(str) -> None
 
 
 class NoAdapter(DeviceAdapter):
@@ -1115,9 +1136,11 @@ class NoAdapter(DeviceAdapter):
     def rpc_xml(self, cb: action(?xml.Node, ?Exception) -> None, xml_rpc: xml.Node) -> None:
         pass
 
-    def subscribe(self, cb: action(?yang.gdata.Node, ?Exception) -> None, filt: ?yang.gdata.FNode, opts: yang.gdata.SubscriptionOpts) -> yang.gdata.SubscriptionHandle:
+    def declare_subscriptions(self, owner_id: str, cb: action(?yang.gdata.Node, ?Exception) -> None, want: set[yang.gdata.SubscriptionSpec]):
         cb(None, NotConnectedError())
-        return yang.gdata.SubscriptionHandle(0, lambda: None)
+
+    def remove_subscriptions(self, owner_id: str):
+        pass
 
 class MockAdapter(DeviceAdapter):
     """Mock device adapter
@@ -1154,10 +1177,12 @@ class MockAdapter(DeviceAdapter):
     def rpc_xml(self, cb: action(?xml.Node, ?Exception) -> None, xml_rpc: xml.Node) -> None:
         return self._driver.rpc_xml(cb, xml_rpc)
 
-    def subscribe(self, cb: action(?yang.gdata.Node, ?Exception) -> None, filt: ?yang.gdata.FNode, opts: yang.gdata.SubscriptionOpts) -> yang.gdata.SubscriptionHandle:
-        # TODO: can / should subscribe do something on a MockAdapter ?
+    def declare_subscriptions(self, owner_id: str, cb: action(?yang.gdata.Node, ?Exception) -> None, want: set[yang.gdata.SubscriptionSpec]):
+        # TODO: can / should subscriptions do something on a MockAdapter ?
         cb(None, NotConnectedError())
-        return yang.gdata.SubscriptionHandle(0, lambda: None)
+
+    def remove_subscriptions(self, owner_id: str):
+        pass
 
 actor MockDriver(dev: DeviceMgr, bundled_schema: DeviceSchema, log_handler: logging.Handler, pcap: ?process.ProcessCap):
     _log = logging.Logger(log_handler)
@@ -1502,8 +1527,8 @@ actor NetconfDriver(dev: DeviceMgr, bundled_schema: DeviceSchema, init_dmc: Devi
     var modset: dict[str, ModCap] = {}
     var schema_hash = None
 
-    var sub_id_seq = 0
-    var subs: dict[int, Subscription] = {}
+    var subs: dict[yang.gdata.SubscriptionSpec, SharedSubscription] = {}
+    var sub_owners: dict[str, SubscriptionOwner] = {}
 
     NS_NC_1_0 = "urn:ietf:params:xml:ns:netconf:base:1.0"
 
@@ -2192,10 +2217,10 @@ actor NetconfDriver(dev: DeviceMgr, bundled_schema: DeviceSchema, init_dmc: Devi
         if client is not None:
             client.rpc(xml_rpc, rpc_reply)
 
-    def _sub_delay(opts: yang.gdata.SubscriptionOpts) -> float:
+    def _sub_delay(spec: yang.gdata.SubscriptionSpec) -> float:
         def ns_to_s(ns: u64) -> float:
             return float(ns) / 1000000000.0
-        pn = opts.period
+        pn = spec.period
         if pn is not None:
             return ns_to_s(pn)
         return float(1)
@@ -2216,67 +2241,138 @@ actor NetconfDriver(dev: DeviceMgr, bundled_schema: DeviceSchema, init_dmc: Devi
             return yang.xml.from_xml(bundled_schema.src_dnode, data_tag, loose=True)
         return None
 
-    def _sub_cancel(sid: int):
-        if sid in subs:
-            subs[sid].active = False
-            del subs[sid]
+    def _owner_publish(owner_id: str, err: ?Exception=None):
+        def _merge_subscription_tree(want: set[yang.gdata.SubscriptionSpec], active: dict[yang.gdata.SubscriptionSpec, SharedSubscription]) -> ?yang.gdata.Node:
+            merged = None
+            for spec in yang.gdata.hack_sorted(iter(want)):
+                if spec in active:
+                    sub = active[spec]
+                    if sub.latest is not None:
+                        base = merged if merged is not None else yang.gdata.Container({})
+                        merged = yang.gdata.patch(base, sub.latest)
+            return merged
 
-    def _sub_schedule_next(sid: int):
-        if sid not in subs:
+        def _snapshot_subscription_tree(tree: ?yang.gdata.Node) -> ?yang.gdata.Node:
+            # TODO: Remove this snapshot once gdata.Node is truly immutable. Today
+            # patch/merge can reuse mutable internals, so retaining last_merged by
+            # reference is not a safe previous-state cache.
+            if tree is not None:
+                return yang.gdata.Node.from_json(tree.to_json())
+            return None
+
+        if owner_id not in sub_owners:
             return
-        st = subs[sid]
+        owner = sub_owners[owner_id]
+        merged = _merge_subscription_tree(owner.want, subs)
+        if err is not None or merged != owner.last_merged:
+            owner.last_merged = _snapshot_subscription_tree(merged)
+            sub_owners[owner_id] = owner
+            owner.cb(merged, err)
+
+    def _sub_cancel(spec: yang.gdata.SubscriptionSpec):
+        if spec in subs:
+            subs[spec].active = False
+            del subs[spec]
+
+    def _sub_schedule_next(spec: yang.gdata.SubscriptionSpec):
+        if spec not in subs:
+            return
+        st = subs[spec]
         if not st.active:
             return
-        delay = _sub_delay(st.opts)
-        after delay: _sub_tick(sid)
+        delay = _sub_delay(st.spec)
+        after delay: _sub_tick(spec)
 
-    def _sub_tick(sid: int):
-        if sid not in subs:
+    def _sub_tick(spec: yang.gdata.SubscriptionSpec):
+        if spec not in subs:
             return
-        st = subs[sid]
+        st = subs[spec]
         if not st.active:
             return
-        if st.opts.mode != yang.gdata.SUB_PERIODIC:
-            cb = st.cb
-            if cb is not None:
-                cb(None, ValueError("NetconfDriver only supports periodic subscriptions"))
-            _sub_cancel(sid)
+        if st.spec.period is None:
+            err = ValueError("NetconfDriver only supports periodic subscriptions")
+            for owner_id in st.owners:
+                _owner_publish(owner_id, err)
+            _sub_cancel(spec)
             return
 
         def on_get(c: netconf.Client, r: ?xml.Node, error: ?netconf.NetconfError):
-            if sid not in subs:
+            if spec not in subs:
                 return
-            st2 = subs[sid]
+            st2 = subs[spec]
             if not st2.active:
                 return
-            cb = st2.cb
             if error is not None:
-                if cb is not None:
-                    cb(None, error)
+                for owner_id in st2.owners:
+                    _owner_publish(owner_id, error)
             else:
                 parsed = _parse_get_reply(r)
                 if parsed is None:
-                    if cb is not None:
-                        cb(None, ValueError("Unexpected rpc-reply for periodic get"))
+                    err = ValueError("Unexpected rpc-reply for periodic get")
+                    for owner_id in st2.owners:
+                        _owner_publish(owner_id, err)
                 else:
-                    if cb is not None:
-                        cb(parsed, None)
-            _sub_schedule_next(sid)
+                    st2.latest = parsed
+                    subs[spec] = st2
+                    for owner_id in st2.owners:
+                        _owner_publish(owner_id)
+            _sub_schedule_next(spec)
 
         filt_xml = None
-        if st.filt is not None:
-            filt_xml = _build_subtree_filter(yang.gdata.expect(st.filt, "subscription filter"))
+        if st.spec.filt is not None:
+            filt_xml = _build_subtree_filter(yang.gdata.expect(st.spec.filt, "subscription filter"))
         if client is not None:
             client.get(on_get, filt_xml)
         else:
-            _sub_schedule_next(sid)
+            _sub_schedule_next(spec)
 
-    def subscribe(cb: action(?yang.gdata.Node, ?Exception) -> None, filt: ?yang.gdata.FNode, opts: yang.gdata.SubscriptionOpts) -> yang.gdata.SubscriptionHandle:
-        sub_id_seq += 1
-        sid = sub_id_seq
-        subs[sid] = Subscription(cb, filt, opts)
-        _sub_tick(sid)
-        return yang.gdata.SubscriptionHandle(sid, lambda: _sub_cancel(sid))
+    def _add_owner_spec(owner_id: str, spec: yang.gdata.SubscriptionSpec):
+        if spec in subs:
+            st = subs[spec]
+        else:
+            st = SharedSubscription(spec)
+        st.owners.add(owner_id)
+        subs[spec] = st
+        if st.latest is None and len(st.owners) == 1:
+            _sub_tick(spec)
+
+    def _remove_owner_spec(owner_id: str, spec: yang.gdata.SubscriptionSpec):
+        if spec not in subs:
+            return
+        st = subs[spec]
+        st.owners.discard(owner_id)
+        if len(st.owners) == 0:
+            _sub_cancel(spec)
+        else:
+            subs[spec] = st
+
+    def declare_subscriptions(owner_id: str, cb: action(?yang.gdata.Node, ?Exception) -> None, want: set[yang.gdata.SubscriptionSpec]):
+        old_want = set()
+        last_merged = None
+        if owner_id in sub_owners:
+            owner = sub_owners[owner_id]
+            old_want = owner.want
+            last_merged = owner.last_merged
+
+        for spec in old_want:
+            if spec not in want:
+                _remove_owner_spec(owner_id, spec)
+
+        sub_owners[owner_id] = SubscriptionOwner(cb, want, last_merged)
+
+        for spec in want:
+            if spec not in old_want:
+                _add_owner_spec(owner_id, spec)
+
+        _owner_publish(owner_id)
+
+    def remove_subscriptions(owner_id: str):
+        if owner_id not in sub_owners:
+            return
+        old_want = sub_owners[owner_id].want
+        del sub_owners[owner_id]
+        for spec in old_want:
+            _remove_owner_spec(owner_id, spec)
 
     _connect(dmc)
 
@@ -2320,8 +2416,11 @@ class NetconfAdapter(DeviceAdapter):
     def rpc_xml(self, cb: action(?xml.Node, ?Exception) -> None, xml_rpc: xml.Node) -> None:
         return self._driver.rpc_xml(cb, xml_rpc)
 
-    def subscribe(self, cb: action(?yang.gdata.Node, ?Exception) -> None, filt: ?yang.gdata.FNode, opts: yang.gdata.SubscriptionOpts) -> yang.gdata.SubscriptionHandle:
-        return self._driver.subscribe(cb, filt, opts)
+    def declare_subscriptions(self, owner_id: str, cb: action(?yang.gdata.Node, ?Exception) -> None, want: set[yang.gdata.SubscriptionSpec]):
+        self._driver.declare_subscriptions(owner_id, cb, want)
+
+    def remove_subscriptions(self, owner_id: str):
+        self._driver.remove_subscriptions(owner_id)
 
     # TODO: try removing proc. at the time of writing this, it led to crash in CPS
     proc def get_mock_server(self) -> ?NetconfMockServer:

--- a/src/orchestron/test_devicemgr_netconf.act
+++ b/src/orchestron/test_devicemgr_netconf.act
@@ -43,6 +43,16 @@ def _current_datetime_filter() -> yang.gdata.FNode:
         ])
     ])
 
+def _boot_datetime_filter() -> yang.gdata.FNode:
+    """Filter matching only system-state/clock/boot-datetime."""
+    return yang.gdata.FNode(None, None, [
+        yang.gdata.FNode(_q("system-state"), children=[
+            yang.gdata.FNode(_q("clock"), children=[
+                yang.gdata.FNode(_q("boot-datetime"))
+            ])
+        ])
+    ])
+
 def _current_datetime_from_tree(n: ?yang.gdata.Node) -> ?str:
     if n is not None and isinstance(n, yang.gdata.Container):
         sys_state = n.get_opt_cnt(_q("system-state"))
@@ -157,7 +167,7 @@ actor _test_subscribe_periodic(t: testing.EnvT):
     2. Seed the mock server oper datastore with system-state/clock (both datetimes).
     3. Start a periodic subtree subscription that selects only system-state/clock/current-datetime.
     4. On the first update, validate current-datetime (and absence of boot-datetime), then mutate the mock oper datastore once.
-    5. On the second update, validate the new current-datetime and cancel the subscription.
+    5. On the second update, validate the new current-datetime and remove the owner declaration.
     6. Fail fast via a short timeout if updates never arrive.
     """
     mock_current_datetime_1 = "2026-02-21T10:11:12Z"
@@ -166,7 +176,6 @@ actor _test_subscribe_periodic(t: testing.EnvT):
 
     var updates = 0
     var done = False
-    var handle: ?yang.gdata.SubscriptionHandle = None
     var mock_server: ?orchestron.device.NetconfMockServer = None
 
     def noop_on_reconf(name: str):
@@ -213,8 +222,7 @@ actor _test_subscribe_periodic(t: testing.EnvT):
             if dt != mock_current_datetime_2:
                 fail("Unexpected second datetime: {dt}")
                 return
-            if handle is not None:
-                handle.cancel()
+            dev.remove_subscriptions("test-subscribe-periodic")
             succeed()
         else:
             fail("Unexpected extra subscription update: {updates}")
@@ -225,8 +233,8 @@ actor _test_subscribe_periodic(t: testing.EnvT):
             mock_server = adapter.get_mock_server()
             if mock_server is not None:
                 mock_server.set_oper_ds(_mock_oper_ds(mock_current_datetime_1, mock_boot_datetime))
-                opts = yang.gdata.SubscriptionOpts(yang.gdata.SUB_PERIODIC, period=u64(50000000))
-                handle = dev.subscribe(on_update, _current_datetime_filter(), opts)
+                want = set([yang.gdata.SubscriptionSpec(_current_datetime_filter(), period=0.05)])
+                dev.declare_subscriptions("test-subscribe-periodic", on_update, want)
             else:
                 fail("Expected NetconfMockServer from NetconfAdapter")
                 return
@@ -236,3 +244,169 @@ actor _test_subscribe_periodic(t: testing.EnvT):
     start()
 
     after 0.5: fail("Timed out waiting for periodic subscription updates")
+
+
+actor _test_subscription_manager_declare(t: testing.EnvT):
+    """Declarative subscription manager over NETCONF mock subscriptions."""
+    mock_current_datetime_1 = "2026-02-21T10:11:12Z"
+    mock_current_datetime_2 = "2026-02-21T10:11:13Z"
+    mock_boot_datetime = "2025-12-31T00:00:00Z"
+
+    var done = False
+    var phase = 0
+    var mock_server: ?orchestron.device.NetconfMockServer = None
+    var subs: ?yang.gdata.SubscriptionManager = None
+
+    def noop_on_reconf(name: str):
+        pass
+    dev = new_netconf_mock_device_mgr(t, "dev-subs", noop_on_reconf)
+
+    def close_subs():
+        if subs is not None:
+            subs.close()
+
+    def fail(msg: str):
+        if done:
+            return
+        done = True
+        close_subs()
+        t.failure(ValueError(msg))
+
+    def succeed():
+        if done:
+            return
+        done = True
+        close_subs()
+        t.success()
+
+    def declare_both():
+        want = set([
+            yang.gdata.SubscriptionSpec(_current_datetime_filter(), period=0.05),
+            yang.gdata.SubscriptionSpec(_boot_datetime_filter(), period=0.05)
+        ])
+        yang.gdata.expect(subs, "subscription manager").declare(want)
+
+    def declare_current_only():
+        want = set([yang.gdata.SubscriptionSpec(_current_datetime_filter(), period=0.05)])
+        yang.gdata.expect(subs, "subscription manager").declare(want)
+
+    def on_update(n: ?yang.gdata.Node, err: ?Exception):
+        if done:
+            return
+        if err is not None:
+            fail("Subscription manager update error: {err}")
+            return
+
+        dt = _current_datetime_from_tree(n)
+        has_boot = _has_boot_datetime(n)
+
+        if phase == 0 and dt == mock_current_datetime_1 and has_boot:
+            phase = 1
+            declare_current_only()
+            return
+
+        if phase == 1 and dt == mock_current_datetime_1 and not has_boot:
+            phase = 2
+            yang.gdata.expect(mock_server, "mock server").set_oper_ds(_mock_oper_ds(mock_current_datetime_2, mock_boot_datetime))
+            return
+
+        if phase == 2 and dt == mock_current_datetime_2 and not has_boot:
+            succeed()
+            return
+
+    def start():
+        adapter = dev.get_adapter()
+        if isinstance(adapter, orchestron.device.NetconfAdapter):
+            ms0 = adapter.get_mock_server()
+            if ms0 is None:
+                fail("Expected NetconfMockServer from NetconfAdapter")
+                return
+            ms = yang.gdata.expect(ms0, "mock server")
+            mock_server = ms
+            ms.set_oper_ds(_mock_oper_ds(mock_current_datetime_1, mock_boot_datetime))
+            subs = yang.gdata.SubscriptionManager(dev.tree_provider(), "test-subscription-manager", on_update)
+            declare_both()
+        else:
+            fail("Expected NetconfAdapter from DeviceMgr")
+
+    start()
+
+    after 0.5: fail("Timed out waiting for declarative subscription manager updates")
+
+
+actor _test_subscription_manager_idempotent(t: testing.EnvT):
+    """Redeclaring the same subscriptions is a no-op."""
+    mock_current_datetime = "2026-02-21T10:11:12Z"
+    mock_boot_datetime = "2025-12-31T00:00:00Z"
+
+    var done = False
+    var updates = 0
+    var subs: ?yang.gdata.SubscriptionManager = None
+
+    def noop_on_reconf(name: str):
+        pass
+    dev = new_netconf_mock_device_mgr(t, "dev-subs-idempotent", noop_on_reconf)
+
+    def close_subs():
+        if subs is not None:
+            subs.close()
+
+    def fail(msg: str):
+        if done:
+            return
+        done = True
+        close_subs()
+        t.failure(ValueError(msg))
+
+    def succeed():
+        if done:
+            return
+        done = True
+        close_subs()
+        t.success()
+
+    def declare_current_only():
+        want = set([yang.gdata.SubscriptionSpec(_current_datetime_filter(), period=0.05)])
+        yang.gdata.expect(subs, "subscription manager").declare(want)
+
+    def on_update(n: ?yang.gdata.Node, err: ?Exception):
+        if done:
+            return
+        if err is not None:
+            fail("Subscription manager update error: {err}")
+            return
+
+        updates += 1
+        if updates > 1:
+            fail("Unexpected extra subscription update: {updates}")
+            return
+
+        dt = _current_datetime_from_tree(n)
+        has_boot = _has_boot_datetime(n)
+        if dt != mock_current_datetime:
+            fail("Unexpected current datetime: {dt}")
+            return
+        if has_boot:
+            fail("Unexpected boot datetime in filtered update")
+            return
+
+        declare_current_only()
+        after 0.15: succeed()
+
+    def start():
+        adapter = dev.get_adapter()
+        if isinstance(adapter, orchestron.device.NetconfAdapter):
+            ms0 = adapter.get_mock_server()
+            if ms0 is None:
+                fail("Expected NetconfMockServer from NetconfAdapter")
+                return
+            ms = yang.gdata.expect(ms0, "mock server")
+            ms.set_oper_ds(_mock_oper_ds(mock_current_datetime, mock_boot_datetime))
+            subs = yang.gdata.SubscriptionManager(dev.tree_provider(), "test-subscription-manager-idempotent", on_update)
+            declare_current_only()
+        else:
+            fail("Expected NetconfAdapter from DeviceMgr")
+
+    start()
+
+    after 0.5: fail("Timed out waiting for idempotent subscription manager test")


### PR DESCRIPTION
The old subscription path was imperative and handle-driven. Callers subscribed one entry at a time, updates were awkward to reconcile, and the minisys example had to short-circuit repeated on_conf calls instead of expressing the desired subscription set declaratively.

This switches StratoWeave to the owner-scoped subscription API from acton-yang. DeviceMgr and the adapters now declare whole sets of SubscriptionSpec values, share physical polls by spec, merge the latest subtrees for each owner into one delivered tree, and only republish when that merged view changes. Minisys now declares its desired subscriptions through SubscriptionManager, the yang dependency is updated to the merged API, and the new subscriptions document explains both the public surface and the current internal behavior.

That matches the longer-lived nature of subscriptions better than the old rpc_root handle flow. Owners can rebuild their desired subscription state on each config update, equivalent polls are shared underneath, and the resulting delivery model is explicit enough to reason about and extend.