### PR TITLE
Filter out dynstate / memory attributes in adata 

### DIFF
--- a/Build.act
+++ b/Build.act
@@ -3,8 +3,8 @@ fingerprint = 0xe602cd36fdb33ec8
 dependencies = {
     "actmf": (
         repo_url="https://github.com/stratoweave/actmf",
-        url="https://github.com/stratoweave/actmf/archive/837db6a1299d45d79ebf5956a2a3cbdcb2e83ef6.zip",
-        hash="N-V-__8AANBzBQDlWPuy9fHz0q53hyALPI7LA8S3e7_HTMPO"
+        url="https://github.com/stratoweave/actmf/archive/3fe2ff41024ca10db5eba5e3596ca791c263019f.zip",
+        hash="N-V-__8AANBzBQBxV-D5V4O7nn4wHsT2sXBBprs9KaPTpi5T"
     ),
     "http_router": (
         repo_url="https://github.com/stratoweave/http-router.git",
@@ -23,8 +23,8 @@ dependencies = {
     ),
     "yang": (
         repo_url="https://github.com/stratoweave/acton-yang.git",
-        url="https://github.com/stratoweave/acton-yang/archive/c22b2ee50df1319131facd1dc8d65aba55350ceb.zip",
-        hash="N-V-__8AADP4IgAxw_PtFSYYZqueDc6sTeXBLjWdEF-RkJnE"
+        url="https://github.com/stratoweave/acton-yang/archive/95ce4ae083a3920a98f6f984c91bd3d09f556231.zip",
+        hash="N-V-__8AADv1IgCnOSwFc0GTl0aUtxRAgC-Cs46To6-U5G-k"
     )
 }
 zig_dependencies = {}

--- a/gen_dmc/Build.act
+++ b/gen_dmc/Build.act
@@ -3,8 +3,8 @@ fingerprint = 0x056275683c869ace
 dependencies = {
     "yang": (
         repo_url="https://github.com/stratoweave/acton-yang.git",
-        url="https://github.com/stratoweave/acton-yang/archive/c22b2ee50df1319131facd1dc8d65aba55350ceb.zip",
-        hash="N-V-__8AADP4IgAxw_PtFSYYZqueDc6sTeXBLjWdEF-RkJnE"
+        url="https://github.com/stratoweave/acton-yang/archive/95ce4ae083a3920a98f6f984c91bd3d09f556231.zip",
+        hash="N-V-__8AADv1IgCnOSwFc0GTl0aUtxRAgC-Cs46To6-U5G-k"
     )
 }
 zig_dependencies = {}

--- a/minisys/src/mini/devices/ietf.act
+++ b/minisys/src/mini/devices/ietf.act
@@ -8720,7 +8720,7 @@ NS_ietf_system = 'urn:ietf:params:xml:ns:yang:ietf-system'
 NS_ietf_yang_types = 'urn:ietf:params:xml:ns:yang:ietf-yang-types'
 
 
-_breaker = 1
+_breaker1 = None
 class ietf_netconf_acm__nacm__groups__group_entry(yang.adata.MNode):
     name: str
     user_name: list[str]
@@ -8735,7 +8735,6 @@ class ietf_netconf_acm__nacm__groups__group_entry(yang.adata.MNode):
             return self.name
         if name == 'user_name':
             return self.user_name
-        raise ValueError('Attribute {name} not found in ietf_netconf_acm__nacm__groups__group')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=True, root_path=['ietf-netconf-acm:nacm', 'groups', 'group'])
@@ -8748,7 +8747,7 @@ class ietf_netconf_acm__nacm__groups__group_entry(yang.adata.MNode):
         """Create a deep copy of this adata object"""
         return ietf_netconf_acm__nacm__groups__group_entry.from_gdata(self.to_gdata())
 
-_breaker = 1
+_breaker2 = None
 class ietf_netconf_acm__nacm__groups__group(yang.adata.MNode):
     elements: list[ietf_netconf_acm__nacm__groups__group_entry]
     mut def __init__(self, elements=[]):
@@ -8789,7 +8788,7 @@ extension ietf_netconf_acm__nacm__groups__group(Iterable[ietf_netconf_acm__nacm_
     def __iter__(self) -> Iterator[ietf_netconf_acm__nacm__groups__group_entry]:
         return self.elements.__iter__()
 
-_breaker = 1
+_breaker3 = None
 class ietf_netconf_acm__nacm__groups(yang.adata.MNode):
     group: ietf_netconf_acm__nacm__groups__group
 
@@ -8800,7 +8799,6 @@ class ietf_netconf_acm__nacm__groups(yang.adata.MNode):
     def _get_attr(self, name: str) -> ?value:
         if name == 'group':
             return iter(self.group)
-        raise ValueError('Attribute {name} not found in ietf_netconf_acm__nacm__groups')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=True, root_path=['ietf-netconf-acm:nacm', 'groups'])
@@ -8816,7 +8814,7 @@ class ietf_netconf_acm__nacm__groups(yang.adata.MNode):
         return ietf_netconf_acm__nacm__groups.from_gdata(self.to_gdata())
 
 
-_breaker = 1
+_breaker4 = None
 class ietf_netconf_acm__nacm__rule_list__rule_entry(yang.adata.MNode):
     name: str
     module_name: ?str
@@ -8855,7 +8853,6 @@ class ietf_netconf_acm__nacm__rule_list__rule_entry(yang.adata.MNode):
             return self.action_
         if name == 'comment':
             return self.comment
-        raise ValueError('Attribute {name} not found in ietf_netconf_acm__nacm__rule_list__rule')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=True, root_path=['ietf-netconf-acm:nacm', 'rule-list', 'rule'])
@@ -8868,7 +8865,7 @@ class ietf_netconf_acm__nacm__rule_list__rule_entry(yang.adata.MNode):
         """Create a deep copy of this adata object"""
         return ietf_netconf_acm__nacm__rule_list__rule_entry.from_gdata(self.to_gdata())
 
-_breaker = 1
+_breaker5 = None
 class ietf_netconf_acm__nacm__rule_list__rule(yang.adata.MNode):
     elements: list[ietf_netconf_acm__nacm__rule_list__rule_entry]
     mut def __init__(self, elements=[]):
@@ -8923,7 +8920,7 @@ extension ietf_netconf_acm__nacm__rule_list__rule(Iterable[ietf_netconf_acm__nac
     def __iter__(self) -> Iterator[ietf_netconf_acm__nacm__rule_list__rule_entry]:
         return self.elements.__iter__()
 
-_breaker = 1
+_breaker6 = None
 class ietf_netconf_acm__nacm__rule_list_entry(yang.adata.MNode):
     name: str
     group: list[str]
@@ -8942,7 +8939,6 @@ class ietf_netconf_acm__nacm__rule_list_entry(yang.adata.MNode):
             return self.group
         if name == 'rule':
             return iter(self.rule)
-        raise ValueError('Attribute {name} not found in ietf_netconf_acm__nacm__rule_list')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=True, root_path=['ietf-netconf-acm:nacm', 'rule-list'])
@@ -8955,7 +8951,7 @@ class ietf_netconf_acm__nacm__rule_list_entry(yang.adata.MNode):
         """Create a deep copy of this adata object"""
         return ietf_netconf_acm__nacm__rule_list_entry.from_gdata(self.to_gdata())
 
-_breaker = 1
+_breaker7 = None
 class ietf_netconf_acm__nacm__rule_list(yang.adata.MNode):
     elements: list[ietf_netconf_acm__nacm__rule_list_entry]
     mut def __init__(self, elements=[]):
@@ -8996,7 +8992,7 @@ extension ietf_netconf_acm__nacm__rule_list(Iterable[ietf_netconf_acm__nacm__rul
     def __iter__(self) -> Iterator[ietf_netconf_acm__nacm__rule_list_entry]:
         return self.elements.__iter__()
 
-_breaker = 1
+_breaker8 = None
 class ietf_netconf_acm__nacm(yang.adata.MNode):
     enable_nacm: ?bool
     read_default: ?str
@@ -9043,7 +9039,6 @@ class ietf_netconf_acm__nacm(yang.adata.MNode):
             return self.groups
         if name == 'rule_list':
             return iter(self.rule_list)
-        raise ValueError('Attribute {name} not found in ietf_netconf_acm__nacm')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=True, root_path=['ietf-netconf-acm:nacm'])
@@ -9059,7 +9054,7 @@ class ietf_netconf_acm__nacm(yang.adata.MNode):
         return ietf_netconf_acm__nacm.from_gdata(self.to_gdata())
 
 
-_breaker = 1
+_breaker9 = None
 class ietf_system__system__clock(yang.adata.MNode):
     timezone_name: ?str
     timezone_utc_offset: ?int
@@ -9074,7 +9069,6 @@ class ietf_system__system__clock(yang.adata.MNode):
             return self.timezone_name
         if name == 'timezone_utc_offset':
             return self.timezone_utc_offset
-        raise ValueError('Attribute {name} not found in ietf_system__system__clock')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=True, root_path=['ietf-system:system', 'clock'])
@@ -9090,7 +9084,7 @@ class ietf_system__system__clock(yang.adata.MNode):
         return ietf_system__system__clock.from_gdata(self.to_gdata())
 
 
-_breaker = 1
+_breaker10 = None
 class ietf_system__system__ntp__server__udp(yang.adata.MNode):
     address: ?str
     port: ?u64
@@ -9105,7 +9099,6 @@ class ietf_system__system__ntp__server__udp(yang.adata.MNode):
             return self.address
         if name == 'port':
             return self.port
-        raise ValueError('Attribute {name} not found in ietf_system__system__ntp__server__udp')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=True, root_path=['ietf-system:system', 'ntp', 'server', 'udp'])
@@ -9121,7 +9114,7 @@ class ietf_system__system__ntp__server__udp(yang.adata.MNode):
         return ietf_system__system__ntp__server__udp.from_gdata(self.to_gdata())
 
 
-_breaker = 1
+_breaker11 = None
 class ietf_system__system__ntp__server_entry(yang.adata.MNode):
     name: str
     udp: ietf_system__system__ntp__server__udp
@@ -9148,7 +9141,6 @@ class ietf_system__system__ntp__server_entry(yang.adata.MNode):
             return self.iburst
         if name == 'prefer':
             return self.prefer
-        raise ValueError('Attribute {name} not found in ietf_system__system__ntp__server')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=True, root_path=['ietf-system:system', 'ntp', 'server'])
@@ -9161,7 +9153,7 @@ class ietf_system__system__ntp__server_entry(yang.adata.MNode):
         """Create a deep copy of this adata object"""
         return ietf_system__system__ntp__server_entry.from_gdata(self.to_gdata())
 
-_breaker = 1
+_breaker12 = None
 class ietf_system__system__ntp__server(yang.adata.MNode):
     elements: list[ietf_system__system__ntp__server_entry]
     mut def __init__(self, elements=[]):
@@ -9208,7 +9200,7 @@ extension ietf_system__system__ntp__server(Iterable[ietf_system__system__ntp__se
     def __iter__(self) -> Iterator[ietf_system__system__ntp__server_entry]:
         return self.elements.__iter__()
 
-_breaker = 1
+_breaker13 = None
 class ietf_system__system__ntp(yang.adata.MNode):
     enabled: ?bool
     server: ietf_system__system__ntp__server
@@ -9223,7 +9215,6 @@ class ietf_system__system__ntp(yang.adata.MNode):
             return self.enabled
         if name == 'server':
             return iter(self.server)
-        raise ValueError('Attribute {name} not found in ietf_system__system__ntp')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=True, root_path=['ietf-system:system', 'ntp'])
@@ -9242,7 +9233,7 @@ class ietf_system__system__ntp(yang.adata.MNode):
         raise Exception('Unreachable in ietf_system__system__ntp.copy()')
 
 
-_breaker = 1
+_breaker14 = None
 class ietf_system__system__dns_resolver__server__udp_and_tcp(yang.adata.MNode):
     address: ?str
     port: ?u64
@@ -9257,7 +9248,6 @@ class ietf_system__system__dns_resolver__server__udp_and_tcp(yang.adata.MNode):
             return self.address
         if name == 'port':
             return self.port
-        raise ValueError('Attribute {name} not found in ietf_system__system__dns_resolver__server__udp_and_tcp')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=True, root_path=['ietf-system:system', 'dns-resolver', 'server', 'udp-and-tcp'])
@@ -9273,7 +9263,7 @@ class ietf_system__system__dns_resolver__server__udp_and_tcp(yang.adata.MNode):
         return ietf_system__system__dns_resolver__server__udp_and_tcp.from_gdata(self.to_gdata())
 
 
-_breaker = 1
+_breaker15 = None
 class ietf_system__system__dns_resolver__server_entry(yang.adata.MNode):
     name: str
     udp_and_tcp: ietf_system__system__dns_resolver__server__udp_and_tcp
@@ -9288,7 +9278,6 @@ class ietf_system__system__dns_resolver__server_entry(yang.adata.MNode):
             return self.name
         if name == 'udp_and_tcp':
             return self.udp_and_tcp
-        raise ValueError('Attribute {name} not found in ietf_system__system__dns_resolver__server')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=True, root_path=['ietf-system:system', 'dns-resolver', 'server'])
@@ -9301,7 +9290,7 @@ class ietf_system__system__dns_resolver__server_entry(yang.adata.MNode):
         """Create a deep copy of this adata object"""
         return ietf_system__system__dns_resolver__server_entry.from_gdata(self.to_gdata())
 
-_breaker = 1
+_breaker16 = None
 class ietf_system__system__dns_resolver__server(yang.adata.MNode):
     elements: list[ietf_system__system__dns_resolver__server_entry]
     mut def __init__(self, elements=[]):
@@ -9342,7 +9331,7 @@ extension ietf_system__system__dns_resolver__server(Iterable[ietf_system__system
     def __iter__(self) -> Iterator[ietf_system__system__dns_resolver__server_entry]:
         return self.elements.__iter__()
 
-_breaker = 1
+_breaker17 = None
 class ietf_system__system__dns_resolver__options(yang.adata.MNode):
     timeout: ?u64
     attempts: ?u64
@@ -9357,7 +9346,6 @@ class ietf_system__system__dns_resolver__options(yang.adata.MNode):
             return self.timeout
         if name == 'attempts':
             return self.attempts
-        raise ValueError('Attribute {name} not found in ietf_system__system__dns_resolver__options')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=True, root_path=['ietf-system:system', 'dns-resolver', 'options'])
@@ -9373,7 +9361,7 @@ class ietf_system__system__dns_resolver__options(yang.adata.MNode):
         return ietf_system__system__dns_resolver__options.from_gdata(self.to_gdata())
 
 
-_breaker = 1
+_breaker18 = None
 class ietf_system__system__dns_resolver(yang.adata.MNode):
     search: list[str]
     server: ietf_system__system__dns_resolver__server
@@ -9392,7 +9380,6 @@ class ietf_system__system__dns_resolver(yang.adata.MNode):
             return iter(self.server)
         if name == 'options':
             return self.options
-        raise ValueError('Attribute {name} not found in ietf_system__system__dns_resolver')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=True, root_path=['ietf-system:system', 'dns-resolver'])
@@ -9408,7 +9395,7 @@ class ietf_system__system__dns_resolver(yang.adata.MNode):
         return ietf_system__system__dns_resolver.from_gdata(self.to_gdata())
 
 
-_breaker = 1
+_breaker19 = None
 class ietf_system__system__radius__server__udp(yang.adata.MNode):
     address: ?str
     authentication_port: ?u64
@@ -9427,7 +9414,6 @@ class ietf_system__system__radius__server__udp(yang.adata.MNode):
             return self.authentication_port
         if name == 'shared_secret':
             return self.shared_secret
-        raise ValueError('Attribute {name} not found in ietf_system__system__radius__server__udp')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=True, root_path=['ietf-system:system', 'radius', 'server', 'udp'])
@@ -9443,7 +9429,7 @@ class ietf_system__system__radius__server__udp(yang.adata.MNode):
         return ietf_system__system__radius__server__udp.from_gdata(self.to_gdata())
 
 
-_breaker = 1
+_breaker20 = None
 class ietf_system__system__radius__server_entry(yang.adata.MNode):
     name: str
     udp: ietf_system__system__radius__server__udp
@@ -9462,7 +9448,6 @@ class ietf_system__system__radius__server_entry(yang.adata.MNode):
             return self.udp
         if name == 'authentication_type':
             return self.authentication_type
-        raise ValueError('Attribute {name} not found in ietf_system__system__radius__server')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=True, root_path=['ietf-system:system', 'radius', 'server'])
@@ -9475,7 +9460,7 @@ class ietf_system__system__radius__server_entry(yang.adata.MNode):
         """Create a deep copy of this adata object"""
         return ietf_system__system__radius__server_entry.from_gdata(self.to_gdata())
 
-_breaker = 1
+_breaker21 = None
 class ietf_system__system__radius__server(yang.adata.MNode):
     elements: list[ietf_system__system__radius__server_entry]
     mut def __init__(self, elements=[]):
@@ -9518,7 +9503,7 @@ extension ietf_system__system__radius__server(Iterable[ietf_system__system__radi
     def __iter__(self) -> Iterator[ietf_system__system__radius__server_entry]:
         return self.elements.__iter__()
 
-_breaker = 1
+_breaker22 = None
 class ietf_system__system__radius__options(yang.adata.MNode):
     timeout: ?u64
     attempts: ?u64
@@ -9533,7 +9518,6 @@ class ietf_system__system__radius__options(yang.adata.MNode):
             return self.timeout
         if name == 'attempts':
             return self.attempts
-        raise ValueError('Attribute {name} not found in ietf_system__system__radius__options')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=True, root_path=['ietf-system:system', 'radius', 'options'])
@@ -9549,7 +9533,7 @@ class ietf_system__system__radius__options(yang.adata.MNode):
         return ietf_system__system__radius__options.from_gdata(self.to_gdata())
 
 
-_breaker = 1
+_breaker23 = None
 class ietf_system__system__radius(yang.adata.MNode):
     server: ietf_system__system__radius__server
     options: ietf_system__system__radius__options
@@ -9564,7 +9548,6 @@ class ietf_system__system__radius(yang.adata.MNode):
             return iter(self.server)
         if name == 'options':
             return self.options
-        raise ValueError('Attribute {name} not found in ietf_system__system__radius')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=True, root_path=['ietf-system:system', 'radius'])
@@ -9580,7 +9563,7 @@ class ietf_system__system__radius(yang.adata.MNode):
         return ietf_system__system__radius.from_gdata(self.to_gdata())
 
 
-_breaker = 1
+_breaker24 = None
 class ietf_system__system__authentication__user__authorized_key_entry(yang.adata.MNode):
     name: str
     algorithm: ?str
@@ -9599,7 +9582,6 @@ class ietf_system__system__authentication__user__authorized_key_entry(yang.adata
             return self.algorithm
         if name == 'key_data':
             return self.key_data
-        raise ValueError('Attribute {name} not found in ietf_system__system__authentication__user__authorized_key')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=True, root_path=['ietf-system:system', 'authentication', 'user', 'authorized-key'])
@@ -9612,7 +9594,7 @@ class ietf_system__system__authentication__user__authorized_key_entry(yang.adata
         """Create a deep copy of this adata object"""
         return ietf_system__system__authentication__user__authorized_key_entry.from_gdata(self.to_gdata())
 
-_breaker = 1
+_breaker25 = None
 class ietf_system__system__authentication__user__authorized_key(yang.adata.MNode):
     elements: list[ietf_system__system__authentication__user__authorized_key_entry]
     mut def __init__(self, elements=[]):
@@ -9657,7 +9639,7 @@ extension ietf_system__system__authentication__user__authorized_key(Iterable[iet
     def __iter__(self) -> Iterator[ietf_system__system__authentication__user__authorized_key_entry]:
         return self.elements.__iter__()
 
-_breaker = 1
+_breaker26 = None
 class ietf_system__system__authentication__user_entry(yang.adata.MNode):
     name: str
     password: ?str
@@ -9676,7 +9658,6 @@ class ietf_system__system__authentication__user_entry(yang.adata.MNode):
             return self.password
         if name == 'authorized_key':
             return iter(self.authorized_key)
-        raise ValueError('Attribute {name} not found in ietf_system__system__authentication__user')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=True, root_path=['ietf-system:system', 'authentication', 'user'])
@@ -9689,7 +9670,7 @@ class ietf_system__system__authentication__user_entry(yang.adata.MNode):
         """Create a deep copy of this adata object"""
         return ietf_system__system__authentication__user_entry.from_gdata(self.to_gdata())
 
-_breaker = 1
+_breaker27 = None
 class ietf_system__system__authentication__user(yang.adata.MNode):
     elements: list[ietf_system__system__authentication__user_entry]
     mut def __init__(self, elements=[]):
@@ -9732,7 +9713,7 @@ extension ietf_system__system__authentication__user(Iterable[ietf_system__system
     def __iter__(self) -> Iterator[ietf_system__system__authentication__user_entry]:
         return self.elements.__iter__()
 
-_breaker = 1
+_breaker28 = None
 class ietf_system__system__authentication(yang.adata.MNode):
     user_authentication_order: list[Identityref]
     user: ietf_system__system__authentication__user
@@ -9747,7 +9728,6 @@ class ietf_system__system__authentication(yang.adata.MNode):
             return self.user_authentication_order
         if name == 'user':
             return iter(self.user)
-        raise ValueError('Attribute {name} not found in ietf_system__system__authentication')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=True, root_path=['ietf-system:system', 'authentication'])
@@ -9763,7 +9743,7 @@ class ietf_system__system__authentication(yang.adata.MNode):
         return ietf_system__system__authentication.from_gdata(self.to_gdata())
 
 
-_breaker = 1
+_breaker29 = None
 class ietf_system__system(yang.adata.MNode):
     contact: ?str
     hostname: ?str
@@ -9812,7 +9792,6 @@ class ietf_system__system(yang.adata.MNode):
             return self.radius
         if name == 'authentication':
             return self.authentication
-        raise ValueError('Attribute {name} not found in ietf_system__system')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=True, root_path=['ietf-system:system'])
@@ -9828,7 +9807,7 @@ class ietf_system__system(yang.adata.MNode):
         return ietf_system__system.from_gdata(self.to_gdata())
 
 
-_breaker = 1
+_breaker30 = None
 class ietf_system__system_state__platform(yang.adata.MNode):
     os_name: ?str
     os_release: ?str
@@ -9851,7 +9830,6 @@ class ietf_system__system_state__platform(yang.adata.MNode):
             return self.os_version
         if name == 'machine':
             return self.machine
-        raise ValueError('Attribute {name} not found in ietf_system__system_state__platform')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=True, root_path=['ietf-system:system-state', 'platform'])
@@ -9867,7 +9845,7 @@ class ietf_system__system_state__platform(yang.adata.MNode):
         return ietf_system__system_state__platform.from_gdata(self.to_gdata())
 
 
-_breaker = 1
+_breaker31 = None
 class ietf_system__system_state__clock(yang.adata.MNode):
     current_datetime: ?str
     boot_datetime: ?str
@@ -9882,7 +9860,6 @@ class ietf_system__system_state__clock(yang.adata.MNode):
             return self.current_datetime
         if name == 'boot_datetime':
             return self.boot_datetime
-        raise ValueError('Attribute {name} not found in ietf_system__system_state__clock')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=True, root_path=['ietf-system:system-state', 'clock'])
@@ -9898,7 +9875,7 @@ class ietf_system__system_state__clock(yang.adata.MNode):
         return ietf_system__system_state__clock.from_gdata(self.to_gdata())
 
 
-_breaker = 1
+_breaker32 = None
 class ietf_system__system_state(yang.adata.MNode):
     platform: ietf_system__system_state__platform
     clock: ietf_system__system_state__clock
@@ -9913,7 +9890,6 @@ class ietf_system__system_state(yang.adata.MNode):
             return self.platform
         if name == 'clock':
             return self.clock
-        raise ValueError('Attribute {name} not found in ietf_system__system_state')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=True, root_path=['ietf-system:system-state'])
@@ -9929,7 +9905,7 @@ class ietf_system__system_state(yang.adata.MNode):
         return ietf_system__system_state.from_gdata(self.to_gdata())
 
 
-_breaker = 1
+_breaker33 = None
 class ietf_interfaces__interfaces__interface__statistics(yang.adata.MNode):
     discontinuity_time: ?str
     in_octets: ?u64
@@ -9992,7 +9968,6 @@ class ietf_interfaces__interfaces__interface__statistics(yang.adata.MNode):
             return self.out_discards
         if name == 'out_errors':
             return self.out_errors
-        raise ValueError('Attribute {name} not found in ietf_interfaces__interfaces__interface__statistics')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=True, root_path=['ietf-interfaces:interfaces', 'interface', 'statistics'])
@@ -10008,7 +9983,7 @@ class ietf_interfaces__interfaces__interface__statistics(yang.adata.MNode):
         return ietf_interfaces__interfaces__interface__statistics.from_gdata(self.to_gdata())
 
 
-_breaker = 1
+_breaker34 = None
 class ietf_interfaces__interfaces__interface__ipv4__address_entry(yang.adata.MNode):
     ip: str
     prefix_length: ?u64
@@ -10031,7 +10006,6 @@ class ietf_interfaces__interfaces__interface__ipv4__address_entry(yang.adata.MNo
             return self.netmask
         if name == 'origin':
             return self.origin
-        raise ValueError('Attribute {name} not found in ietf_interfaces__interfaces__interface__ipv4__address')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=True, root_path=['ietf-interfaces:interfaces', 'interface', 'ietf-ip:ipv4', 'address'])
@@ -10044,7 +10018,7 @@ class ietf_interfaces__interfaces__interface__ipv4__address_entry(yang.adata.MNo
         """Create a deep copy of this adata object"""
         return ietf_interfaces__interfaces__interface__ipv4__address_entry.from_gdata(self.to_gdata())
 
-_breaker = 1
+_breaker35 = None
 class ietf_interfaces__interfaces__interface__ipv4__address(yang.adata.MNode):
     elements: list[ietf_interfaces__interfaces__interface__ipv4__address_entry]
     mut def __init__(self, elements=[]):
@@ -10091,7 +10065,7 @@ extension ietf_interfaces__interfaces__interface__ipv4__address(Iterable[ietf_in
     def __iter__(self) -> Iterator[ietf_interfaces__interfaces__interface__ipv4__address_entry]:
         return self.elements.__iter__()
 
-_breaker = 1
+_breaker36 = None
 class ietf_interfaces__interfaces__interface__ipv4__neighbor_entry(yang.adata.MNode):
     ip: str
     link_layer_address: ?str
@@ -10110,7 +10084,6 @@ class ietf_interfaces__interfaces__interface__ipv4__neighbor_entry(yang.adata.MN
             return self.link_layer_address
         if name == 'origin':
             return self.origin
-        raise ValueError('Attribute {name} not found in ietf_interfaces__interfaces__interface__ipv4__neighbor')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=True, root_path=['ietf-interfaces:interfaces', 'interface', 'ietf-ip:ipv4', 'neighbor'])
@@ -10123,7 +10096,7 @@ class ietf_interfaces__interfaces__interface__ipv4__neighbor_entry(yang.adata.MN
         """Create a deep copy of this adata object"""
         return ietf_interfaces__interfaces__interface__ipv4__neighbor_entry.from_gdata(self.to_gdata())
 
-_breaker = 1
+_breaker37 = None
 class ietf_interfaces__interfaces__interface__ipv4__neighbor(yang.adata.MNode):
     elements: list[ietf_interfaces__interfaces__interface__ipv4__neighbor_entry]
     mut def __init__(self, elements=[]):
@@ -10168,7 +10141,7 @@ extension ietf_interfaces__interfaces__interface__ipv4__neighbor(Iterable[ietf_i
     def __iter__(self) -> Iterator[ietf_interfaces__interfaces__interface__ipv4__neighbor_entry]:
         return self.elements.__iter__()
 
-_breaker = 1
+_breaker38 = None
 class ietf_interfaces__interfaces__interface__ipv4(yang.adata.MNode):
     enabled: ?bool
     forwarding: ?bool
@@ -10195,7 +10168,6 @@ class ietf_interfaces__interfaces__interface__ipv4(yang.adata.MNode):
             return iter(self.address)
         if name == 'neighbor':
             return iter(self.neighbor)
-        raise ValueError('Attribute {name} not found in ietf_interfaces__interfaces__interface__ipv4')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=True, root_path=['ietf-interfaces:interfaces', 'interface', 'ietf-ip:ipv4'])
@@ -10214,7 +10186,7 @@ class ietf_interfaces__interfaces__interface__ipv4(yang.adata.MNode):
         raise Exception('Unreachable in ietf_interfaces__interfaces__interface__ipv4.copy()')
 
 
-_breaker = 1
+_breaker39 = None
 class ietf_interfaces__interfaces__interface__ipv6__address_entry(yang.adata.MNode):
     ip: str
     prefix_length: ?u64
@@ -10237,7 +10209,6 @@ class ietf_interfaces__interfaces__interface__ipv6__address_entry(yang.adata.MNo
             return self.origin
         if name == 'status':
             return self.status
-        raise ValueError('Attribute {name} not found in ietf_interfaces__interfaces__interface__ipv6__address')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=True, root_path=['ietf-interfaces:interfaces', 'interface', 'ietf-ip:ipv6', 'address'])
@@ -10250,7 +10221,7 @@ class ietf_interfaces__interfaces__interface__ipv6__address_entry(yang.adata.MNo
         """Create a deep copy of this adata object"""
         return ietf_interfaces__interfaces__interface__ipv6__address_entry.from_gdata(self.to_gdata())
 
-_breaker = 1
+_breaker40 = None
 class ietf_interfaces__interfaces__interface__ipv6__address(yang.adata.MNode):
     elements: list[ietf_interfaces__interfaces__interface__ipv6__address_entry]
     mut def __init__(self, elements=[]):
@@ -10297,7 +10268,7 @@ extension ietf_interfaces__interfaces__interface__ipv6__address(Iterable[ietf_in
     def __iter__(self) -> Iterator[ietf_interfaces__interfaces__interface__ipv6__address_entry]:
         return self.elements.__iter__()
 
-_breaker = 1
+_breaker41 = None
 class ietf_interfaces__interfaces__interface__ipv6__neighbor_entry(yang.adata.MNode):
     ip: str
     link_layer_address: ?str
@@ -10324,7 +10295,6 @@ class ietf_interfaces__interfaces__interface__ipv6__neighbor_entry(yang.adata.MN
             return self.is_router
         if name == 'state':
             return self.state
-        raise ValueError('Attribute {name} not found in ietf_interfaces__interfaces__interface__ipv6__neighbor')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=True, root_path=['ietf-interfaces:interfaces', 'interface', 'ietf-ip:ipv6', 'neighbor'])
@@ -10337,7 +10307,7 @@ class ietf_interfaces__interfaces__interface__ipv6__neighbor_entry(yang.adata.MN
         """Create a deep copy of this adata object"""
         return ietf_interfaces__interfaces__interface__ipv6__neighbor_entry.from_gdata(self.to_gdata())
 
-_breaker = 1
+_breaker42 = None
 class ietf_interfaces__interfaces__interface__ipv6__neighbor(yang.adata.MNode):
     elements: list[ietf_interfaces__interfaces__interface__ipv6__neighbor_entry]
     mut def __init__(self, elements=[]):
@@ -10386,7 +10356,7 @@ extension ietf_interfaces__interfaces__interface__ipv6__neighbor(Iterable[ietf_i
     def __iter__(self) -> Iterator[ietf_interfaces__interfaces__interface__ipv6__neighbor_entry]:
         return self.elements.__iter__()
 
-_breaker = 1
+_breaker43 = None
 class ietf_interfaces__interfaces__interface__ipv6__autoconf(yang.adata.MNode):
     create_global_addresses: ?bool
     create_temporary_addresses: ?bool
@@ -10409,7 +10379,6 @@ class ietf_interfaces__interfaces__interface__ipv6__autoconf(yang.adata.MNode):
             return self.temporary_valid_lifetime
         if name == 'temporary_preferred_lifetime':
             return self.temporary_preferred_lifetime
-        raise ValueError('Attribute {name} not found in ietf_interfaces__interfaces__interface__ipv6__autoconf')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=True, root_path=['ietf-interfaces:interfaces', 'interface', 'ietf-ip:ipv6', 'autoconf'])
@@ -10425,7 +10394,7 @@ class ietf_interfaces__interfaces__interface__ipv6__autoconf(yang.adata.MNode):
         return ietf_interfaces__interfaces__interface__ipv6__autoconf.from_gdata(self.to_gdata())
 
 
-_breaker = 1
+_breaker44 = None
 class ietf_interfaces__interfaces__interface__ipv6(yang.adata.MNode):
     enabled: ?bool
     forwarding: ?bool
@@ -10460,7 +10429,6 @@ class ietf_interfaces__interfaces__interface__ipv6(yang.adata.MNode):
             return self.dup_addr_detect_transmits
         if name == 'autoconf':
             return self.autoconf
-        raise ValueError('Attribute {name} not found in ietf_interfaces__interfaces__interface__ipv6')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=True, root_path=['ietf-interfaces:interfaces', 'interface', 'ietf-ip:ipv6'])
@@ -10479,7 +10447,7 @@ class ietf_interfaces__interfaces__interface__ipv6(yang.adata.MNode):
         raise Exception('Unreachable in ietf_interfaces__interfaces__interface__ipv6.copy()')
 
 
-_breaker = 1
+_breaker45 = None
 class ietf_interfaces__interfaces__interface_entry(yang.adata.MNode):
     name: str
     description: ?str
@@ -10580,7 +10548,6 @@ class ietf_interfaces__interfaces__interface_entry(yang.adata.MNode):
             return self.ipv4
         if name == 'ipv6':
             return self.ipv6
-        raise ValueError('Attribute {name} not found in ietf_interfaces__interfaces__interface')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=True, root_path=['ietf-interfaces:interfaces', 'interface'])
@@ -10593,7 +10560,7 @@ class ietf_interfaces__interfaces__interface_entry(yang.adata.MNode):
         """Create a deep copy of this adata object"""
         return ietf_interfaces__interfaces__interface_entry.from_gdata(self.to_gdata())
 
-_breaker = 1
+_breaker46 = None
 class ietf_interfaces__interfaces__interface(yang.adata.MNode):
     elements: list[ietf_interfaces__interfaces__interface_entry]
     mut def __init__(self, elements=[]):
@@ -10654,7 +10621,7 @@ extension ietf_interfaces__interfaces__interface(Iterable[ietf_interfaces__inter
     def __iter__(self) -> Iterator[ietf_interfaces__interfaces__interface_entry]:
         return self.elements.__iter__()
 
-_breaker = 1
+_breaker47 = None
 class ietf_interfaces__interfaces(yang.adata.MNode):
     interface: ietf_interfaces__interfaces__interface
 
@@ -10665,7 +10632,6 @@ class ietf_interfaces__interfaces(yang.adata.MNode):
     def _get_attr(self, name: str) -> ?value:
         if name == 'interface':
             return iter(self.interface)
-        raise ValueError('Attribute {name} not found in ietf_interfaces__interfaces')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=True, root_path=['ietf-interfaces:interfaces'])
@@ -10681,7 +10647,7 @@ class ietf_interfaces__interfaces(yang.adata.MNode):
         return ietf_interfaces__interfaces.from_gdata(self.to_gdata())
 
 
-_breaker = 1
+_breaker48 = None
 class ietf_interfaces__interfaces_state__interface__statistics(yang.adata.MNode):
     discontinuity_time: ?str
     in_octets: ?u64
@@ -10744,7 +10710,6 @@ class ietf_interfaces__interfaces_state__interface__statistics(yang.adata.MNode)
             return self.out_discards
         if name == 'out_errors':
             return self.out_errors
-        raise ValueError('Attribute {name} not found in ietf_interfaces__interfaces_state__interface__statistics')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=True, root_path=['ietf-interfaces:interfaces-state', 'interface', 'statistics'])
@@ -10760,7 +10725,7 @@ class ietf_interfaces__interfaces_state__interface__statistics(yang.adata.MNode)
         return ietf_interfaces__interfaces_state__interface__statistics.from_gdata(self.to_gdata())
 
 
-_breaker = 1
+_breaker49 = None
 class ietf_interfaces__interfaces_state__interface__ipv4__address_entry(yang.adata.MNode):
     ip: str
     prefix_length: ?u64
@@ -10783,7 +10748,6 @@ class ietf_interfaces__interfaces_state__interface__ipv4__address_entry(yang.ada
             return self.netmask
         if name == 'origin':
             return self.origin
-        raise ValueError('Attribute {name} not found in ietf_interfaces__interfaces_state__interface__ipv4__address')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=True, root_path=['ietf-interfaces:interfaces-state', 'interface', 'ietf-ip:ipv4', 'address'])
@@ -10796,7 +10760,7 @@ class ietf_interfaces__interfaces_state__interface__ipv4__address_entry(yang.ada
         """Create a deep copy of this adata object"""
         return ietf_interfaces__interfaces_state__interface__ipv4__address_entry.from_gdata(self.to_gdata())
 
-_breaker = 1
+_breaker50 = None
 class ietf_interfaces__interfaces_state__interface__ipv4__address(yang.adata.MNode):
     elements: list[ietf_interfaces__interfaces_state__interface__ipv4__address_entry]
     mut def __init__(self, elements=[]):
@@ -10843,7 +10807,7 @@ extension ietf_interfaces__interfaces_state__interface__ipv4__address(Iterable[i
     def __iter__(self) -> Iterator[ietf_interfaces__interfaces_state__interface__ipv4__address_entry]:
         return self.elements.__iter__()
 
-_breaker = 1
+_breaker51 = None
 class ietf_interfaces__interfaces_state__interface__ipv4__neighbor_entry(yang.adata.MNode):
     ip: str
     link_layer_address: ?str
@@ -10862,7 +10826,6 @@ class ietf_interfaces__interfaces_state__interface__ipv4__neighbor_entry(yang.ad
             return self.link_layer_address
         if name == 'origin':
             return self.origin
-        raise ValueError('Attribute {name} not found in ietf_interfaces__interfaces_state__interface__ipv4__neighbor')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=True, root_path=['ietf-interfaces:interfaces-state', 'interface', 'ietf-ip:ipv4', 'neighbor'])
@@ -10875,7 +10838,7 @@ class ietf_interfaces__interfaces_state__interface__ipv4__neighbor_entry(yang.ad
         """Create a deep copy of this adata object"""
         return ietf_interfaces__interfaces_state__interface__ipv4__neighbor_entry.from_gdata(self.to_gdata())
 
-_breaker = 1
+_breaker52 = None
 class ietf_interfaces__interfaces_state__interface__ipv4__neighbor(yang.adata.MNode):
     elements: list[ietf_interfaces__interfaces_state__interface__ipv4__neighbor_entry]
     mut def __init__(self, elements=[]):
@@ -10920,7 +10883,7 @@ extension ietf_interfaces__interfaces_state__interface__ipv4__neighbor(Iterable[
     def __iter__(self) -> Iterator[ietf_interfaces__interfaces_state__interface__ipv4__neighbor_entry]:
         return self.elements.__iter__()
 
-_breaker = 1
+_breaker53 = None
 class ietf_interfaces__interfaces_state__interface__ipv4(yang.adata.MNode):
     forwarding: ?bool
     mtu: ?u64
@@ -10943,7 +10906,6 @@ class ietf_interfaces__interfaces_state__interface__ipv4(yang.adata.MNode):
             return iter(self.address)
         if name == 'neighbor':
             return iter(self.neighbor)
-        raise ValueError('Attribute {name} not found in ietf_interfaces__interfaces_state__interface__ipv4')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=True, root_path=['ietf-interfaces:interfaces-state', 'interface', 'ietf-ip:ipv4'])
@@ -10962,7 +10924,7 @@ class ietf_interfaces__interfaces_state__interface__ipv4(yang.adata.MNode):
         raise Exception('Unreachable in ietf_interfaces__interfaces_state__interface__ipv4.copy()')
 
 
-_breaker = 1
+_breaker54 = None
 class ietf_interfaces__interfaces_state__interface__ipv6__address_entry(yang.adata.MNode):
     ip: str
     prefix_length: ?u64
@@ -10985,7 +10947,6 @@ class ietf_interfaces__interfaces_state__interface__ipv6__address_entry(yang.ada
             return self.origin
         if name == 'status':
             return self.status
-        raise ValueError('Attribute {name} not found in ietf_interfaces__interfaces_state__interface__ipv6__address')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=True, root_path=['ietf-interfaces:interfaces-state', 'interface', 'ietf-ip:ipv6', 'address'])
@@ -10998,7 +10959,7 @@ class ietf_interfaces__interfaces_state__interface__ipv6__address_entry(yang.ada
         """Create a deep copy of this adata object"""
         return ietf_interfaces__interfaces_state__interface__ipv6__address_entry.from_gdata(self.to_gdata())
 
-_breaker = 1
+_breaker55 = None
 class ietf_interfaces__interfaces_state__interface__ipv6__address(yang.adata.MNode):
     elements: list[ietf_interfaces__interfaces_state__interface__ipv6__address_entry]
     mut def __init__(self, elements=[]):
@@ -11045,7 +11006,7 @@ extension ietf_interfaces__interfaces_state__interface__ipv6__address(Iterable[i
     def __iter__(self) -> Iterator[ietf_interfaces__interfaces_state__interface__ipv6__address_entry]:
         return self.elements.__iter__()
 
-_breaker = 1
+_breaker56 = None
 class ietf_interfaces__interfaces_state__interface__ipv6__neighbor_entry(yang.adata.MNode):
     ip: str
     link_layer_address: ?str
@@ -11072,7 +11033,6 @@ class ietf_interfaces__interfaces_state__interface__ipv6__neighbor_entry(yang.ad
             return self.is_router
         if name == 'state':
             return self.state
-        raise ValueError('Attribute {name} not found in ietf_interfaces__interfaces_state__interface__ipv6__neighbor')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=True, root_path=['ietf-interfaces:interfaces-state', 'interface', 'ietf-ip:ipv6', 'neighbor'])
@@ -11085,7 +11045,7 @@ class ietf_interfaces__interfaces_state__interface__ipv6__neighbor_entry(yang.ad
         """Create a deep copy of this adata object"""
         return ietf_interfaces__interfaces_state__interface__ipv6__neighbor_entry.from_gdata(self.to_gdata())
 
-_breaker = 1
+_breaker57 = None
 class ietf_interfaces__interfaces_state__interface__ipv6__neighbor(yang.adata.MNode):
     elements: list[ietf_interfaces__interfaces_state__interface__ipv6__neighbor_entry]
     mut def __init__(self, elements=[]):
@@ -11134,7 +11094,7 @@ extension ietf_interfaces__interfaces_state__interface__ipv6__neighbor(Iterable[
     def __iter__(self) -> Iterator[ietf_interfaces__interfaces_state__interface__ipv6__neighbor_entry]:
         return self.elements.__iter__()
 
-_breaker = 1
+_breaker58 = None
 class ietf_interfaces__interfaces_state__interface__ipv6(yang.adata.MNode):
     forwarding: ?bool
     mtu: ?u64
@@ -11157,7 +11117,6 @@ class ietf_interfaces__interfaces_state__interface__ipv6(yang.adata.MNode):
             return iter(self.address)
         if name == 'neighbor':
             return iter(self.neighbor)
-        raise ValueError('Attribute {name} not found in ietf_interfaces__interfaces_state__interface__ipv6')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=True, root_path=['ietf-interfaces:interfaces-state', 'interface', 'ietf-ip:ipv6'])
@@ -11176,7 +11135,7 @@ class ietf_interfaces__interfaces_state__interface__ipv6(yang.adata.MNode):
         raise Exception('Unreachable in ietf_interfaces__interfaces_state__interface__ipv6.copy()')
 
 
-_breaker = 1
+_breaker59 = None
 class ietf_interfaces__interfaces_state__interface_entry(yang.adata.MNode):
     name: str
     type: ?Identityref
@@ -11259,7 +11218,6 @@ class ietf_interfaces__interfaces_state__interface_entry(yang.adata.MNode):
             return self.ipv4
         if name == 'ipv6':
             return self.ipv6
-        raise ValueError('Attribute {name} not found in ietf_interfaces__interfaces_state__interface')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=True, root_path=['ietf-interfaces:interfaces-state', 'interface'])
@@ -11272,7 +11230,7 @@ class ietf_interfaces__interfaces_state__interface_entry(yang.adata.MNode):
         """Create a deep copy of this adata object"""
         return ietf_interfaces__interfaces_state__interface_entry.from_gdata(self.to_gdata())
 
-_breaker = 1
+_breaker60 = None
 class ietf_interfaces__interfaces_state__interface(yang.adata.MNode):
     elements: list[ietf_interfaces__interfaces_state__interface_entry]
     mut def __init__(self, elements=[]):
@@ -11327,7 +11285,7 @@ extension ietf_interfaces__interfaces_state__interface(Iterable[ietf_interfaces_
     def __iter__(self) -> Iterator[ietf_interfaces__interfaces_state__interface_entry]:
         return self.elements.__iter__()
 
-_breaker = 1
+_breaker61 = None
 class ietf_interfaces__interfaces_state(yang.adata.MNode):
     interface: ietf_interfaces__interfaces_state__interface
 
@@ -11338,7 +11296,6 @@ class ietf_interfaces__interfaces_state(yang.adata.MNode):
     def _get_attr(self, name: str) -> ?value:
         if name == 'interface':
             return iter(self.interface)
-        raise ValueError('Attribute {name} not found in ietf_interfaces__interfaces_state')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=True, root_path=['ietf-interfaces:interfaces-state'])
@@ -11354,7 +11311,7 @@ class ietf_interfaces__interfaces_state(yang.adata.MNode):
         return ietf_interfaces__interfaces_state.from_gdata(self.to_gdata())
 
 
-_breaker = 1
+_breaker62 = None
 class root(yang.adata.MNode):
     nacm: ietf_netconf_acm__nacm
     system: ietf_system__system
@@ -11381,7 +11338,6 @@ class root(yang.adata.MNode):
             return self.interfaces
         if name == 'interfaces_state':
             return self.interfaces_state
-        raise ValueError('Attribute {name} not found in root')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=True)
@@ -11397,7 +11353,7 @@ class root(yang.adata.MNode):
         return root.from_gdata(self.to_gdata())
 
 
-_breaker = 1
+_breaker63 = None
 class ietf_system__set_current_datetime__input(yang.adata.MNode):
     current_datetime: ?str
 
@@ -11408,7 +11364,6 @@ class ietf_system__set_current_datetime__input(yang.adata.MNode):
     def _get_attr(self, name: str) -> ?value:
         if name == 'current_datetime':
             return self.current_datetime
-        raise ValueError('Attribute {name} not found in ietf_system__set_current_datetime__input')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=True, root_path=['ietf-system:set-current-datetime', 'input'])

--- a/minisys/src/mini/layers/y_0.act
+++ b/minisys/src/mini/layers/y_0.act
@@ -719,7 +719,7 @@ NS_stratoweave = 'http://stratoweave.org/yang/stratoweave.yang'
 NS_ietf_inet_types = 'urn:ietf:params:xml:ns:yang:ietf-inet-types'
 
 
-_breaker = 1
+_breaker1 = None
 class netinfra__netinfra__router_entry(yang.adata.MNode):
     name: str
     id: u64
@@ -742,7 +742,6 @@ class netinfra__netinfra__router_entry(yang.adata.MNode):
             return self.type
         if name == 'mock':
             return self.mock
-        raise ValueError('Attribute {name} not found in netinfra__netinfra__router')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=False, root_path=['netinfra:netinfra', 'router'])
@@ -755,7 +754,7 @@ class netinfra__netinfra__router_entry(yang.adata.MNode):
         """Create a deep copy of this adata object"""
         return netinfra__netinfra__router_entry.from_gdata(self.to_gdata())
 
-_breaker = 1
+_breaker2 = None
 class netinfra__netinfra__router(yang.adata.MNode):
     elements: list[netinfra__netinfra__router_entry]
     mut def __init__(self, elements=[]):
@@ -800,7 +799,7 @@ extension netinfra__netinfra__router(Iterable[netinfra__netinfra__router_entry])
     def __iter__(self) -> Iterator[netinfra__netinfra__router_entry]:
         return self.elements.__iter__()
 
-_breaker = 1
+_breaker3 = None
 class netinfra__netinfra(yang.adata.MNode):
     router: netinfra__netinfra__router
 
@@ -811,7 +810,6 @@ class netinfra__netinfra(yang.adata.MNode):
     def _get_attr(self, name: str) -> ?value:
         if name == 'router':
             return iter(self.router)
-        raise ValueError('Attribute {name} not found in netinfra__netinfra')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=False, root_path=['netinfra:netinfra'])
@@ -827,7 +825,7 @@ class netinfra__netinfra(yang.adata.MNode):
         return netinfra__netinfra.from_gdata(self.to_gdata())
 
 
-_breaker = 1
+_breaker4 = None
 class l3vpn__l3vpn__endpoint_entry(yang.adata.MNode):
     device: str
     interface_name: str
@@ -870,7 +868,6 @@ class l3vpn__l3vpn__endpoint_entry(yang.adata.MNode):
             return self.site_code
         if name == 'description':
             return self.description
-        raise ValueError('Attribute {name} not found in l3vpn__l3vpn__endpoint')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=False, root_path=['l3vpn:l3vpn', 'endpoint'])
@@ -883,7 +880,7 @@ class l3vpn__l3vpn__endpoint_entry(yang.adata.MNode):
         """Create a deep copy of this adata object"""
         return l3vpn__l3vpn__endpoint_entry.from_gdata(self.to_gdata())
 
-_breaker = 1
+_breaker5 = None
 class l3vpn__l3vpn__endpoint(yang.adata.MNode):
     elements: list[l3vpn__l3vpn__endpoint_entry]
     mut def __init__(self, elements=[]):
@@ -939,7 +936,7 @@ extension l3vpn__l3vpn__endpoint(Iterable[l3vpn__l3vpn__endpoint_entry]):
     def __iter__(self) -> Iterator[l3vpn__l3vpn__endpoint_entry]:
         return self.elements.__iter__()
 
-_breaker = 1
+_breaker6 = None
 class l3vpn__l3vpn_entry(yang.adata.MNode):
     name: str
     customer_name: str
@@ -974,7 +971,6 @@ class l3vpn__l3vpn_entry(yang.adata.MNode):
             return self.description
         if name == 'endpoint':
             return iter(self.endpoint)
-        raise ValueError('Attribute {name} not found in l3vpn__l3vpn')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=False, root_path=['l3vpn:l3vpn'])
@@ -987,7 +983,7 @@ class l3vpn__l3vpn_entry(yang.adata.MNode):
         """Create a deep copy of this adata object"""
         return l3vpn__l3vpn_entry.from_gdata(self.to_gdata())
 
-_breaker = 1
+_breaker7 = None
 class l3vpn__l3vpn(yang.adata.MNode):
     elements: list[l3vpn__l3vpn_entry]
     mut def __init__(self, elements=[]):
@@ -1036,7 +1032,7 @@ extension l3vpn__l3vpn(Iterable[l3vpn__l3vpn_entry]):
     def __iter__(self) -> Iterator[l3vpn__l3vpn_entry]:
         return self.elements.__iter__()
 
-_breaker = 1
+_breaker8 = None
 class root(yang.adata.MNode):
     netinfra: netinfra__netinfra
     l3vpn: l3vpn__l3vpn
@@ -1051,7 +1047,6 @@ class root(yang.adata.MNode):
             return self.netinfra
         if name == 'l3vpn':
             return iter(self.l3vpn)
-        raise ValueError('Attribute {name} not found in root')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=False)

--- a/minisys/src/mini/layers/y_0_loose.act
+++ b/minisys/src/mini/layers/y_0_loose.act
@@ -719,7 +719,7 @@ NS_stratoweave = 'http://stratoweave.org/yang/stratoweave.yang'
 NS_ietf_inet_types = 'urn:ietf:params:xml:ns:yang:ietf-inet-types'
 
 
-_breaker = 1
+_breaker1 = None
 class netinfra__netinfra__router_entry(yang.adata.MNode):
     name: str
     id: ?u64
@@ -742,7 +742,6 @@ class netinfra__netinfra__router_entry(yang.adata.MNode):
             return self.type
         if name == 'mock':
             return self.mock
-        raise ValueError('Attribute {name} not found in netinfra__netinfra__router')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=True, root_path=['netinfra:netinfra', 'router'])
@@ -755,7 +754,7 @@ class netinfra__netinfra__router_entry(yang.adata.MNode):
         """Create a deep copy of this adata object"""
         return netinfra__netinfra__router_entry.from_gdata(self.to_gdata())
 
-_breaker = 1
+_breaker2 = None
 class netinfra__netinfra__router(yang.adata.MNode):
     elements: list[netinfra__netinfra__router_entry]
     mut def __init__(self, elements=[]):
@@ -802,7 +801,7 @@ extension netinfra__netinfra__router(Iterable[netinfra__netinfra__router_entry])
     def __iter__(self) -> Iterator[netinfra__netinfra__router_entry]:
         return self.elements.__iter__()
 
-_breaker = 1
+_breaker3 = None
 class netinfra__netinfra(yang.adata.MNode):
     router: netinfra__netinfra__router
 
@@ -813,7 +812,6 @@ class netinfra__netinfra(yang.adata.MNode):
     def _get_attr(self, name: str) -> ?value:
         if name == 'router':
             return iter(self.router)
-        raise ValueError('Attribute {name} not found in netinfra__netinfra')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=True, root_path=['netinfra:netinfra'])
@@ -829,7 +827,7 @@ class netinfra__netinfra(yang.adata.MNode):
         return netinfra__netinfra.from_gdata(self.to_gdata())
 
 
-_breaker = 1
+_breaker4 = None
 class l3vpn__l3vpn__endpoint_entry(yang.adata.MNode):
     device: str
     interface_name: str
@@ -872,7 +870,6 @@ class l3vpn__l3vpn__endpoint_entry(yang.adata.MNode):
             return self.site_code
         if name == 'description':
             return self.description
-        raise ValueError('Attribute {name} not found in l3vpn__l3vpn__endpoint')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=True, root_path=['l3vpn:l3vpn', 'endpoint'])
@@ -885,7 +882,7 @@ class l3vpn__l3vpn__endpoint_entry(yang.adata.MNode):
         """Create a deep copy of this adata object"""
         return l3vpn__l3vpn__endpoint_entry.from_gdata(self.to_gdata())
 
-_breaker = 1
+_breaker5 = None
 class l3vpn__l3vpn__endpoint(yang.adata.MNode):
     elements: list[l3vpn__l3vpn__endpoint_entry]
     mut def __init__(self, elements=[]):
@@ -943,7 +940,7 @@ extension l3vpn__l3vpn__endpoint(Iterable[l3vpn__l3vpn__endpoint_entry]):
     def __iter__(self) -> Iterator[l3vpn__l3vpn__endpoint_entry]:
         return self.elements.__iter__()
 
-_breaker = 1
+_breaker6 = None
 class l3vpn__l3vpn_entry(yang.adata.MNode):
     name: str
     customer_name: ?str
@@ -978,7 +975,6 @@ class l3vpn__l3vpn_entry(yang.adata.MNode):
             return self.description
         if name == 'endpoint':
             return iter(self.endpoint)
-        raise ValueError('Attribute {name} not found in l3vpn__l3vpn')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=True, root_path=['l3vpn:l3vpn'])
@@ -991,7 +987,7 @@ class l3vpn__l3vpn_entry(yang.adata.MNode):
         """Create a deep copy of this adata object"""
         return l3vpn__l3vpn_entry.from_gdata(self.to_gdata())
 
-_breaker = 1
+_breaker7 = None
 class l3vpn__l3vpn(yang.adata.MNode):
     elements: list[l3vpn__l3vpn_entry]
     mut def __init__(self, elements=[]):
@@ -1042,7 +1038,7 @@ extension l3vpn__l3vpn(Iterable[l3vpn__l3vpn_entry]):
     def __iter__(self) -> Iterator[l3vpn__l3vpn_entry]:
         return self.elements.__iter__()
 
-_breaker = 1
+_breaker8 = None
 class root(yang.adata.MNode):
     netinfra: netinfra__netinfra
     l3vpn: l3vpn__l3vpn
@@ -1057,7 +1053,6 @@ class root(yang.adata.MNode):
             return self.netinfra
         if name == 'l3vpn':
             return iter(self.l3vpn)
-        raise ValueError('Attribute {name} not found in root')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=True)

--- a/minisys/src/mini/layers/y_1.act
+++ b/minisys/src/mini/layers/y_1.act
@@ -908,7 +908,7 @@ NS_stratoweave = 'http://stratoweave.org/yang/stratoweave.yang'
 NS_ietf_inet_types = 'urn:ietf:params:xml:ns:yang:ietf-inet-types'
 
 
-_breaker = 1
+_breaker1 = None
 class stratoweave_rfs__device__address__initial_credentials_entry(yang.adata.MNode):
     username: str
     password: str
@@ -927,7 +927,6 @@ class stratoweave_rfs__device__address__initial_credentials_entry(yang.adata.MNo
             return self.password
         if name == 'key':
             return self.key
-        raise ValueError('Attribute {name} not found in stratoweave_rfs__device__address__initial_credentials')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=False, root_path=['stratoweave-rfs:device', 'address', 'initial-credentials'])
@@ -940,7 +939,7 @@ class stratoweave_rfs__device__address__initial_credentials_entry(yang.adata.MNo
         """Create a deep copy of this adata object"""
         return stratoweave_rfs__device__address__initial_credentials_entry.from_gdata(self.to_gdata())
 
-_breaker = 1
+_breaker2 = None
 class stratoweave_rfs__device__address__initial_credentials(yang.adata.MNode):
     elements: list[stratoweave_rfs__device__address__initial_credentials_entry]
     mut def __init__(self, elements=[]):
@@ -987,7 +986,7 @@ extension stratoweave_rfs__device__address__initial_credentials(Iterable[stratow
     def __iter__(self) -> Iterator[stratoweave_rfs__device__address__initial_credentials_entry]:
         return self.elements.__iter__()
 
-_breaker = 1
+_breaker3 = None
 class stratoweave_rfs__device__address_entry(yang.adata.MNode):
     name: str
     address: str
@@ -1010,7 +1009,6 @@ class stratoweave_rfs__device__address_entry(yang.adata.MNode):
             return self.port
         if name == 'initial_credentials':
             return iter(self.initial_credentials)
-        raise ValueError('Attribute {name} not found in stratoweave_rfs__device__address')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=False, root_path=['stratoweave-rfs:device', 'address'])
@@ -1023,7 +1021,7 @@ class stratoweave_rfs__device__address_entry(yang.adata.MNode):
         """Create a deep copy of this adata object"""
         return stratoweave_rfs__device__address_entry.from_gdata(self.to_gdata())
 
-_breaker = 1
+_breaker4 = None
 class stratoweave_rfs__device__address(yang.adata.MNode):
     elements: list[stratoweave_rfs__device__address_entry]
     mut def __init__(self, elements=[]):
@@ -1067,7 +1065,7 @@ extension stratoweave_rfs__device__address(Iterable[stratoweave_rfs__device__add
     def __iter__(self) -> Iterator[stratoweave_rfs__device__address_entry]:
         return self.elements.__iter__()
 
-_breaker = 1
+_breaker5 = None
 class stratoweave_rfs__device__credentials__key_entry(yang.adata.MNode):
     key: str
     private_key: ?str
@@ -1082,7 +1080,6 @@ class stratoweave_rfs__device__credentials__key_entry(yang.adata.MNode):
             return self.key
         if name == 'private_key':
             return self.private_key
-        raise ValueError('Attribute {name} not found in stratoweave_rfs__device__credentials__key')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=False, root_path=['stratoweave-rfs:device', 'credentials', 'key'])
@@ -1095,7 +1092,7 @@ class stratoweave_rfs__device__credentials__key_entry(yang.adata.MNode):
         """Create a deep copy of this adata object"""
         return stratoweave_rfs__device__credentials__key_entry.from_gdata(self.to_gdata())
 
-_breaker = 1
+_breaker6 = None
 class stratoweave_rfs__device__credentials__key(yang.adata.MNode):
     elements: list[stratoweave_rfs__device__credentials__key_entry]
     mut def __init__(self, elements=[]):
@@ -1138,7 +1135,7 @@ extension stratoweave_rfs__device__credentials__key(Iterable[stratoweave_rfs__de
     def __iter__(self) -> Iterator[stratoweave_rfs__device__credentials__key_entry]:
         return self.elements.__iter__()
 
-_breaker = 1
+_breaker7 = None
 class stratoweave_rfs__device__credentials(yang.adata.MNode):
     username: str
     password: ?str
@@ -1157,7 +1154,6 @@ class stratoweave_rfs__device__credentials(yang.adata.MNode):
             return self.password
         if name == 'key':
             return iter(self.key)
-        raise ValueError('Attribute {name} not found in stratoweave_rfs__device__credentials')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=False, root_path=['stratoweave-rfs:device', 'credentials'])
@@ -1173,7 +1169,7 @@ class stratoweave_rfs__device__credentials(yang.adata.MNode):
         return stratoweave_rfs__device__credentials.from_gdata(self.to_gdata())
 
 
-_breaker = 1
+_breaker8 = None
 class stratoweave_rfs__device__initial_credentials_entry(yang.adata.MNode):
     username: str
     password: str
@@ -1192,7 +1188,6 @@ class stratoweave_rfs__device__initial_credentials_entry(yang.adata.MNode):
             return self.password
         if name == 'key':
             return self.key
-        raise ValueError('Attribute {name} not found in stratoweave_rfs__device__initial_credentials')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=False, root_path=['stratoweave-rfs:device', 'initial-credentials'])
@@ -1205,7 +1200,7 @@ class stratoweave_rfs__device__initial_credentials_entry(yang.adata.MNode):
         """Create a deep copy of this adata object"""
         return stratoweave_rfs__device__initial_credentials_entry.from_gdata(self.to_gdata())
 
-_breaker = 1
+_breaker9 = None
 class stratoweave_rfs__device__initial_credentials(yang.adata.MNode):
     elements: list[stratoweave_rfs__device__initial_credentials_entry]
     mut def __init__(self, elements=[]):
@@ -1252,7 +1247,7 @@ extension stratoweave_rfs__device__initial_credentials(Iterable[stratoweave_rfs_
     def __iter__(self) -> Iterator[stratoweave_rfs__device__initial_credentials_entry]:
         return self.elements.__iter__()
 
-_breaker = 1
+_breaker10 = None
 class stratoweave_rfs__device__mock__module_entry(yang.adata.MNode):
     name: str
     namespace: str
@@ -1275,7 +1270,6 @@ class stratoweave_rfs__device__mock__module_entry(yang.adata.MNode):
             return self.revision
         if name == 'feature':
             return self.feature
-        raise ValueError('Attribute {name} not found in stratoweave_rfs__device__mock__module')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=False, root_path=['stratoweave-rfs:device', 'mock', 'module'])
@@ -1288,7 +1282,7 @@ class stratoweave_rfs__device__mock__module_entry(yang.adata.MNode):
         """Create a deep copy of this adata object"""
         return stratoweave_rfs__device__mock__module_entry.from_gdata(self.to_gdata())
 
-_breaker = 1
+_breaker11 = None
 class stratoweave_rfs__device__mock__module(yang.adata.MNode):
     elements: list[stratoweave_rfs__device__mock__module_entry]
     mut def __init__(self, elements=[]):
@@ -1332,7 +1326,7 @@ extension stratoweave_rfs__device__mock__module(Iterable[stratoweave_rfs__device
     def __iter__(self) -> Iterator[stratoweave_rfs__device__mock__module_entry]:
         return self.elements.__iter__()
 
-_breaker = 1
+_breaker12 = None
 class stratoweave_rfs__device__mock(yang.adata.MNode):
     enabled: bool
     preset: list[str]
@@ -1351,7 +1345,6 @@ class stratoweave_rfs__device__mock(yang.adata.MNode):
             return self.preset
         if name == 'module':
             return iter(self.module)
-        raise ValueError('Attribute {name} not found in stratoweave_rfs__device__mock')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=False, root_path=['stratoweave-rfs:device', 'mock'])
@@ -1367,7 +1360,7 @@ class stratoweave_rfs__device__mock(yang.adata.MNode):
         return stratoweave_rfs__device__mock.from_gdata(self.to_gdata())
 
 
-_breaker = 1
+_breaker13 = None
 class stratoweave_rfs__device__debug(yang.adata.MNode):
     connection: bool
 
@@ -1378,7 +1371,6 @@ class stratoweave_rfs__device__debug(yang.adata.MNode):
     def _get_attr(self, name: str) -> ?value:
         if name == 'connection':
             return self.connection
-        raise ValueError('Attribute {name} not found in stratoweave_rfs__device__debug')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=False, root_path=['stratoweave-rfs:device', 'debug'])
@@ -1394,7 +1386,7 @@ class stratoweave_rfs__device__debug(yang.adata.MNode):
         return stratoweave_rfs__device__debug.from_gdata(self.to_gdata())
 
 
-_breaker = 1
+_breaker14 = None
 class stratoweave_rfs__device__feature_flags(yang.adata.MNode):
     runtime_schema_fetch: bool
 
@@ -1405,7 +1397,6 @@ class stratoweave_rfs__device__feature_flags(yang.adata.MNode):
     def _get_attr(self, name: str) -> ?value:
         if name == 'runtime_schema_fetch':
             return self.runtime_schema_fetch
-        raise ValueError('Attribute {name} not found in stratoweave_rfs__device__feature_flags')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=False, root_path=['stratoweave-rfs:device', 'feature-flags'])
@@ -1421,7 +1412,7 @@ class stratoweave_rfs__device__feature_flags(yang.adata.MNode):
         return stratoweave_rfs__device__feature_flags.from_gdata(self.to_gdata())
 
 
-_breaker = 1
+_breaker15 = None
 class stratoweave_rfs__device_entry(yang.adata.MNode):
     name: str
     description: ?str
@@ -1468,7 +1459,6 @@ class stratoweave_rfs__device_entry(yang.adata.MNode):
             return self.debug
         if name == 'feature_flags':
             return self.feature_flags
-        raise ValueError('Attribute {name} not found in stratoweave_rfs__device')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=False, root_path=['stratoweave-rfs:device'])
@@ -1481,7 +1471,7 @@ class stratoweave_rfs__device_entry(yang.adata.MNode):
         """Create a deep copy of this adata object"""
         return stratoweave_rfs__device_entry.from_gdata(self.to_gdata())
 
-_breaker = 1
+_breaker16 = None
 class stratoweave_rfs__device(yang.adata.MNode):
     elements: list[stratoweave_rfs__device_entry]
     mut def __init__(self, elements=[]):
@@ -1529,7 +1519,7 @@ extension stratoweave_rfs__device(Iterable[stratoweave_rfs__device_entry]):
     def __iter__(self) -> Iterator[stratoweave_rfs__device_entry]:
         return self.elements.__iter__()
 
-_breaker = 1
+_breaker17 = None
 class stratoweave_rfs__rfs__base_config__dynstate(yang.adata.MNode):
     current_datetime: ?str
 
@@ -1540,7 +1530,6 @@ class stratoweave_rfs__rfs__base_config__dynstate(yang.adata.MNode):
     def _get_attr(self, name: str) -> ?value:
         if name == 'current_datetime':
             return self.current_datetime
-        raise ValueError('Attribute {name} not found in stratoweave_rfs__rfs__base_config__dynstate')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=False, root_path=['stratoweave-rfs:rfs', 'mini-rfs:base-config', 'dynstate'])
@@ -1556,26 +1545,21 @@ class stratoweave_rfs__rfs__base_config__dynstate(yang.adata.MNode):
         return stratoweave_rfs__rfs__base_config__dynstate.from_gdata(self.to_gdata())
 
 
-_breaker = 1
+_breaker18 = None
 class stratoweave_rfs__rfs__base_config(yang.adata.MNode):
     name: str
     ipv4_address: str
-    dynstate: stratoweave_rfs__rfs__base_config__dynstate
 
-    mut def __init__(self, name: str, ipv4_address: str, dynstate: ?stratoweave_rfs__rfs__base_config__dynstate=None):
+    mut def __init__(self, name: str, ipv4_address: str):
         self._ns = 'http://example.com/mini-rfs'
         self.name = name
         self.ipv4_address = ipv4_address
-        self.dynstate = dynstate if dynstate is not None else stratoweave_rfs__rfs__base_config__dynstate()
 
     def _get_attr(self, name: str) -> ?value:
         if name == 'name':
             return self.name
         if name == 'ipv4_address':
             return self.ipv4_address
-        if name == 'dynstate':
-            return self.dynstate
-        raise ValueError('Attribute {name} not found in stratoweave_rfs__rfs__base_config')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=False, root_path=['stratoweave-rfs:rfs', 'mini-rfs:base-config'])
@@ -1583,7 +1567,7 @@ class stratoweave_rfs__rfs__base_config(yang.adata.MNode):
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> stratoweave_rfs__rfs__base_config:
         if n is not None:
-            return stratoweave_rfs__rfs__base_config(name=n.get_str(yang.gdata.Id(NS_mini_rfs, 'name')), ipv4_address=n.get_str(yang.gdata.Id(NS_mini_rfs, 'ipv4-address')), dynstate=stratoweave_rfs__rfs__base_config__dynstate.from_gdata(n.get_opt_cnt(yang.gdata.Id(NS_mini_rfs, 'dynstate'))))
+            return stratoweave_rfs__rfs__base_config(name=n.get_str(yang.gdata.Id(NS_mini_rfs, 'name')), ipv4_address=n.get_str(yang.gdata.Id(NS_mini_rfs, 'ipv4-address')))
         raise ValueError('Missing required subtree stratoweave_rfs__rfs__base_config')
 
     def copy(self):
@@ -1591,7 +1575,7 @@ class stratoweave_rfs__rfs__base_config(yang.adata.MNode):
         return stratoweave_rfs__rfs__base_config.from_gdata(self.to_gdata())
 
 
-_breaker = 1
+_breaker19 = None
 class stratoweave_rfs__rfs__l3vpn_endpoint_entry(yang.adata.MNode):
     interface_name: str
     vpn_name: str
@@ -1650,7 +1634,6 @@ class stratoweave_rfs__rfs__l3vpn_endpoint_entry(yang.adata.MNode):
             return self.site_code
         if name == 'description':
             return self.description
-        raise ValueError('Attribute {name} not found in stratoweave_rfs__rfs__l3vpn_endpoint')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=False, root_path=['stratoweave-rfs:rfs', 'mini-rfs:l3vpn-endpoint'])
@@ -1663,7 +1646,7 @@ class stratoweave_rfs__rfs__l3vpn_endpoint_entry(yang.adata.MNode):
         """Create a deep copy of this adata object"""
         return stratoweave_rfs__rfs__l3vpn_endpoint_entry.from_gdata(self.to_gdata())
 
-_breaker = 1
+_breaker20 = None
 class stratoweave_rfs__rfs__l3vpn_endpoint(yang.adata.MNode):
     elements: list[stratoweave_rfs__rfs__l3vpn_endpoint_entry]
     mut def __init__(self, elements=[]):
@@ -1719,7 +1702,7 @@ extension stratoweave_rfs__rfs__l3vpn_endpoint(Iterable[stratoweave_rfs__rfs__l3
     def __iter__(self) -> Iterator[stratoweave_rfs__rfs__l3vpn_endpoint_entry]:
         return self.elements.__iter__()
 
-_breaker = 1
+_breaker21 = None
 class stratoweave_rfs__rfs_entry(yang.adata.MNode):
     name: str
     base_config: stratoweave_rfs__rfs__base_config
@@ -1738,7 +1721,6 @@ class stratoweave_rfs__rfs_entry(yang.adata.MNode):
             return self.base_config
         if name == 'l3vpn_endpoint':
             return iter(self.l3vpn_endpoint)
-        raise ValueError('Attribute {name} not found in stratoweave_rfs__rfs')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=False, root_path=['stratoweave-rfs:rfs'])
@@ -1751,7 +1733,7 @@ class stratoweave_rfs__rfs_entry(yang.adata.MNode):
         """Create a deep copy of this adata object"""
         return stratoweave_rfs__rfs_entry.from_gdata(self.to_gdata())
 
-_breaker = 1
+_breaker22 = None
 class stratoweave_rfs__rfs(yang.adata.MNode):
     elements: list[stratoweave_rfs__rfs_entry]
     mut def __init__(self, elements=[]):
@@ -1793,7 +1775,7 @@ extension stratoweave_rfs__rfs(Iterable[stratoweave_rfs__rfs_entry]):
     def __iter__(self) -> Iterator[stratoweave_rfs__rfs_entry]:
         return self.elements.__iter__()
 
-_breaker = 1
+_breaker23 = None
 class root(yang.adata.MNode):
     device: stratoweave_rfs__device
     rfs: stratoweave_rfs__rfs
@@ -1808,7 +1790,6 @@ class root(yang.adata.MNode):
             return iter(self.device)
         if name == 'rfs':
             return iter(self.rfs)
-        raise ValueError('Attribute {name} not found in root')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=False)

--- a/minisys/src/mini/layers/y_1_loose.act
+++ b/minisys/src/mini/layers/y_1_loose.act
@@ -908,7 +908,7 @@ NS_stratoweave = 'http://stratoweave.org/yang/stratoweave.yang'
 NS_ietf_inet_types = 'urn:ietf:params:xml:ns:yang:ietf-inet-types'
 
 
-_breaker = 1
+_breaker1 = None
 class stratoweave_rfs__device__address__initial_credentials_entry(yang.adata.MNode):
     username: str
     password: str
@@ -927,7 +927,6 @@ class stratoweave_rfs__device__address__initial_credentials_entry(yang.adata.MNo
             return self.password
         if name == 'key':
             return self.key
-        raise ValueError('Attribute {name} not found in stratoweave_rfs__device__address__initial_credentials')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=True, root_path=['stratoweave-rfs:device', 'address', 'initial-credentials'])
@@ -940,7 +939,7 @@ class stratoweave_rfs__device__address__initial_credentials_entry(yang.adata.MNo
         """Create a deep copy of this adata object"""
         return stratoweave_rfs__device__address__initial_credentials_entry.from_gdata(self.to_gdata())
 
-_breaker = 1
+_breaker2 = None
 class stratoweave_rfs__device__address__initial_credentials(yang.adata.MNode):
     elements: list[stratoweave_rfs__device__address__initial_credentials_entry]
     mut def __init__(self, elements=[]):
@@ -987,7 +986,7 @@ extension stratoweave_rfs__device__address__initial_credentials(Iterable[stratow
     def __iter__(self) -> Iterator[stratoweave_rfs__device__address__initial_credentials_entry]:
         return self.elements.__iter__()
 
-_breaker = 1
+_breaker3 = None
 class stratoweave_rfs__device__address_entry(yang.adata.MNode):
     name: str
     address: ?str
@@ -1010,7 +1009,6 @@ class stratoweave_rfs__device__address_entry(yang.adata.MNode):
             return self.port
         if name == 'initial_credentials':
             return iter(self.initial_credentials)
-        raise ValueError('Attribute {name} not found in stratoweave_rfs__device__address')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=True, root_path=['stratoweave-rfs:device', 'address'])
@@ -1023,7 +1021,7 @@ class stratoweave_rfs__device__address_entry(yang.adata.MNode):
         """Create a deep copy of this adata object"""
         return stratoweave_rfs__device__address_entry.from_gdata(self.to_gdata())
 
-_breaker = 1
+_breaker4 = None
 class stratoweave_rfs__device__address(yang.adata.MNode):
     elements: list[stratoweave_rfs__device__address_entry]
     mut def __init__(self, elements=[]):
@@ -1068,7 +1066,7 @@ extension stratoweave_rfs__device__address(Iterable[stratoweave_rfs__device__add
     def __iter__(self) -> Iterator[stratoweave_rfs__device__address_entry]:
         return self.elements.__iter__()
 
-_breaker = 1
+_breaker5 = None
 class stratoweave_rfs__device__credentials__key_entry(yang.adata.MNode):
     key: str
     private_key: ?str
@@ -1083,7 +1081,6 @@ class stratoweave_rfs__device__credentials__key_entry(yang.adata.MNode):
             return self.key
         if name == 'private_key':
             return self.private_key
-        raise ValueError('Attribute {name} not found in stratoweave_rfs__device__credentials__key')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=True, root_path=['stratoweave-rfs:device', 'credentials', 'key'])
@@ -1096,7 +1093,7 @@ class stratoweave_rfs__device__credentials__key_entry(yang.adata.MNode):
         """Create a deep copy of this adata object"""
         return stratoweave_rfs__device__credentials__key_entry.from_gdata(self.to_gdata())
 
-_breaker = 1
+_breaker6 = None
 class stratoweave_rfs__device__credentials__key(yang.adata.MNode):
     elements: list[stratoweave_rfs__device__credentials__key_entry]
     mut def __init__(self, elements=[]):
@@ -1139,7 +1136,7 @@ extension stratoweave_rfs__device__credentials__key(Iterable[stratoweave_rfs__de
     def __iter__(self) -> Iterator[stratoweave_rfs__device__credentials__key_entry]:
         return self.elements.__iter__()
 
-_breaker = 1
+_breaker7 = None
 class stratoweave_rfs__device__credentials(yang.adata.MNode):
     username: ?str
     password: ?str
@@ -1158,7 +1155,6 @@ class stratoweave_rfs__device__credentials(yang.adata.MNode):
             return self.password
         if name == 'key':
             return iter(self.key)
-        raise ValueError('Attribute {name} not found in stratoweave_rfs__device__credentials')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=True, root_path=['stratoweave-rfs:device', 'credentials'])
@@ -1174,7 +1170,7 @@ class stratoweave_rfs__device__credentials(yang.adata.MNode):
         return stratoweave_rfs__device__credentials.from_gdata(self.to_gdata())
 
 
-_breaker = 1
+_breaker8 = None
 class stratoweave_rfs__device__initial_credentials_entry(yang.adata.MNode):
     username: str
     password: str
@@ -1193,7 +1189,6 @@ class stratoweave_rfs__device__initial_credentials_entry(yang.adata.MNode):
             return self.password
         if name == 'key':
             return self.key
-        raise ValueError('Attribute {name} not found in stratoweave_rfs__device__initial_credentials')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=True, root_path=['stratoweave-rfs:device', 'initial-credentials'])
@@ -1206,7 +1201,7 @@ class stratoweave_rfs__device__initial_credentials_entry(yang.adata.MNode):
         """Create a deep copy of this adata object"""
         return stratoweave_rfs__device__initial_credentials_entry.from_gdata(self.to_gdata())
 
-_breaker = 1
+_breaker9 = None
 class stratoweave_rfs__device__initial_credentials(yang.adata.MNode):
     elements: list[stratoweave_rfs__device__initial_credentials_entry]
     mut def __init__(self, elements=[]):
@@ -1253,7 +1248,7 @@ extension stratoweave_rfs__device__initial_credentials(Iterable[stratoweave_rfs_
     def __iter__(self) -> Iterator[stratoweave_rfs__device__initial_credentials_entry]:
         return self.elements.__iter__()
 
-_breaker = 1
+_breaker10 = None
 class stratoweave_rfs__device__mock__module_entry(yang.adata.MNode):
     name: str
     namespace: ?str
@@ -1276,7 +1271,6 @@ class stratoweave_rfs__device__mock__module_entry(yang.adata.MNode):
             return self.revision
         if name == 'feature':
             return self.feature
-        raise ValueError('Attribute {name} not found in stratoweave_rfs__device__mock__module')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=True, root_path=['stratoweave-rfs:device', 'mock', 'module'])
@@ -1289,7 +1283,7 @@ class stratoweave_rfs__device__mock__module_entry(yang.adata.MNode):
         """Create a deep copy of this adata object"""
         return stratoweave_rfs__device__mock__module_entry.from_gdata(self.to_gdata())
 
-_breaker = 1
+_breaker11 = None
 class stratoweave_rfs__device__mock__module(yang.adata.MNode):
     elements: list[stratoweave_rfs__device__mock__module_entry]
     mut def __init__(self, elements=[]):
@@ -1334,7 +1328,7 @@ extension stratoweave_rfs__device__mock__module(Iterable[stratoweave_rfs__device
     def __iter__(self) -> Iterator[stratoweave_rfs__device__mock__module_entry]:
         return self.elements.__iter__()
 
-_breaker = 1
+_breaker12 = None
 class stratoweave_rfs__device__mock(yang.adata.MNode):
     enabled: ?bool
     preset: list[str]
@@ -1353,7 +1347,6 @@ class stratoweave_rfs__device__mock(yang.adata.MNode):
             return self.preset
         if name == 'module':
             return iter(self.module)
-        raise ValueError('Attribute {name} not found in stratoweave_rfs__device__mock')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=True, root_path=['stratoweave-rfs:device', 'mock'])
@@ -1369,7 +1362,7 @@ class stratoweave_rfs__device__mock(yang.adata.MNode):
         return stratoweave_rfs__device__mock.from_gdata(self.to_gdata())
 
 
-_breaker = 1
+_breaker13 = None
 class stratoweave_rfs__device__debug(yang.adata.MNode):
     connection: ?bool
 
@@ -1380,7 +1373,6 @@ class stratoweave_rfs__device__debug(yang.adata.MNode):
     def _get_attr(self, name: str) -> ?value:
         if name == 'connection':
             return self.connection
-        raise ValueError('Attribute {name} not found in stratoweave_rfs__device__debug')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=True, root_path=['stratoweave-rfs:device', 'debug'])
@@ -1396,7 +1388,7 @@ class stratoweave_rfs__device__debug(yang.adata.MNode):
         return stratoweave_rfs__device__debug.from_gdata(self.to_gdata())
 
 
-_breaker = 1
+_breaker14 = None
 class stratoweave_rfs__device__feature_flags(yang.adata.MNode):
     runtime_schema_fetch: ?bool
 
@@ -1407,7 +1399,6 @@ class stratoweave_rfs__device__feature_flags(yang.adata.MNode):
     def _get_attr(self, name: str) -> ?value:
         if name == 'runtime_schema_fetch':
             return self.runtime_schema_fetch
-        raise ValueError('Attribute {name} not found in stratoweave_rfs__device__feature_flags')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=True, root_path=['stratoweave-rfs:device', 'feature-flags'])
@@ -1423,7 +1414,7 @@ class stratoweave_rfs__device__feature_flags(yang.adata.MNode):
         return stratoweave_rfs__device__feature_flags.from_gdata(self.to_gdata())
 
 
-_breaker = 1
+_breaker15 = None
 class stratoweave_rfs__device_entry(yang.adata.MNode):
     name: str
     description: ?str
@@ -1470,7 +1461,6 @@ class stratoweave_rfs__device_entry(yang.adata.MNode):
             return self.debug
         if name == 'feature_flags':
             return self.feature_flags
-        raise ValueError('Attribute {name} not found in stratoweave_rfs__device')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=True, root_path=['stratoweave-rfs:device'])
@@ -1483,7 +1473,7 @@ class stratoweave_rfs__device_entry(yang.adata.MNode):
         """Create a deep copy of this adata object"""
         return stratoweave_rfs__device_entry.from_gdata(self.to_gdata())
 
-_breaker = 1
+_breaker16 = None
 class stratoweave_rfs__device(yang.adata.MNode):
     elements: list[stratoweave_rfs__device_entry]
     mut def __init__(self, elements=[]):
@@ -1530,7 +1520,7 @@ extension stratoweave_rfs__device(Iterable[stratoweave_rfs__device_entry]):
     def __iter__(self) -> Iterator[stratoweave_rfs__device_entry]:
         return self.elements.__iter__()
 
-_breaker = 1
+_breaker17 = None
 class stratoweave_rfs__rfs__base_config__dynstate(yang.adata.MNode):
     current_datetime: ?str
 
@@ -1541,7 +1531,6 @@ class stratoweave_rfs__rfs__base_config__dynstate(yang.adata.MNode):
     def _get_attr(self, name: str) -> ?value:
         if name == 'current_datetime':
             return self.current_datetime
-        raise ValueError('Attribute {name} not found in stratoweave_rfs__rfs__base_config__dynstate')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=True, root_path=['stratoweave-rfs:rfs', 'mini-rfs:base-config', 'dynstate'])
@@ -1557,26 +1546,21 @@ class stratoweave_rfs__rfs__base_config__dynstate(yang.adata.MNode):
         return stratoweave_rfs__rfs__base_config__dynstate.from_gdata(self.to_gdata())
 
 
-_breaker = 1
+_breaker18 = None
 class stratoweave_rfs__rfs__base_config(yang.adata.MNode):
     name: ?str
     ipv4_address: ?str
-    dynstate: stratoweave_rfs__rfs__base_config__dynstate
 
-    mut def __init__(self, name: ?str, ipv4_address: ?str, dynstate: ?stratoweave_rfs__rfs__base_config__dynstate=None):
+    mut def __init__(self, name: ?str, ipv4_address: ?str):
         self._ns = 'http://example.com/mini-rfs'
         self.name = name
         self.ipv4_address = ipv4_address
-        self.dynstate = dynstate if dynstate is not None else stratoweave_rfs__rfs__base_config__dynstate()
 
     def _get_attr(self, name: str) -> ?value:
         if name == 'name':
             return self.name
         if name == 'ipv4_address':
             return self.ipv4_address
-        if name == 'dynstate':
-            return self.dynstate
-        raise ValueError('Attribute {name} not found in stratoweave_rfs__rfs__base_config')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=True, root_path=['stratoweave-rfs:rfs', 'mini-rfs:base-config'])
@@ -1584,7 +1568,7 @@ class stratoweave_rfs__rfs__base_config(yang.adata.MNode):
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> stratoweave_rfs__rfs__base_config:
         if n is not None:
-            return stratoweave_rfs__rfs__base_config(name=n.get_opt_str(yang.gdata.Id(NS_mini_rfs, 'name')), ipv4_address=n.get_opt_str(yang.gdata.Id(NS_mini_rfs, 'ipv4-address')), dynstate=stratoweave_rfs__rfs__base_config__dynstate.from_gdata(n.get_opt_cnt(yang.gdata.Id(NS_mini_rfs, 'dynstate'))))
+            return stratoweave_rfs__rfs__base_config(name=n.get_opt_str(yang.gdata.Id(NS_mini_rfs, 'name')), ipv4_address=n.get_opt_str(yang.gdata.Id(NS_mini_rfs, 'ipv4-address')))
         return stratoweave_rfs__rfs__base_config()
 
     def copy(self):
@@ -1592,7 +1576,7 @@ class stratoweave_rfs__rfs__base_config(yang.adata.MNode):
         return stratoweave_rfs__rfs__base_config.from_gdata(self.to_gdata())
 
 
-_breaker = 1
+_breaker19 = None
 class stratoweave_rfs__rfs__l3vpn_endpoint_entry(yang.adata.MNode):
     interface_name: str
     vpn_name: ?str
@@ -1651,7 +1635,6 @@ class stratoweave_rfs__rfs__l3vpn_endpoint_entry(yang.adata.MNode):
             return self.site_code
         if name == 'description':
             return self.description
-        raise ValueError('Attribute {name} not found in stratoweave_rfs__rfs__l3vpn_endpoint')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=True, root_path=['stratoweave-rfs:rfs', 'mini-rfs:l3vpn-endpoint'])
@@ -1664,7 +1647,7 @@ class stratoweave_rfs__rfs__l3vpn_endpoint_entry(yang.adata.MNode):
         """Create a deep copy of this adata object"""
         return stratoweave_rfs__rfs__l3vpn_endpoint_entry.from_gdata(self.to_gdata())
 
-_breaker = 1
+_breaker20 = None
 class stratoweave_rfs__rfs__l3vpn_endpoint(yang.adata.MNode):
     elements: list[stratoweave_rfs__rfs__l3vpn_endpoint_entry]
     mut def __init__(self, elements=[]):
@@ -1729,7 +1712,7 @@ extension stratoweave_rfs__rfs__l3vpn_endpoint(Iterable[stratoweave_rfs__rfs__l3
     def __iter__(self) -> Iterator[stratoweave_rfs__rfs__l3vpn_endpoint_entry]:
         return self.elements.__iter__()
 
-_breaker = 1
+_breaker21 = None
 class stratoweave_rfs__rfs_entry(yang.adata.MNode):
     name: str
     base_config: stratoweave_rfs__rfs__base_config
@@ -1748,7 +1731,6 @@ class stratoweave_rfs__rfs_entry(yang.adata.MNode):
             return self.base_config
         if name == 'l3vpn_endpoint':
             return iter(self.l3vpn_endpoint)
-        raise ValueError('Attribute {name} not found in stratoweave_rfs__rfs')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=True, root_path=['stratoweave-rfs:rfs'])
@@ -1761,7 +1743,7 @@ class stratoweave_rfs__rfs_entry(yang.adata.MNode):
         """Create a deep copy of this adata object"""
         return stratoweave_rfs__rfs_entry.from_gdata(self.to_gdata())
 
-_breaker = 1
+_breaker22 = None
 class stratoweave_rfs__rfs(yang.adata.MNode):
     elements: list[stratoweave_rfs__rfs_entry]
     mut def __init__(self, elements=[]):
@@ -1802,7 +1784,7 @@ extension stratoweave_rfs__rfs(Iterable[stratoweave_rfs__rfs_entry]):
     def __iter__(self) -> Iterator[stratoweave_rfs__rfs_entry]:
         return self.elements.__iter__()
 
-_breaker = 1
+_breaker23 = None
 class root(yang.adata.MNode):
     device: stratoweave_rfs__device
     rfs: stratoweave_rfs__rfs
@@ -1817,7 +1799,6 @@ class root(yang.adata.MNode):
             return iter(self.device)
         if name == 'rfs':
             return iter(self.rfs)
-        raise ValueError('Attribute {name} not found in root')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=True)

--- a/minisys/src/mini/layers/y_2.act
+++ b/minisys/src/mini/layers/y_2.act
@@ -123,7 +123,7 @@ NS_stratoweave_device = 'http://stratoweave.org/yang/stratoweave-device.yang'
 NS_stratoweave = 'http://stratoweave.org/yang/stratoweave.yang'
 
 
-_breaker = 1
+_breaker1 = None
 class stratoweave_device__devices__device_entry(yang.adata.MNode):
     name: str
     modset_id: ?str
@@ -138,7 +138,6 @@ class stratoweave_device__devices__device_entry(yang.adata.MNode):
             return self.name
         if name == 'modset_id':
             return self.modset_id
-        raise ValueError('Attribute {name} not found in stratoweave_device__devices__device')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=False, root_path=['stratoweave-device:devices', 'device'])
@@ -151,7 +150,7 @@ class stratoweave_device__devices__device_entry(yang.adata.MNode):
         """Create a deep copy of this adata object"""
         return stratoweave_device__devices__device_entry.from_gdata(self.to_gdata())
 
-_breaker = 1
+_breaker2 = None
 class stratoweave_device__devices__device(yang.adata.MNode):
     elements: list[stratoweave_device__devices__device_entry]
     mut def __init__(self, elements=[]):
@@ -194,7 +193,7 @@ extension stratoweave_device__devices__device(Iterable[stratoweave_device__devic
     def __iter__(self) -> Iterator[stratoweave_device__devices__device_entry]:
         return self.elements.__iter__()
 
-_breaker = 1
+_breaker3 = None
 class stratoweave_device__devices(yang.adata.MNode):
     device: stratoweave_device__devices__device
 
@@ -205,7 +204,6 @@ class stratoweave_device__devices(yang.adata.MNode):
     def _get_attr(self, name: str) -> ?value:
         if name == 'device':
             return iter(self.device)
-        raise ValueError('Attribute {name} not found in stratoweave_device__devices')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=False, root_path=['stratoweave-device:devices'])
@@ -221,7 +219,7 @@ class stratoweave_device__devices(yang.adata.MNode):
         return stratoweave_device__devices.from_gdata(self.to_gdata())
 
 
-_breaker = 1
+_breaker4 = None
 class root(yang.adata.MNode):
     devices: stratoweave_device__devices
 
@@ -232,7 +230,6 @@ class root(yang.adata.MNode):
     def _get_attr(self, name: str) -> ?value:
         if name == 'devices':
             return self.devices
-        raise ValueError('Attribute {name} not found in root')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=False)

--- a/minisys/src/mini/layers/y_2_loose.act
+++ b/minisys/src/mini/layers/y_2_loose.act
@@ -123,7 +123,7 @@ NS_stratoweave_device = 'http://stratoweave.org/yang/stratoweave-device.yang'
 NS_stratoweave = 'http://stratoweave.org/yang/stratoweave.yang'
 
 
-_breaker = 1
+_breaker1 = None
 class stratoweave_device__devices__device_entry(yang.adata.MNode):
     name: str
     modset_id: ?str
@@ -138,7 +138,6 @@ class stratoweave_device__devices__device_entry(yang.adata.MNode):
             return self.name
         if name == 'modset_id':
             return self.modset_id
-        raise ValueError('Attribute {name} not found in stratoweave_device__devices__device')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=True, root_path=['stratoweave-device:devices', 'device'])
@@ -151,7 +150,7 @@ class stratoweave_device__devices__device_entry(yang.adata.MNode):
         """Create a deep copy of this adata object"""
         return stratoweave_device__devices__device_entry.from_gdata(self.to_gdata())
 
-_breaker = 1
+_breaker2 = None
 class stratoweave_device__devices__device(yang.adata.MNode):
     elements: list[stratoweave_device__devices__device_entry]
     mut def __init__(self, elements=[]):
@@ -194,7 +193,7 @@ extension stratoweave_device__devices__device(Iterable[stratoweave_device__devic
     def __iter__(self) -> Iterator[stratoweave_device__devices__device_entry]:
         return self.elements.__iter__()
 
-_breaker = 1
+_breaker3 = None
 class stratoweave_device__devices(yang.adata.MNode):
     device: stratoweave_device__devices__device
 
@@ -205,7 +204,6 @@ class stratoweave_device__devices(yang.adata.MNode):
     def _get_attr(self, name: str) -> ?value:
         if name == 'device':
             return iter(self.device)
-        raise ValueError('Attribute {name} not found in stratoweave_device__devices')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=True, root_path=['stratoweave-device:devices'])
@@ -221,7 +219,7 @@ class stratoweave_device__devices(yang.adata.MNode):
         return stratoweave_device__devices.from_gdata(self.to_gdata())
 
 
-_breaker = 1
+_breaker4 = None
 class root(yang.adata.MNode):
     devices: stratoweave_device__devices
 
@@ -232,7 +230,6 @@ class root(yang.adata.MNode):
     def _get_attr(self, name: str) -> ?value:
         if name == 'devices':
             return self.devices
-        raise ValueError('Attribute {name} not found in root')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=True)

--- a/src/orchestron/build.act
+++ b/src/orchestron/build.act
@@ -8,6 +8,8 @@ import orchestron.yang as oyang
 import transform_unions
 import yang.parser
 
+_SW_NS = "http://stratoweave.org/yang/stratoweave.yang"
+_SW_EXCLUDE_EXT = [("dynstate", _SW_NS), ("memory", _SW_NS)]
 
 def _maybe_write_file(fc: file.FileCap, name: str, content: str) -> bool:
     """Write new content to a file if the content is different from existing content"""
@@ -92,7 +94,7 @@ class CompiledSysSpec(object):
             y_name = "{output_dir}/{self.name}/layers/y_{lname}.act"
             modname = "{self.name}.layers.y_{lname}"
 
-            if _maybe_write_file(fc, y_name, layer.print()):
+            if _maybe_write_file(fc, y_name, layer.print(exclude_ext=_SW_EXCLUDE_EXT)):
                 print("+ Layer {idx} adata changed")
             else:
                 print("+ Layer {idx} adata unchanged")
@@ -135,7 +137,7 @@ class CompiledSysSpec(object):
             syssrc_schema_for_layer += "        return {self.name}.layers.y_{idx}.SRC_DNODE\n"
 
             loose_name = "{output_dir}/{self.name}/layers/y_{idx}_loose.act"
-            if _maybe_write_file(fc, loose_name, layer.print(loose=True)):
+            if _maybe_write_file(fc, loose_name, layer.print(loose=True, exclude_ext=_SW_EXCLUDE_EXT)):
                 print("+ Layer {idx} loose adata changed")
             else:
                 print("+ Layer {idx} loose adata unchanged")
@@ -254,7 +256,7 @@ class CompiledLayerBase(object):
     root: yang.schema.DRoot
     src: list[str]
 
-    def print(self, loose=False, gen_json=True, include_state=False):
+    def print(self, loose=False, gen_json=True, include_state=False, exclude_ext: list[(name: str, namespace: str)]=[]):
         """Print the Acton (adata) classes for the layer
 
         This prints the entire contents of the Acton module representing a
@@ -262,7 +264,7 @@ class CompiledLayerBase(object):
         classes, XML and JSON deserializers and the schema info. The schema is
         used by the XML and JSON schema-driven deserializers.
         """
-        return self.root.prdaclass(schema_yang=self.src, loose=loose, include_state=include_state)
+        return self.root.prdaclass(schema_yang=self.src, loose=loose, include_state=include_state, exclude_ext=exclude_ext)
 
 class CompiledLayer(CompiledLayerBase):
     def __init__(self, root: yang.schema.DRoot, src: list[str], name: ?str=None):

--- a/src/orchestron/device_meta_config.act
+++ b/src/orchestron/device_meta_config.act
@@ -768,7 +768,7 @@ NS_stratoweave = 'http://stratoweave.org/yang/stratoweave.yang'
 NS_ietf_inet_types = 'urn:ietf:params:xml:ns:yang:ietf-inet-types'
 
 
-_breaker = 1
+_breaker1 = None
 class stratoweave_rfs__device__address__initial_credentials_entry(yang.adata.MNode):
     username: str
     password: str
@@ -787,7 +787,6 @@ class stratoweave_rfs__device__address__initial_credentials_entry(yang.adata.MNo
             return self.password
         if name == 'key':
             return self.key
-        raise ValueError('Attribute {name} not found in stratoweave_rfs__device__address__initial_credentials')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=False, root_path=['stratoweave-rfs:device', 'address', 'initial-credentials'])
@@ -800,7 +799,7 @@ class stratoweave_rfs__device__address__initial_credentials_entry(yang.adata.MNo
         """Create a deep copy of this adata object"""
         return stratoweave_rfs__device__address__initial_credentials_entry.from_gdata(self.to_gdata())
 
-_breaker = 1
+_breaker2 = None
 class stratoweave_rfs__device__address__initial_credentials(yang.adata.MNode):
     elements: list[stratoweave_rfs__device__address__initial_credentials_entry]
     mut def __init__(self, elements=[]):
@@ -847,7 +846,7 @@ extension stratoweave_rfs__device__address__initial_credentials(Iterable[stratow
     def __iter__(self) -> Iterator[stratoweave_rfs__device__address__initial_credentials_entry]:
         return self.elements.__iter__()
 
-_breaker = 1
+_breaker3 = None
 class stratoweave_rfs__device__address_entry(yang.adata.MNode):
     name: str
     address: str
@@ -870,7 +869,6 @@ class stratoweave_rfs__device__address_entry(yang.adata.MNode):
             return self.port
         if name == 'initial_credentials':
             return iter(self.initial_credentials)
-        raise ValueError('Attribute {name} not found in stratoweave_rfs__device__address')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=False, root_path=['stratoweave-rfs:device', 'address'])
@@ -883,7 +881,7 @@ class stratoweave_rfs__device__address_entry(yang.adata.MNode):
         """Create a deep copy of this adata object"""
         return stratoweave_rfs__device__address_entry.from_gdata(self.to_gdata())
 
-_breaker = 1
+_breaker4 = None
 class stratoweave_rfs__device__address(yang.adata.MNode):
     elements: list[stratoweave_rfs__device__address_entry]
     mut def __init__(self, elements=[]):
@@ -927,7 +925,7 @@ extension stratoweave_rfs__device__address(Iterable[stratoweave_rfs__device__add
     def __iter__(self) -> Iterator[stratoweave_rfs__device__address_entry]:
         return self.elements.__iter__()
 
-_breaker = 1
+_breaker5 = None
 class stratoweave_rfs__device__credentials__key_entry(yang.adata.MNode):
     key: str
     private_key: ?str
@@ -942,7 +940,6 @@ class stratoweave_rfs__device__credentials__key_entry(yang.adata.MNode):
             return self.key
         if name == 'private_key':
             return self.private_key
-        raise ValueError('Attribute {name} not found in stratoweave_rfs__device__credentials__key')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=False, root_path=['stratoweave-rfs:device', 'credentials', 'key'])
@@ -955,7 +952,7 @@ class stratoweave_rfs__device__credentials__key_entry(yang.adata.MNode):
         """Create a deep copy of this adata object"""
         return stratoweave_rfs__device__credentials__key_entry.from_gdata(self.to_gdata())
 
-_breaker = 1
+_breaker6 = None
 class stratoweave_rfs__device__credentials__key(yang.adata.MNode):
     elements: list[stratoweave_rfs__device__credentials__key_entry]
     mut def __init__(self, elements=[]):
@@ -998,7 +995,7 @@ extension stratoweave_rfs__device__credentials__key(Iterable[stratoweave_rfs__de
     def __iter__(self) -> Iterator[stratoweave_rfs__device__credentials__key_entry]:
         return self.elements.__iter__()
 
-_breaker = 1
+_breaker7 = None
 class stratoweave_rfs__device__credentials(yang.adata.MNode):
     username: str
     password: ?str
@@ -1017,7 +1014,6 @@ class stratoweave_rfs__device__credentials(yang.adata.MNode):
             return self.password
         if name == 'key':
             return iter(self.key)
-        raise ValueError('Attribute {name} not found in stratoweave_rfs__device__credentials')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=False, root_path=['stratoweave-rfs:device', 'credentials'])
@@ -1033,7 +1029,7 @@ class stratoweave_rfs__device__credentials(yang.adata.MNode):
         return stratoweave_rfs__device__credentials.from_gdata(self.to_gdata())
 
 
-_breaker = 1
+_breaker8 = None
 class stratoweave_rfs__device__initial_credentials_entry(yang.adata.MNode):
     username: str
     password: str
@@ -1052,7 +1048,6 @@ class stratoweave_rfs__device__initial_credentials_entry(yang.adata.MNode):
             return self.password
         if name == 'key':
             return self.key
-        raise ValueError('Attribute {name} not found in stratoweave_rfs__device__initial_credentials')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=False, root_path=['stratoweave-rfs:device', 'initial-credentials'])
@@ -1065,7 +1060,7 @@ class stratoweave_rfs__device__initial_credentials_entry(yang.adata.MNode):
         """Create a deep copy of this adata object"""
         return stratoweave_rfs__device__initial_credentials_entry.from_gdata(self.to_gdata())
 
-_breaker = 1
+_breaker9 = None
 class stratoweave_rfs__device__initial_credentials(yang.adata.MNode):
     elements: list[stratoweave_rfs__device__initial_credentials_entry]
     mut def __init__(self, elements=[]):
@@ -1112,7 +1107,7 @@ extension stratoweave_rfs__device__initial_credentials(Iterable[stratoweave_rfs_
     def __iter__(self) -> Iterator[stratoweave_rfs__device__initial_credentials_entry]:
         return self.elements.__iter__()
 
-_breaker = 1
+_breaker10 = None
 class stratoweave_rfs__device__mock__module_entry(yang.adata.MNode):
     name: str
     namespace: str
@@ -1135,7 +1130,6 @@ class stratoweave_rfs__device__mock__module_entry(yang.adata.MNode):
             return self.revision
         if name == 'feature':
             return self.feature
-        raise ValueError('Attribute {name} not found in stratoweave_rfs__device__mock__module')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=False, root_path=['stratoweave-rfs:device', 'mock', 'module'])
@@ -1148,7 +1142,7 @@ class stratoweave_rfs__device__mock__module_entry(yang.adata.MNode):
         """Create a deep copy of this adata object"""
         return stratoweave_rfs__device__mock__module_entry.from_gdata(self.to_gdata())
 
-_breaker = 1
+_breaker11 = None
 class stratoweave_rfs__device__mock__module(yang.adata.MNode):
     elements: list[stratoweave_rfs__device__mock__module_entry]
     mut def __init__(self, elements=[]):
@@ -1192,7 +1186,7 @@ extension stratoweave_rfs__device__mock__module(Iterable[stratoweave_rfs__device
     def __iter__(self) -> Iterator[stratoweave_rfs__device__mock__module_entry]:
         return self.elements.__iter__()
 
-_breaker = 1
+_breaker12 = None
 class stratoweave_rfs__device__mock(yang.adata.MNode):
     enabled: bool
     preset: list[str]
@@ -1211,7 +1205,6 @@ class stratoweave_rfs__device__mock(yang.adata.MNode):
             return self.preset
         if name == 'module':
             return iter(self.module)
-        raise ValueError('Attribute {name} not found in stratoweave_rfs__device__mock')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=False, root_path=['stratoweave-rfs:device', 'mock'])
@@ -1227,7 +1220,7 @@ class stratoweave_rfs__device__mock(yang.adata.MNode):
         return stratoweave_rfs__device__mock.from_gdata(self.to_gdata())
 
 
-_breaker = 1
+_breaker13 = None
 class stratoweave_rfs__device__debug(yang.adata.MNode):
     connection: bool
 
@@ -1238,7 +1231,6 @@ class stratoweave_rfs__device__debug(yang.adata.MNode):
     def _get_attr(self, name: str) -> ?value:
         if name == 'connection':
             return self.connection
-        raise ValueError('Attribute {name} not found in stratoweave_rfs__device__debug')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=False, root_path=['stratoweave-rfs:device', 'debug'])
@@ -1254,7 +1246,7 @@ class stratoweave_rfs__device__debug(yang.adata.MNode):
         return stratoweave_rfs__device__debug.from_gdata(self.to_gdata())
 
 
-_breaker = 1
+_breaker14 = None
 class stratoweave_rfs__device__feature_flags(yang.adata.MNode):
     runtime_schema_fetch: bool
 
@@ -1265,7 +1257,6 @@ class stratoweave_rfs__device__feature_flags(yang.adata.MNode):
     def _get_attr(self, name: str) -> ?value:
         if name == 'runtime_schema_fetch':
             return self.runtime_schema_fetch
-        raise ValueError('Attribute {name} not found in stratoweave_rfs__device__feature_flags')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=False, root_path=['stratoweave-rfs:device', 'feature-flags'])
@@ -1281,7 +1272,7 @@ class stratoweave_rfs__device__feature_flags(yang.adata.MNode):
         return stratoweave_rfs__device__feature_flags.from_gdata(self.to_gdata())
 
 
-_breaker = 1
+_breaker15 = None
 class stratoweave_rfs__device_entry(yang.adata.MNode):
     name: str
     description: ?str
@@ -1328,7 +1319,6 @@ class stratoweave_rfs__device_entry(yang.adata.MNode):
             return self.debug
         if name == 'feature_flags':
             return self.feature_flags
-        raise ValueError('Attribute {name} not found in stratoweave_rfs__device')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=False, root_path=['stratoweave-rfs:device'])
@@ -1341,7 +1331,7 @@ class stratoweave_rfs__device_entry(yang.adata.MNode):
         """Create a deep copy of this adata object"""
         return stratoweave_rfs__device_entry.from_gdata(self.to_gdata())
 
-_breaker = 1
+_breaker16 = None
 class stratoweave_rfs__device(yang.adata.MNode):
     elements: list[stratoweave_rfs__device_entry]
     mut def __init__(self, elements=[]):


### PR DESCRIPTION
When generating adata (for a transform) filter out the dynstate / memory
contianers so that they do do show up as an attribute on a transform
input / output type.

Closes #124 