### PR TITLE
Wire linked inputs in generated TTT helper modules

### DIFF
--- a/gen_dmc/src/swyang.act
+++ b/gen_dmc/src/swyang.act
@@ -45,6 +45,20 @@ stratoweave = r"""module stratoweave {
       function inputs with an additional read-only structure. The transform
       function may update this subtree by returning new data.";
   }
+  extension link {
+    description
+      "Declares a link demand from this transform towards another (linked)
+      transform. The argument is a tag that identifies the link. On a leafref
+      leaf, the link target is derived from the leafref path. On other nodes,
+      a nested sw:path substatement provides the target path.";
+    argument "tag";
+  }
+  extension path {
+    description
+      "Substatement of sw:link that provides an explicit absolute schema path
+      to the linked transform target.";
+    argument "path";
+  }
 }"""
 
 

--- a/minisys/gen/yang/cfs/l3vpn.yang
+++ b/minisys/gen/yang/cfs/l3vpn.yang
@@ -10,6 +10,9 @@ module l3vpn {
   import ietf-inet-types {
     prefix inet;
   }
+  import netinfra {
+    prefix netinfra;
+  }
   import stratoweave {
     prefix sw;
   }
@@ -18,6 +21,9 @@ module l3vpn {
     key name;
 
     sw:transform mini.cfs.L3vpn;
+    sw:link global {
+      sw:path /netinfra:netinfra/netinfra:global-settings;
+    }
 
     leaf name {
       type string;
@@ -51,7 +57,10 @@ module l3vpn {
       key "device interface-name";
 
       leaf device {
-        type string;
+        sw:link router;
+        type leafref {
+          path /netinfra:netinfra/netinfra:router/netinfra:name;
+        }
         mandatory true;
       }
 

--- a/minisys/gen/yang/cfs/netinfra.yang
+++ b/minisys/gen/yang/cfs/netinfra.yang
@@ -13,10 +13,19 @@ module netinfra {
 
   container netinfra {
     description "Network infrastructure";
+    container global-settings {
+      sw:transform mini.cfs.GlobalSettings;
+      leaf asn {
+        type uint32;
+      }
+    }
     list router {
       key name;
 
       sw:transform mini.cfs.Router;
+      sw:link global {
+        sw:path /netinfra/global-settings;
+      }
 
       leaf name {
         type string;

--- a/minisys/src/mini/cfs.act
+++ b/minisys/src/mini/cfs.act
@@ -8,6 +8,11 @@ import mini.layers.base_0 as base
 # https://github.com/actonlang/acton/issues/2390
 import yang.identityref, mini.layers.y_0
 
+class GlobalSettings(base.GlobalSettings):
+    def transform(self, i):
+        o = base.o_root()
+        return o
+
 class Router(base.Router):
     def transform(self, i):
         o = base.o_root()

--- a/minisys/src/mini/cfs.act
+++ b/minisys/src/mini/cfs.act
@@ -1,6 +1,7 @@
 import logging
 
 import yang.adata
+import yang.gdata # required for linked input parameter to transform function
 import stratoweave.ttt
 
 import mini.layers.base_0 as base
@@ -14,7 +15,7 @@ class GlobalSettings(base.GlobalSettings):
         return o
 
 class Router(base.Router):
-    def transform(self, i):
+    def transform(self, i, linked):
         o = base.o_root()
         print("CFS router transform running", i.name)
         dev = o.device.create(i.name)
@@ -35,7 +36,7 @@ class Router(base.Router):
 
 
 class L3vpn(base.L3vpn):
-    def transform(self, i):
+    def transform(self, i, linked):
         o = base.o_root()
         print("CFS l3vpn transform running", i.name)
         rd = "65000:{i.vpn_id}"

--- a/minisys/src/mini/layers/base_0.act
+++ b/minisys/src/mini/layers/base_0.act
@@ -27,7 +27,7 @@ class GlobalSettings(ttt.TransformFunction):
         """Return the modeled input type for this transform"""
         return netinfra__netinfra__global_settings
 
-    mut def transform_wrapper(self, i: yang.gdata.Node, memory: ?yang.gdata.Node, dynstate: ?yang.gdata.Node) -> (yang.gdata.Node, ?yang.gdata.Node):
+    mut def transform_wrapper(self, i: yang.gdata.Node, linked: yang.gdata.Node, memory: ?yang.gdata.Node, dynstate: ?yang.gdata.Node) -> (yang.gdata.Node, ?yang.gdata.Node):
         """Wrap the user provided transform method to convert from gdata to
         modeled input and back to gdata
         """
@@ -35,7 +35,7 @@ class GlobalSettings(ttt.TransformFunction):
 
         return self.transform(modeled_input).to_gdata(), None
 
-    mut def transform_xml(self, i: xml.Node, memory: ?yang.gdata.Node, dynstate: ?yang.gdata.Node) -> (yang.gdata.Node, ?yang.gdata.Node):
+    mut def transform_xml(self, i: xml.Node, linked: yang.gdata.Node, memory: ?yang.gdata.Node, dynstate: ?yang.gdata.Node) -> (yang.gdata.Node, ?yang.gdata.Node):
         """Wrap the user provided transform method to convert from XML to
         modeled input and return gdata
         """
@@ -45,51 +45,51 @@ class GlobalSettings(ttt.TransformFunction):
         return self.transform(modeled_input).to_gdata(), None
 
 class Router(ttt.TransformFunction):
-    transform: mut(netinfra__netinfra__router_entry) -> yang.adata.MNode
+    transform: mut(netinfra__netinfra__router_entry, linked: yang.gdata.Node) -> yang.adata.MNode
 
     @staticmethod
     def input_type():
         """Return the modeled input type for this transform"""
         return netinfra__netinfra__router_entry
 
-    mut def transform_wrapper(self, i: yang.gdata.Node, memory: ?yang.gdata.Node, dynstate: ?yang.gdata.Node) -> (yang.gdata.Node, ?yang.gdata.Node):
+    mut def transform_wrapper(self, i: yang.gdata.Node, linked: yang.gdata.Node, memory: ?yang.gdata.Node, dynstate: ?yang.gdata.Node) -> (yang.gdata.Node, ?yang.gdata.Node):
         """Wrap the user provided transform method to convert from gdata to
         modeled input and back to gdata
         """
         modeled_input = netinfra__netinfra__router_entry.from_gdata(i)
 
-        return self.transform(modeled_input).to_gdata(), None
+        return self.transform(modeled_input, linked).to_gdata(), None
 
-    mut def transform_xml(self, i: xml.Node, memory: ?yang.gdata.Node, dynstate: ?yang.gdata.Node) -> (yang.gdata.Node, ?yang.gdata.Node):
+    mut def transform_xml(self, i: xml.Node, linked: yang.gdata.Node, memory: ?yang.gdata.Node, dynstate: ?yang.gdata.Node) -> (yang.gdata.Node, ?yang.gdata.Node):
         """Wrap the user provided transform method to convert from XML to
         modeled input and return gdata
         """
         gdata_input = yang.xml.from_xml(SRC_DNODE, i, loose=False, root_path=['netinfra:netinfra', 'router'])
         modeled_input = netinfra__netinfra__router_entry.from_gdata(gdata_input)
 
-        return self.transform(modeled_input).to_gdata(), None
+        return self.transform(modeled_input, linked).to_gdata(), None
 
 class L3vpn(ttt.TransformFunction):
-    transform: mut(l3vpn__l3vpn_entry) -> yang.adata.MNode
+    transform: mut(l3vpn__l3vpn_entry, linked: yang.gdata.Node) -> yang.adata.MNode
 
     @staticmethod
     def input_type():
         """Return the modeled input type for this transform"""
         return l3vpn__l3vpn_entry
 
-    mut def transform_wrapper(self, i: yang.gdata.Node, memory: ?yang.gdata.Node, dynstate: ?yang.gdata.Node) -> (yang.gdata.Node, ?yang.gdata.Node):
+    mut def transform_wrapper(self, i: yang.gdata.Node, linked: yang.gdata.Node, memory: ?yang.gdata.Node, dynstate: ?yang.gdata.Node) -> (yang.gdata.Node, ?yang.gdata.Node):
         """Wrap the user provided transform method to convert from gdata to
         modeled input and back to gdata
         """
         modeled_input = l3vpn__l3vpn_entry.from_gdata(i)
 
-        return self.transform(modeled_input).to_gdata(), None
+        return self.transform(modeled_input, linked).to_gdata(), None
 
-    mut def transform_xml(self, i: xml.Node, memory: ?yang.gdata.Node, dynstate: ?yang.gdata.Node) -> (yang.gdata.Node, ?yang.gdata.Node):
+    mut def transform_xml(self, i: xml.Node, linked: yang.gdata.Node, memory: ?yang.gdata.Node, dynstate: ?yang.gdata.Node) -> (yang.gdata.Node, ?yang.gdata.Node):
         """Wrap the user provided transform method to convert from XML to
         modeled input and return gdata
         """
         gdata_input = yang.xml.from_xml(SRC_DNODE, i, loose=False, root_path=['l3vpn:l3vpn'])
         modeled_input = l3vpn__l3vpn_entry.from_gdata(gdata_input)
 
-        return self.transform(modeled_input).to_gdata(), None
+        return self.transform(modeled_input, linked).to_gdata(), None

--- a/minisys/src/mini/layers/base_0.act
+++ b/minisys/src/mini/layers/base_0.act
@@ -9,6 +9,7 @@ import yang.adata
 import yang.gdata
 import yang.xml
 
+from mini.layers.y_0 import netinfra__netinfra__global_settings
 from mini.layers.y_0 import netinfra__netinfra__router_entry
 from mini.layers.y_0 import l3vpn__l3vpn_entry
 from mini.layers.y_0 import SRC_DNODE
@@ -17,6 +18,31 @@ from mini.layers.y_1_loose import root as output_root
 def o_root():
     return output_root()
 
+
+class GlobalSettings(ttt.TransformFunction):
+    transform: mut(netinfra__netinfra__global_settings) -> yang.adata.MNode
+
+    @staticmethod
+    def input_type():
+        """Return the modeled input type for this transform"""
+        return netinfra__netinfra__global_settings
+
+    mut def transform_wrapper(self, i: yang.gdata.Node, memory: ?yang.gdata.Node, dynstate: ?yang.gdata.Node) -> (yang.gdata.Node, ?yang.gdata.Node):
+        """Wrap the user provided transform method to convert from gdata to
+        modeled input and back to gdata
+        """
+        modeled_input = netinfra__netinfra__global_settings.from_gdata(i)
+
+        return self.transform(modeled_input).to_gdata(), None
+
+    mut def transform_xml(self, i: xml.Node, memory: ?yang.gdata.Node, dynstate: ?yang.gdata.Node) -> (yang.gdata.Node, ?yang.gdata.Node):
+        """Wrap the user provided transform method to convert from XML to
+        modeled input and return gdata
+        """
+        gdata_input = yang.xml.from_xml(SRC_DNODE, i, loose=False, root_path=['netinfra:netinfra', 'global-settings'])
+        modeled_input = netinfra__netinfra__global_settings.from_gdata(gdata_input)
+
+        return self.transform(modeled_input).to_gdata(), None
 
 class Router(ttt.TransformFunction):
     transform: mut(netinfra__netinfra__router_entry) -> yang.adata.MNode

--- a/minisys/src/mini/layers/t_0.act
+++ b/minisys/src/mini/layers/t_0.act
@@ -12,5 +12,24 @@ import mini.cfs
 
 
 def get_ttt(lower: ?ttt.Layer, dev_registry: swdev.DeviceRegistry, log_handler: ?logging.Handler=None) -> proc(?ttt.Path,?ttt.Layer)->ttt.Node:
-    r = ttt.Container({yang.gdata.Id("http://example.com/netinfra", "netinfra"): ttt.Container({yang.gdata.Id("http://example.com/netinfra", "router"): ttt.List(ttt.Transform(mini.cfs.Router, None, lower, log_handler), [yang.gdata.Id("http://example.com/netinfra", "name")])}, ns='http://example.com/netinfra', module='netinfra'), yang.gdata.Id("http://example.com/l3vpn", "l3vpn"): ttt.List(ttt.Transform(mini.cfs.L3vpn, None, lower, log_handler), [yang.gdata.Id("http://example.com/l3vpn", "name")], ns='http://example.com/l3vpn', module='l3vpn')})
+    r = ttt.Container({yang.gdata.Id("http://example.com/netinfra", "netinfra"): ttt.Container({yang.gdata.Id("http://example.com/netinfra", "global-settings"): ttt.Transform(mini.cfs.GlobalSettings, None, None, lower, log_handler), yang.gdata.Id("http://example.com/netinfra", "router"): ttt.List(ttt.Transform(mini.cfs.Router, None, _build_target_links_netinfra__netinfra__router_entry, lower, log_handler), [yang.gdata.Id("http://example.com/netinfra", "name")])}, ns='http://example.com/netinfra', module='netinfra'), yang.gdata.Id("http://example.com/l3vpn", "l3vpn"): ttt.List(ttt.Transform(mini.cfs.L3vpn, None, _build_target_links_l3vpn__l3vpn_entry, lower, log_handler), [yang.gdata.Id("http://example.com/l3vpn", "name")], ns='http://example.com/l3vpn', module='l3vpn')})
     return r
+
+def _build_target_links_netinfra__netinfra__router_entry(conf: yang.gdata.Node) -> list[ttt.TaggedPath]:
+    res = []
+    # static link: global
+    res.append(ttt.TaggedPath('global', yang.gdata.FNode(yang.gdata.Id("http://example.com/netinfra", "netinfra"), children=[yang.gdata.FNode(yang.gdata.Id("http://example.com/netinfra", "global-settings"))])))
+    return res
+
+def _build_target_links_l3vpn__l3vpn_entry(conf: yang.gdata.Node) -> list[ttt.TaggedPath]:
+    res = []
+    # static link: global
+    res.append(ttt.TaggedPath('global', yang.gdata.FNode(yang.gdata.Id("http://example.com/netinfra", "netinfra"), children=[yang.gdata.FNode(yang.gdata.Id("http://example.com/netinfra", "global-settings"))])))
+    # leafref link: router
+    _l0 = conf.get_opt_list(yang.gdata.Id("http://example.com/l3vpn", "endpoint"))
+    if _l0 is not None:
+        for _e0 in _l0.elements:
+            _v1 = _e0.get_opt_value(yang.gdata.Id("http://example.com/l3vpn", "device"))
+            if _v1 is not None:
+                res.append(ttt.TaggedPath('router', yang.gdata.FNode(yang.gdata.Id("http://example.com/netinfra", "netinfra"), children=[yang.gdata.FNode(yang.gdata.Id("http://example.com/netinfra", "router"), children=[yang.gdata.FNode(yang.gdata.Id("http://example.com/netinfra", "name"), value_match=_v1)])])))
+    return res

--- a/minisys/src/mini/layers/y_0.act
+++ b/minisys/src/mini/layers/y_0.act
@@ -20,8 +20,14 @@ _identities: list[DIdentity] = []
 
 
 SRC_DNODE_CHILD_0 = DContainer(module='netinfra', namespace='http://example.com/netinfra', prefix='netinfra', name='netinfra', config=True, description='Network infrastructure', presence=False, children=[
+    DContainer(module='netinfra', namespace='http://example.com/netinfra', prefix='netinfra', name='global-settings', config=True, presence=False, exts=[
+            DExt(module='stratoweave', namespace='http://stratoweave.org/yang/stratoweave.yang', prefix='sw', name='transform', arg='mini.cfs.GlobalSettings', exts=[])
+        ], children=[
+        DLeaf(module='netinfra', namespace='http://example.com/netinfra', prefix='netinfra', name='asn', config=True, mandatory=False, type_=DTypeIntegerUnsigned(name='uint32', description=None, reference=None, exts=[], builtin_type='uint32', default=None, ranges=Ranges([(0, 4294967295)])))
+    ]),
     DList(module='netinfra', namespace='http://example.com/netinfra', prefix='netinfra', name='router', key=['name'], config=True, min_elements=0, ordered_by='system', exts=[
-            DExt(module='stratoweave', namespace='http://stratoweave.org/yang/stratoweave.yang', prefix='sw', name='transform', arg='mini.cfs.Router', exts=[])
+            DExt(module='stratoweave', namespace='http://stratoweave.org/yang/stratoweave.yang', prefix='sw', name='transform', arg='mini.cfs.Router', exts=[]),
+            DExt(module='stratoweave', namespace='http://stratoweave.org/yang/stratoweave.yang', prefix='sw', name='link', arg='global', exts=[DExt(module='stratoweave', namespace='http://stratoweave.org/yang/stratoweave.yang', prefix='sw', name='path', arg='/netinfra/global-settings', exts=[])])
         ], children=[
         DLeaf(module='netinfra', namespace='http://example.com/netinfra', prefix='netinfra', name='name', config=True, mandatory=False, type_=DTypeString(name='string', description=None, reference=None, exts=[], builtin_type='string', default=None, length=None, patterns=[])),
         DLeaf(module='netinfra', namespace='http://example.com/netinfra', prefix='netinfra', name='id', config=True, description='router id', mandatory=True, type_=DTypeIntegerUnsigned(name='uint32', description=None, reference=None, exts=[], builtin_type='uint32', default=None, ranges=Ranges([(0, 4294967295)]))),
@@ -31,7 +37,8 @@ SRC_DNODE_CHILD_0 = DContainer(module='netinfra', namespace='http://example.com/
 ])
 
 SRC_DNODE_CHILD_1 = DList(module='l3vpn', namespace='http://example.com/l3vpn', prefix='l3vpn', name='l3vpn', key=['name'], config=True, min_elements=0, ordered_by='system', exts=[
-        DExt(module='stratoweave', namespace='http://stratoweave.org/yang/stratoweave.yang', prefix='sw', name='transform', arg='mini.cfs.L3vpn', exts=[])
+        DExt(module='stratoweave', namespace='http://stratoweave.org/yang/stratoweave.yang', prefix='sw', name='transform', arg='mini.cfs.L3vpn', exts=[]),
+        DExt(module='stratoweave', namespace='http://stratoweave.org/yang/stratoweave.yang', prefix='sw', name='link', arg='global', exts=[DExt(module='stratoweave', namespace='http://stratoweave.org/yang/stratoweave.yang', prefix='sw', name='path', arg='/netinfra:netinfra/netinfra:global-settings', exts=[])])
     ], children=[
     DLeaf(module='l3vpn', namespace='http://example.com/l3vpn', prefix='l3vpn', name='name', config=True, mandatory=False, type_=DTypeString(name='string', description=None, reference=None, exts=[], builtin_type='string', default=None, length=None, patterns=[])),
     DLeaf(module='l3vpn', namespace='http://example.com/l3vpn', prefix='l3vpn', name='customer-name', config=True, mandatory=True, type_=DTypeString(name='string', description=None, reference=None, exts=[], builtin_type='string', default=None, length=None, patterns=[])),
@@ -43,7 +50,9 @@ SRC_DNODE_CHILD_1 = DList(module='l3vpn', namespace='http://example.com/l3vpn', 
 'device',
 'interface-name'
         ], config=True, min_elements=0, ordered_by='system', children=[
-        DLeaf(module='l3vpn', namespace='http://example.com/l3vpn', prefix='l3vpn', name='device', config=True, mandatory=True, type_=DTypeString(name='string', description=None, reference=None, exts=[], builtin_type='string', default=None, length=None, patterns=[])),
+        DLeaf(module='l3vpn', namespace='http://example.com/l3vpn', prefix='l3vpn', name='device', config=True, mandatory=True, type_=DTypeLeafref(name='leafref', description=None, reference=None, exts=[], builtin_type='leafref', default=None, path=yang.xpath.AbsoluteLocationPath([yang.xpath.NodeTestStep('netinfra', 'netinfra', []), yang.xpath.NodeTestStep('netinfra', 'router', []), yang.xpath.NodeTestStep('netinfra', 'name', [])]), require_instance=False, target_type=DTypeString(name='string', description=None, reference=None, exts=[], builtin_type='string', default=None, length=None, patterns=[])), exts=[
+                DExt(module='stratoweave', namespace='http://stratoweave.org/yang/stratoweave.yang', prefix='sw', name='link', arg='router', exts=[])
+            ]),
         DLeaf(module='l3vpn', namespace='http://example.com/l3vpn', prefix='l3vpn', name='interface-name', config=True, mandatory=True, type_=DTypeString(name='string', description=None, reference=None, exts=[], builtin_type='string', default=None, length=None, patterns=[])),
         DLeaf(module='l3vpn', namespace='http://example.com/l3vpn', prefix='l3vpn', name='ipv4-address', config=True, mandatory=True, type_=DTypeString(name='inet:ipv4-address-no-zone', description='An IPv4 address without a zone index.  This type, derived from\nipv4-address, may be used in situations where the zone is\nknown from the context and hence no zone index is needed.', reference=None, exts=[], builtin_type='string', default=None, length=None, patterns=[YangPattern(yang_regex='(([0-9]|[1-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5])\\.){{3}}([0-9]|[1-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5])(%[\\p{{N}}\\p{{L}}]+)?', pcre='^((([0-9]|[1-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5])\\.){{3}}([0-9]|[1-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5])(%[\\p{{N}}\\p{{L}}]+)?)$', invert=False), YangPattern(yang_regex='[0-9\\.]*', pcre='^([0-9\\.]*)$', invert=False)])),
         DLeaf(module='l3vpn', namespace='http://example.com/l3vpn', prefix='l3vpn', name='prefix-length', config=True, mandatory=True, type_=DTypeIntegerUnsigned(name='uint8', description=None, reference=None, exts=[], builtin_type='uint8', default=None, ranges=Ranges([(0, 32)]))),
@@ -76,6 +85,9 @@ def src_yang():
   import ietf-inet-types {
     prefix inet;
   }
+  import netinfra {
+    prefix netinfra;
+  }
   import stratoweave {
     prefix sw;
   }
@@ -84,6 +96,9 @@ def src_yang():
     key name;
 
     sw:transform mini.cfs.L3vpn;
+    sw:link global {
+      sw:path /netinfra:netinfra/netinfra:global-settings;
+    }
 
     leaf name {
       type string;
@@ -117,7 +132,10 @@ def src_yang():
       key "device interface-name";
 
       leaf device {
-        type string;
+        sw:link router;
+        type leafref {
+          path /netinfra:netinfra/netinfra:router/netinfra:name;
+        }
         mandatory true;
       }
 
@@ -177,10 +195,19 @@ def src_yang():
 
   container netinfra {
     description "Network infrastructure";
+    container global-settings {
+      sw:transform mini.cfs.GlobalSettings;
+      leaf asn {
+        type uint32;
+      }
+    }
     list router {
       key name;
 
       sw:transform mini.cfs.Router;
+      sw:link global {
+        sw:path /netinfra/global-settings;
+      }
 
       leaf name {
         type string;
@@ -249,6 +276,20 @@ def src_yang():
       "Used in the memory container of a transform model. Enriches the transform
       function inputs with an additional read-only structure. The transform
       function may update this subtree by returning new data.";
+  }
+  extension link {
+    description
+      "Declares a link demand from this transform towards another (linked)
+      transform. The argument is a tag that identifies the link. On a leafref
+      leaf, the link target is derived from the leafref path. On other nodes,
+      a nested sw:path substatement provides the target path.";
+    argument "tag";
+  }
+  extension path {
+    description
+      "Substatement of sw:link that provides an explicit absolute schema path
+      to the linked transform target.";
+    argument "path";
   }
 }""")
     res.append(r"""module ietf-inet-types {
@@ -720,6 +761,32 @@ NS_ietf_inet_types = 'urn:ietf:params:xml:ns:yang:ietf-inet-types'
 
 
 _breaker1 = None
+class netinfra__netinfra__global_settings(yang.adata.MNode):
+    asn: ?u64
+
+    mut def __init__(self, asn: ?u64):
+        self._ns = 'http://example.com/netinfra'
+        self.asn = asn
+
+    def _get_attr(self, name: str) -> ?value:
+        if name == 'asn':
+            return self.asn
+
+    mut def to_gdata(self) -> yang.gdata.Node:
+        return yang.adata.from_adata(SRC_DNODE, self, loose=False, root_path=['netinfra:netinfra', 'global-settings'])
+
+    @staticmethod
+    mut def from_gdata(n: ?yang.gdata.Node) -> netinfra__netinfra__global_settings:
+        if n is not None:
+            return netinfra__netinfra__global_settings(asn=n.get_opt_u64(yang.gdata.Id(NS_netinfra, 'asn')))
+        return netinfra__netinfra__global_settings()
+
+    def copy(self):
+        """Create a deep copy of this adata object"""
+        return netinfra__netinfra__global_settings.from_gdata(self.to_gdata())
+
+
+_breaker2 = None
 class netinfra__netinfra__router_entry(yang.adata.MNode):
     name: str
     id: u64
@@ -754,7 +821,7 @@ class netinfra__netinfra__router_entry(yang.adata.MNode):
         """Create a deep copy of this adata object"""
         return netinfra__netinfra__router_entry.from_gdata(self.to_gdata())
 
-_breaker2 = None
+_breaker3 = None
 class netinfra__netinfra__router(yang.adata.MNode):
     elements: list[netinfra__netinfra__router_entry]
     mut def __init__(self, elements=[]):
@@ -799,15 +866,19 @@ extension netinfra__netinfra__router(Iterable[netinfra__netinfra__router_entry])
     def __iter__(self) -> Iterator[netinfra__netinfra__router_entry]:
         return self.elements.__iter__()
 
-_breaker3 = None
+_breaker4 = None
 class netinfra__netinfra(yang.adata.MNode):
+    global_settings: netinfra__netinfra__global_settings
     router: netinfra__netinfra__router
 
-    mut def __init__(self, router: list[netinfra__netinfra__router_entry]=[]):
+    mut def __init__(self, global_settings: ?netinfra__netinfra__global_settings=None, router: list[netinfra__netinfra__router_entry]=[]):
         self._ns = 'http://example.com/netinfra'
+        self.global_settings = global_settings if global_settings is not None else netinfra__netinfra__global_settings()
         self.router = netinfra__netinfra__router(elements=router)
 
     def _get_attr(self, name: str) -> ?value:
+        if name == 'global_settings':
+            return self.global_settings
         if name == 'router':
             return iter(self.router)
 
@@ -817,7 +888,7 @@ class netinfra__netinfra(yang.adata.MNode):
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> netinfra__netinfra:
         if n is not None:
-            return netinfra__netinfra(router=netinfra__netinfra__router.from_gdata(n.get_opt_list(yang.gdata.Id(NS_netinfra, 'router'))))
+            return netinfra__netinfra(global_settings=netinfra__netinfra__global_settings.from_gdata(n.get_opt_cnt(yang.gdata.Id(NS_netinfra, 'global-settings'))), router=netinfra__netinfra__router.from_gdata(n.get_opt_list(yang.gdata.Id(NS_netinfra, 'router'))))
         return netinfra__netinfra()
 
     def copy(self):
@@ -825,7 +896,7 @@ class netinfra__netinfra(yang.adata.MNode):
         return netinfra__netinfra.from_gdata(self.to_gdata())
 
 
-_breaker4 = None
+_breaker5 = None
 class l3vpn__l3vpn__endpoint_entry(yang.adata.MNode):
     device: str
     interface_name: str
@@ -880,7 +951,7 @@ class l3vpn__l3vpn__endpoint_entry(yang.adata.MNode):
         """Create a deep copy of this adata object"""
         return l3vpn__l3vpn__endpoint_entry.from_gdata(self.to_gdata())
 
-_breaker5 = None
+_breaker6 = None
 class l3vpn__l3vpn__endpoint(yang.adata.MNode):
     elements: list[l3vpn__l3vpn__endpoint_entry]
     mut def __init__(self, elements=[]):
@@ -936,7 +1007,7 @@ extension l3vpn__l3vpn__endpoint(Iterable[l3vpn__l3vpn__endpoint_entry]):
     def __iter__(self) -> Iterator[l3vpn__l3vpn__endpoint_entry]:
         return self.elements.__iter__()
 
-_breaker6 = None
+_breaker7 = None
 class l3vpn__l3vpn_entry(yang.adata.MNode):
     name: str
     customer_name: str
@@ -983,7 +1054,7 @@ class l3vpn__l3vpn_entry(yang.adata.MNode):
         """Create a deep copy of this adata object"""
         return l3vpn__l3vpn_entry.from_gdata(self.to_gdata())
 
-_breaker7 = None
+_breaker8 = None
 class l3vpn__l3vpn(yang.adata.MNode):
     elements: list[l3vpn__l3vpn_entry]
     mut def __init__(self, elements=[]):
@@ -1032,7 +1103,7 @@ extension l3vpn__l3vpn(Iterable[l3vpn__l3vpn_entry]):
     def __iter__(self) -> Iterator[l3vpn__l3vpn_entry]:
         return self.elements.__iter__()
 
-_breaker8 = None
+_breaker9 = None
 class root(yang.adata.MNode):
     netinfra: netinfra__netinfra
     l3vpn: l3vpn__l3vpn

--- a/minisys/src/mini/layers/y_0_loose.act
+++ b/minisys/src/mini/layers/y_0_loose.act
@@ -20,8 +20,14 @@ _identities: list[DIdentity] = []
 
 
 SRC_DNODE_CHILD_0 = DContainer(module='netinfra', namespace='http://example.com/netinfra', prefix='netinfra', name='netinfra', config=True, description='Network infrastructure', presence=False, children=[
+    DContainer(module='netinfra', namespace='http://example.com/netinfra', prefix='netinfra', name='global-settings', config=True, presence=False, exts=[
+            DExt(module='stratoweave', namespace='http://stratoweave.org/yang/stratoweave.yang', prefix='sw', name='transform', arg='mini.cfs.GlobalSettings', exts=[])
+        ], children=[
+        DLeaf(module='netinfra', namespace='http://example.com/netinfra', prefix='netinfra', name='asn', config=True, mandatory=False, type_=DTypeIntegerUnsigned(name='uint32', description=None, reference=None, exts=[], builtin_type='uint32', default=None, ranges=Ranges([(0, 4294967295)])))
+    ]),
     DList(module='netinfra', namespace='http://example.com/netinfra', prefix='netinfra', name='router', key=['name'], config=True, min_elements=0, ordered_by='system', exts=[
-            DExt(module='stratoweave', namespace='http://stratoweave.org/yang/stratoweave.yang', prefix='sw', name='transform', arg='mini.cfs.Router', exts=[])
+            DExt(module='stratoweave', namespace='http://stratoweave.org/yang/stratoweave.yang', prefix='sw', name='transform', arg='mini.cfs.Router', exts=[]),
+            DExt(module='stratoweave', namespace='http://stratoweave.org/yang/stratoweave.yang', prefix='sw', name='link', arg='global', exts=[DExt(module='stratoweave', namespace='http://stratoweave.org/yang/stratoweave.yang', prefix='sw', name='path', arg='/netinfra/global-settings', exts=[])])
         ], children=[
         DLeaf(module='netinfra', namespace='http://example.com/netinfra', prefix='netinfra', name='name', config=True, mandatory=False, type_=DTypeString(name='string', description=None, reference=None, exts=[], builtin_type='string', default=None, length=None, patterns=[])),
         DLeaf(module='netinfra', namespace='http://example.com/netinfra', prefix='netinfra', name='id', config=True, description='router id', mandatory=True, type_=DTypeIntegerUnsigned(name='uint32', description=None, reference=None, exts=[], builtin_type='uint32', default=None, ranges=Ranges([(0, 4294967295)]))),
@@ -31,7 +37,8 @@ SRC_DNODE_CHILD_0 = DContainer(module='netinfra', namespace='http://example.com/
 ])
 
 SRC_DNODE_CHILD_1 = DList(module='l3vpn', namespace='http://example.com/l3vpn', prefix='l3vpn', name='l3vpn', key=['name'], config=True, min_elements=0, ordered_by='system', exts=[
-        DExt(module='stratoweave', namespace='http://stratoweave.org/yang/stratoweave.yang', prefix='sw', name='transform', arg='mini.cfs.L3vpn', exts=[])
+        DExt(module='stratoweave', namespace='http://stratoweave.org/yang/stratoweave.yang', prefix='sw', name='transform', arg='mini.cfs.L3vpn', exts=[]),
+        DExt(module='stratoweave', namespace='http://stratoweave.org/yang/stratoweave.yang', prefix='sw', name='link', arg='global', exts=[DExt(module='stratoweave', namespace='http://stratoweave.org/yang/stratoweave.yang', prefix='sw', name='path', arg='/netinfra:netinfra/netinfra:global-settings', exts=[])])
     ], children=[
     DLeaf(module='l3vpn', namespace='http://example.com/l3vpn', prefix='l3vpn', name='name', config=True, mandatory=False, type_=DTypeString(name='string', description=None, reference=None, exts=[], builtin_type='string', default=None, length=None, patterns=[])),
     DLeaf(module='l3vpn', namespace='http://example.com/l3vpn', prefix='l3vpn', name='customer-name', config=True, mandatory=True, type_=DTypeString(name='string', description=None, reference=None, exts=[], builtin_type='string', default=None, length=None, patterns=[])),
@@ -43,7 +50,9 @@ SRC_DNODE_CHILD_1 = DList(module='l3vpn', namespace='http://example.com/l3vpn', 
 'device',
 'interface-name'
         ], config=True, min_elements=0, ordered_by='system', children=[
-        DLeaf(module='l3vpn', namespace='http://example.com/l3vpn', prefix='l3vpn', name='device', config=True, mandatory=True, type_=DTypeString(name='string', description=None, reference=None, exts=[], builtin_type='string', default=None, length=None, patterns=[])),
+        DLeaf(module='l3vpn', namespace='http://example.com/l3vpn', prefix='l3vpn', name='device', config=True, mandatory=True, type_=DTypeLeafref(name='leafref', description=None, reference=None, exts=[], builtin_type='leafref', default=None, path=yang.xpath.AbsoluteLocationPath([yang.xpath.NodeTestStep('netinfra', 'netinfra', []), yang.xpath.NodeTestStep('netinfra', 'router', []), yang.xpath.NodeTestStep('netinfra', 'name', [])]), require_instance=False, target_type=DTypeString(name='string', description=None, reference=None, exts=[], builtin_type='string', default=None, length=None, patterns=[])), exts=[
+                DExt(module='stratoweave', namespace='http://stratoweave.org/yang/stratoweave.yang', prefix='sw', name='link', arg='router', exts=[])
+            ]),
         DLeaf(module='l3vpn', namespace='http://example.com/l3vpn', prefix='l3vpn', name='interface-name', config=True, mandatory=True, type_=DTypeString(name='string', description=None, reference=None, exts=[], builtin_type='string', default=None, length=None, patterns=[])),
         DLeaf(module='l3vpn', namespace='http://example.com/l3vpn', prefix='l3vpn', name='ipv4-address', config=True, mandatory=True, type_=DTypeString(name='inet:ipv4-address-no-zone', description='An IPv4 address without a zone index.  This type, derived from\nipv4-address, may be used in situations where the zone is\nknown from the context and hence no zone index is needed.', reference=None, exts=[], builtin_type='string', default=None, length=None, patterns=[YangPattern(yang_regex='(([0-9]|[1-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5])\\.){{3}}([0-9]|[1-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5])(%[\\p{{N}}\\p{{L}}]+)?', pcre='^((([0-9]|[1-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5])\\.){{3}}([0-9]|[1-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5])(%[\\p{{N}}\\p{{L}}]+)?)$', invert=False), YangPattern(yang_regex='[0-9\\.]*', pcre='^([0-9\\.]*)$', invert=False)])),
         DLeaf(module='l3vpn', namespace='http://example.com/l3vpn', prefix='l3vpn', name='prefix-length', config=True, mandatory=True, type_=DTypeIntegerUnsigned(name='uint8', description=None, reference=None, exts=[], builtin_type='uint8', default=None, ranges=Ranges([(0, 32)]))),
@@ -76,6 +85,9 @@ def src_yang():
   import ietf-inet-types {
     prefix inet;
   }
+  import netinfra {
+    prefix netinfra;
+  }
   import stratoweave {
     prefix sw;
   }
@@ -84,6 +96,9 @@ def src_yang():
     key name;
 
     sw:transform mini.cfs.L3vpn;
+    sw:link global {
+      sw:path /netinfra:netinfra/netinfra:global-settings;
+    }
 
     leaf name {
       type string;
@@ -117,7 +132,10 @@ def src_yang():
       key "device interface-name";
 
       leaf device {
-        type string;
+        sw:link router;
+        type leafref {
+          path /netinfra:netinfra/netinfra:router/netinfra:name;
+        }
         mandatory true;
       }
 
@@ -177,10 +195,19 @@ def src_yang():
 
   container netinfra {
     description "Network infrastructure";
+    container global-settings {
+      sw:transform mini.cfs.GlobalSettings;
+      leaf asn {
+        type uint32;
+      }
+    }
     list router {
       key name;
 
       sw:transform mini.cfs.Router;
+      sw:link global {
+        sw:path /netinfra/global-settings;
+      }
 
       leaf name {
         type string;
@@ -249,6 +276,20 @@ def src_yang():
       "Used in the memory container of a transform model. Enriches the transform
       function inputs with an additional read-only structure. The transform
       function may update this subtree by returning new data.";
+  }
+  extension link {
+    description
+      "Declares a link demand from this transform towards another (linked)
+      transform. The argument is a tag that identifies the link. On a leafref
+      leaf, the link target is derived from the leafref path. On other nodes,
+      a nested sw:path substatement provides the target path.";
+    argument "tag";
+  }
+  extension path {
+    description
+      "Substatement of sw:link that provides an explicit absolute schema path
+      to the linked transform target.";
+    argument "path";
   }
 }""")
     res.append(r"""module ietf-inet-types {
@@ -720,6 +761,32 @@ NS_ietf_inet_types = 'urn:ietf:params:xml:ns:yang:ietf-inet-types'
 
 
 _breaker1 = None
+class netinfra__netinfra__global_settings(yang.adata.MNode):
+    asn: ?u64
+
+    mut def __init__(self, asn: ?u64):
+        self._ns = 'http://example.com/netinfra'
+        self.asn = asn
+
+    def _get_attr(self, name: str) -> ?value:
+        if name == 'asn':
+            return self.asn
+
+    mut def to_gdata(self) -> yang.gdata.Node:
+        return yang.adata.from_adata(SRC_DNODE, self, loose=True, root_path=['netinfra:netinfra', 'global-settings'])
+
+    @staticmethod
+    mut def from_gdata(n: ?yang.gdata.Node) -> netinfra__netinfra__global_settings:
+        if n is not None:
+            return netinfra__netinfra__global_settings(asn=n.get_opt_u64(yang.gdata.Id(NS_netinfra, 'asn')))
+        return netinfra__netinfra__global_settings()
+
+    def copy(self):
+        """Create a deep copy of this adata object"""
+        return netinfra__netinfra__global_settings.from_gdata(self.to_gdata())
+
+
+_breaker2 = None
 class netinfra__netinfra__router_entry(yang.adata.MNode):
     name: str
     id: ?u64
@@ -754,7 +821,7 @@ class netinfra__netinfra__router_entry(yang.adata.MNode):
         """Create a deep copy of this adata object"""
         return netinfra__netinfra__router_entry.from_gdata(self.to_gdata())
 
-_breaker2 = None
+_breaker3 = None
 class netinfra__netinfra__router(yang.adata.MNode):
     elements: list[netinfra__netinfra__router_entry]
     mut def __init__(self, elements=[]):
@@ -801,15 +868,19 @@ extension netinfra__netinfra__router(Iterable[netinfra__netinfra__router_entry])
     def __iter__(self) -> Iterator[netinfra__netinfra__router_entry]:
         return self.elements.__iter__()
 
-_breaker3 = None
+_breaker4 = None
 class netinfra__netinfra(yang.adata.MNode):
+    global_settings: netinfra__netinfra__global_settings
     router: netinfra__netinfra__router
 
-    mut def __init__(self, router: list[netinfra__netinfra__router_entry]=[]):
+    mut def __init__(self, global_settings: ?netinfra__netinfra__global_settings=None, router: list[netinfra__netinfra__router_entry]=[]):
         self._ns = 'http://example.com/netinfra'
+        self.global_settings = global_settings if global_settings is not None else netinfra__netinfra__global_settings()
         self.router = netinfra__netinfra__router(elements=router)
 
     def _get_attr(self, name: str) -> ?value:
+        if name == 'global_settings':
+            return self.global_settings
         if name == 'router':
             return iter(self.router)
 
@@ -819,7 +890,7 @@ class netinfra__netinfra(yang.adata.MNode):
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> netinfra__netinfra:
         if n is not None:
-            return netinfra__netinfra(router=netinfra__netinfra__router.from_gdata(n.get_opt_list(yang.gdata.Id(NS_netinfra, 'router'))))
+            return netinfra__netinfra(global_settings=netinfra__netinfra__global_settings.from_gdata(n.get_opt_cnt(yang.gdata.Id(NS_netinfra, 'global-settings'))), router=netinfra__netinfra__router.from_gdata(n.get_opt_list(yang.gdata.Id(NS_netinfra, 'router'))))
         return netinfra__netinfra()
 
     def copy(self):
@@ -827,7 +898,7 @@ class netinfra__netinfra(yang.adata.MNode):
         return netinfra__netinfra.from_gdata(self.to_gdata())
 
 
-_breaker4 = None
+_breaker5 = None
 class l3vpn__l3vpn__endpoint_entry(yang.adata.MNode):
     device: str
     interface_name: str
@@ -882,7 +953,7 @@ class l3vpn__l3vpn__endpoint_entry(yang.adata.MNode):
         """Create a deep copy of this adata object"""
         return l3vpn__l3vpn__endpoint_entry.from_gdata(self.to_gdata())
 
-_breaker5 = None
+_breaker6 = None
 class l3vpn__l3vpn__endpoint(yang.adata.MNode):
     elements: list[l3vpn__l3vpn__endpoint_entry]
     mut def __init__(self, elements=[]):
@@ -940,7 +1011,7 @@ extension l3vpn__l3vpn__endpoint(Iterable[l3vpn__l3vpn__endpoint_entry]):
     def __iter__(self) -> Iterator[l3vpn__l3vpn__endpoint_entry]:
         return self.elements.__iter__()
 
-_breaker6 = None
+_breaker7 = None
 class l3vpn__l3vpn_entry(yang.adata.MNode):
     name: str
     customer_name: ?str
@@ -987,7 +1058,7 @@ class l3vpn__l3vpn_entry(yang.adata.MNode):
         """Create a deep copy of this adata object"""
         return l3vpn__l3vpn_entry.from_gdata(self.to_gdata())
 
-_breaker7 = None
+_breaker8 = None
 class l3vpn__l3vpn(yang.adata.MNode):
     elements: list[l3vpn__l3vpn_entry]
     mut def __init__(self, elements=[]):
@@ -1038,7 +1109,7 @@ extension l3vpn__l3vpn(Iterable[l3vpn__l3vpn_entry]):
     def __iter__(self) -> Iterator[l3vpn__l3vpn_entry]:
         return self.elements.__iter__()
 
-_breaker8 = None
+_breaker9 = None
 class root(yang.adata.MNode):
     netinfra: netinfra__netinfra
     l3vpn: l3vpn__l3vpn

--- a/minisys/src/mini/layers/y_1.act
+++ b/minisys/src/mini/layers/y_1.act
@@ -283,6 +283,20 @@ def src_yang():
       function inputs with an additional read-only structure. The transform
       function may update this subtree by returning new data.";
   }
+  extension link {
+    description
+      "Declares a link demand from this transform towards another (linked)
+      transform. The argument is a tag that identifies the link. On a leafref
+      leaf, the link target is derived from the leafref path. On other nodes,
+      a nested sw:path substatement provides the target path.";
+    argument "tag";
+  }
+  extension path {
+    description
+      "Substatement of sw:link that provides an explicit absolute schema path
+      to the linked transform target.";
+    argument "path";
+  }
 }""")
     res.append(r"""module stratoweave-rfs {
   yang-version "1.1";

--- a/minisys/src/mini/layers/y_1_loose.act
+++ b/minisys/src/mini/layers/y_1_loose.act
@@ -283,6 +283,20 @@ def src_yang():
       function inputs with an additional read-only structure. The transform
       function may update this subtree by returning new data.";
   }
+  extension link {
+    description
+      "Declares a link demand from this transform towards another (linked)
+      transform. The argument is a tag that identifies the link. On a leafref
+      leaf, the link target is derived from the leafref path. On other nodes,
+      a nested sw:path substatement provides the target path.";
+    argument "tag";
+  }
+  extension path {
+    description
+      "Substatement of sw:link that provides an explicit absolute schema path
+      to the linked transform target.";
+    argument "path";
+  }
 }""")
     res.append(r"""module stratoweave-rfs {
   yang-version "1.1";

--- a/minisys/src/mini/layers/y_2.act
+++ b/minisys/src/mini/layers/y_2.act
@@ -84,6 +84,20 @@ def src_yang():
       function inputs with an additional read-only structure. The transform
       function may update this subtree by returning new data.";
   }
+  extension link {
+    description
+      "Declares a link demand from this transform towards another (linked)
+      transform. The argument is a tag that identifies the link. On a leafref
+      leaf, the link target is derived from the leafref path. On other nodes,
+      a nested sw:path substatement provides the target path.";
+    argument "tag";
+  }
+  extension path {
+    description
+      "Substatement of sw:link that provides an explicit absolute schema path
+      to the linked transform target.";
+    argument "path";
+  }
 }""")
     res.append(r"""module stratoweave-device {
   yang-version "1.1";

--- a/minisys/src/mini/layers/y_2_loose.act
+++ b/minisys/src/mini/layers/y_2_loose.act
@@ -84,6 +84,20 @@ def src_yang():
       function inputs with an additional read-only structure. The transform
       function may update this subtree by returning new data.";
   }
+  extension link {
+    description
+      "Declares a link demand from this transform towards another (linked)
+      transform. The argument is a tag that identifies the link. On a leafref
+      leaf, the link target is derived from the leafref path. On other nodes,
+      a nested sw:path substatement provides the target path.";
+    argument "tag";
+  }
+  extension path {
+    description
+      "Substatement of sw:link that provides an explicit absolute schema path
+      to the linked transform target.";
+    argument "path";
+  }
 }""")
     res.append(r"""module stratoweave-device {
   yang-version "1.1";

--- a/snapshots/expected/test_ttt_gen/ttt_gen_cfs_base
+++ b/snapshots/expected/test_ttt_gen/ttt_gen_cfs_base
@@ -25,7 +25,7 @@ class Foobar(ttt.TransformFunction):
         """Return the modeled input type for this transform"""
         return foo__c1__foo__bar_entry
 
-    mut def transform_wrapper(self, i: yang.gdata.Node, memory: ?yang.gdata.Node, dynstate: ?yang.gdata.Node) -> (yang.gdata.Node, ?yang.gdata.Node):
+    mut def transform_wrapper(self, i: yang.gdata.Node, linked: yang.gdata.Node, memory: ?yang.gdata.Node, dynstate: ?yang.gdata.Node) -> (yang.gdata.Node, ?yang.gdata.Node):
         """Wrap the user provided transform method to convert from gdata to
         modeled input and back to gdata
         """
@@ -33,7 +33,7 @@ class Foobar(ttt.TransformFunction):
 
         return self.transform(modeled_input).to_gdata(), None
 
-    mut def transform_xml(self, i: xml.Node, memory: ?yang.gdata.Node, dynstate: ?yang.gdata.Node) -> (yang.gdata.Node, ?yang.gdata.Node):
+    mut def transform_xml(self, i: xml.Node, linked: yang.gdata.Node, memory: ?yang.gdata.Node, dynstate: ?yang.gdata.Node) -> (yang.gdata.Node, ?yang.gdata.Node):
         """Wrap the user provided transform method to convert from XML to
         modeled input and return gdata
         """

--- a/snapshots/expected/test_ttt_gen/ttt_gen_cfs_ttt
+++ b/snapshots/expected/test_ttt_gen/ttt_gen_cfs_ttt
@@ -12,5 +12,5 @@ import respnet.cfs
 
 
 def get_ttt(lower: ?ttt.Layer, dev_registry: swdev.DeviceRegistry, log_handler: ?logging.Handler=None) -> proc(?ttt.Path,?ttt.Layer)->ttt.Node:
-    r = ttt.Container({yang.gdata.Id("http://example.com/foo", "c1"): ttt.Container({yang.gdata.Id("http://example.com/foo", "foo"): ttt.List(ttt.Container({yang.gdata.Id("http://example.com/foo", "bar"): ttt.List(ttt.Transform(respnet.cfs.Foobar, None, lower, log_handler), [yang.gdata.Id("http://example.com/foo", "name")])}), [yang.gdata.Id("http://example.com/foo", "name")])}, ns='http://example.com/foo', module='foo')})
+    r = ttt.Container({yang.gdata.Id("http://example.com/foo", "c1"): ttt.Container({yang.gdata.Id("http://example.com/foo", "foo"): ttt.List(ttt.Container({yang.gdata.Id("http://example.com/foo", "bar"): ttt.List(ttt.Transform(respnet.cfs.Foobar, None, None, lower, log_handler), [yang.gdata.Id("http://example.com/foo", "name")])}), [yang.gdata.Id("http://example.com/foo", "name")])}, ns='http://example.com/foo', module='foo')})
     return r

--- a/snapshots/expected/test_ttt_gen/ttt_gen_linked_leafref_l3vpn_base
+++ b/snapshots/expected/test_ttt_gen/ttt_gen_linked_leafref_l3vpn_base
@@ -27,7 +27,7 @@ class GlobalSettings(ttt.TransformFunction):
         """Return the modeled input type for this transform"""
         return ietf_l3vpn_svc__global_settings
 
-    mut def transform_wrapper(self, i: yang.gdata.Node, memory: ?yang.gdata.Node, dynstate: ?yang.gdata.Node) -> (yang.gdata.Node, ?yang.gdata.Node):
+    mut def transform_wrapper(self, i: yang.gdata.Node, linked: yang.gdata.Node, memory: ?yang.gdata.Node, dynstate: ?yang.gdata.Node) -> (yang.gdata.Node, ?yang.gdata.Node):
         """Wrap the user provided transform method to convert from gdata to
         modeled input and back to gdata
         """
@@ -35,7 +35,7 @@ class GlobalSettings(ttt.TransformFunction):
 
         return self.transform(modeled_input).to_gdata(), None
 
-    mut def transform_xml(self, i: xml.Node, memory: ?yang.gdata.Node, dynstate: ?yang.gdata.Node) -> (yang.gdata.Node, ?yang.gdata.Node):
+    mut def transform_xml(self, i: xml.Node, linked: yang.gdata.Node, memory: ?yang.gdata.Node, dynstate: ?yang.gdata.Node) -> (yang.gdata.Node, ?yang.gdata.Node):
         """Wrap the user provided transform method to convert from XML to
         modeled input and return gdata
         """
@@ -52,7 +52,7 @@ class L3VpnVpnService(ttt.TransformFunction):
         """Return the modeled input type for this transform"""
         return ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service_entry
 
-    mut def transform_wrapper(self, i: yang.gdata.Node, memory: ?yang.gdata.Node, dynstate: ?yang.gdata.Node) -> (yang.gdata.Node, ?yang.gdata.Node):
+    mut def transform_wrapper(self, i: yang.gdata.Node, linked: yang.gdata.Node, memory: ?yang.gdata.Node, dynstate: ?yang.gdata.Node) -> (yang.gdata.Node, ?yang.gdata.Node):
         """Wrap the user provided transform method to convert from gdata to
         modeled input and back to gdata
         """
@@ -60,7 +60,7 @@ class L3VpnVpnService(ttt.TransformFunction):
 
         return self.transform(modeled_input).to_gdata(), None
 
-    mut def transform_xml(self, i: xml.Node, memory: ?yang.gdata.Node, dynstate: ?yang.gdata.Node) -> (yang.gdata.Node, ?yang.gdata.Node):
+    mut def transform_xml(self, i: xml.Node, linked: yang.gdata.Node, memory: ?yang.gdata.Node, dynstate: ?yang.gdata.Node) -> (yang.gdata.Node, ?yang.gdata.Node):
         """Wrap the user provided transform method to convert from XML to
         modeled input and return gdata
         """
@@ -70,26 +70,26 @@ class L3VpnVpnService(ttt.TransformFunction):
         return self.transform(modeled_input).to_gdata(), None
 
 class L3VpnSite(ttt.TransformFunction):
-    transform: mut(ietf_l3vpn_svc__l3vpn_svc__sites__site_entry) -> yang.adata.MNode
+    transform: mut(ietf_l3vpn_svc__l3vpn_svc__sites__site_entry, linked: yang.gdata.Node) -> yang.adata.MNode
 
     @staticmethod
     def input_type():
         """Return the modeled input type for this transform"""
         return ietf_l3vpn_svc__l3vpn_svc__sites__site_entry
 
-    mut def transform_wrapper(self, i: yang.gdata.Node, memory: ?yang.gdata.Node, dynstate: ?yang.gdata.Node) -> (yang.gdata.Node, ?yang.gdata.Node):
+    mut def transform_wrapper(self, i: yang.gdata.Node, linked: yang.gdata.Node, memory: ?yang.gdata.Node, dynstate: ?yang.gdata.Node) -> (yang.gdata.Node, ?yang.gdata.Node):
         """Wrap the user provided transform method to convert from gdata to
         modeled input and back to gdata
         """
         modeled_input = ietf_l3vpn_svc__l3vpn_svc__sites__site_entry.from_gdata(i)
 
-        return self.transform(modeled_input).to_gdata(), None
+        return self.transform(modeled_input, linked).to_gdata(), None
 
-    mut def transform_xml(self, i: xml.Node, memory: ?yang.gdata.Node, dynstate: ?yang.gdata.Node) -> (yang.gdata.Node, ?yang.gdata.Node):
+    mut def transform_xml(self, i: xml.Node, linked: yang.gdata.Node, memory: ?yang.gdata.Node, dynstate: ?yang.gdata.Node) -> (yang.gdata.Node, ?yang.gdata.Node):
         """Wrap the user provided transform method to convert from XML to
         modeled input and return gdata
         """
         gdata_input = yang.xml.from_xml(SRC_DNODE, i, loose=False, root_path=['ietf-l3vpn-svc:l3vpn-svc', 'sites', 'site'])
         modeled_input = ietf_l3vpn_svc__l3vpn_svc__sites__site_entry.from_gdata(gdata_input)
 
-        return self.transform(modeled_input).to_gdata(), None
+        return self.transform(modeled_input, linked).to_gdata(), None

--- a/snapshots/expected/test_ttt_gen/ttt_gen_linked_leafref_l3vpn_base
+++ b/snapshots/expected/test_ttt_gen/ttt_gen_linked_leafref_l3vpn_base
@@ -1,0 +1,95 @@
+# WARNING WARNING WARNING WARNING WARNING
+# DO NOT MODIFY THIS FILE!! This file is generated!
+# WARNING WARNING WARNING WARNING WARNING
+
+import logging
+import xml
+import stratoweave.ttt as ttt
+import yang.adata
+import yang.gdata
+import yang.xml
+
+from respnet.layers.y_0 import ietf_l3vpn_svc__global_settings
+from respnet.layers.y_0 import ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service_entry
+from respnet.layers.y_0 import ietf_l3vpn_svc__l3vpn_svc__sites__site_entry
+from respnet.layers.y_0 import SRC_DNODE
+from respnet.layers.y_1_loose import root as output_root
+
+def o_root():
+    return output_root()
+
+
+class GlobalSettings(ttt.TransformFunction):
+    transform: mut(ietf_l3vpn_svc__global_settings) -> yang.adata.MNode
+
+    @staticmethod
+    def input_type():
+        """Return the modeled input type for this transform"""
+        return ietf_l3vpn_svc__global_settings
+
+    mut def transform_wrapper(self, i: yang.gdata.Node, memory: ?yang.gdata.Node, dynstate: ?yang.gdata.Node) -> (yang.gdata.Node, ?yang.gdata.Node):
+        """Wrap the user provided transform method to convert from gdata to
+        modeled input and back to gdata
+        """
+        modeled_input = ietf_l3vpn_svc__global_settings.from_gdata(i)
+
+        return self.transform(modeled_input).to_gdata(), None
+
+    mut def transform_xml(self, i: xml.Node, memory: ?yang.gdata.Node, dynstate: ?yang.gdata.Node) -> (yang.gdata.Node, ?yang.gdata.Node):
+        """Wrap the user provided transform method to convert from XML to
+        modeled input and return gdata
+        """
+        gdata_input = yang.xml.from_xml(SRC_DNODE, i, loose=False, root_path=['ietf-l3vpn-svc:global-settings'])
+        modeled_input = ietf_l3vpn_svc__global_settings.from_gdata(gdata_input)
+
+        return self.transform(modeled_input).to_gdata(), None
+
+class L3VpnVpnService(ttt.TransformFunction):
+    transform: mut(ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service_entry) -> yang.adata.MNode
+
+    @staticmethod
+    def input_type():
+        """Return the modeled input type for this transform"""
+        return ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service_entry
+
+    mut def transform_wrapper(self, i: yang.gdata.Node, memory: ?yang.gdata.Node, dynstate: ?yang.gdata.Node) -> (yang.gdata.Node, ?yang.gdata.Node):
+        """Wrap the user provided transform method to convert from gdata to
+        modeled input and back to gdata
+        """
+        modeled_input = ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service_entry.from_gdata(i)
+
+        return self.transform(modeled_input).to_gdata(), None
+
+    mut def transform_xml(self, i: xml.Node, memory: ?yang.gdata.Node, dynstate: ?yang.gdata.Node) -> (yang.gdata.Node, ?yang.gdata.Node):
+        """Wrap the user provided transform method to convert from XML to
+        modeled input and return gdata
+        """
+        gdata_input = yang.xml.from_xml(SRC_DNODE, i, loose=False, root_path=['ietf-l3vpn-svc:l3vpn-svc', 'vpn-services', 'vpn-service'])
+        modeled_input = ietf_l3vpn_svc__l3vpn_svc__vpn_services__vpn_service_entry.from_gdata(gdata_input)
+
+        return self.transform(modeled_input).to_gdata(), None
+
+class L3VpnSite(ttt.TransformFunction):
+    transform: mut(ietf_l3vpn_svc__l3vpn_svc__sites__site_entry) -> yang.adata.MNode
+
+    @staticmethod
+    def input_type():
+        """Return the modeled input type for this transform"""
+        return ietf_l3vpn_svc__l3vpn_svc__sites__site_entry
+
+    mut def transform_wrapper(self, i: yang.gdata.Node, memory: ?yang.gdata.Node, dynstate: ?yang.gdata.Node) -> (yang.gdata.Node, ?yang.gdata.Node):
+        """Wrap the user provided transform method to convert from gdata to
+        modeled input and back to gdata
+        """
+        modeled_input = ietf_l3vpn_svc__l3vpn_svc__sites__site_entry.from_gdata(i)
+
+        return self.transform(modeled_input).to_gdata(), None
+
+    mut def transform_xml(self, i: xml.Node, memory: ?yang.gdata.Node, dynstate: ?yang.gdata.Node) -> (yang.gdata.Node, ?yang.gdata.Node):
+        """Wrap the user provided transform method to convert from XML to
+        modeled input and return gdata
+        """
+        gdata_input = yang.xml.from_xml(SRC_DNODE, i, loose=False, root_path=['ietf-l3vpn-svc:l3vpn-svc', 'sites', 'site'])
+        modeled_input = ietf_l3vpn_svc__l3vpn_svc__sites__site_entry.from_gdata(gdata_input)
+
+        return self.transform(modeled_input).to_gdata(), None

--- a/snapshots/expected/test_ttt_gen/ttt_gen_linked_leafref_l3vpn_ttt
+++ b/snapshots/expected/test_ttt_gen/ttt_gen_linked_leafref_l3vpn_ttt
@@ -1,0 +1,29 @@
+# WARNING WARNING WARNING WARNING WARNING
+# DO NOT MODIFY THIS FILE!! This file is generated!
+# WARNING WARNING WARNING WARNING WARNING
+
+import logging
+
+import stratoweave.device as swdev
+import stratoweave.ttt as ttt
+import yang.gdata
+
+import respnet.cfs
+
+
+def get_ttt(lower: ?ttt.Layer, dev_registry: swdev.DeviceRegistry, log_handler: ?logging.Handler=None) -> proc(?ttt.Path,?ttt.Layer)->ttt.Node:
+    r = ttt.Container({yang.gdata.Id("urn:ietf:params:xml:ns:yang:ietf-l3vpn-svc", "global-settings"): ttt.Transform(respnet.cfs.GlobalSettings, None, None, lower, log_handler), yang.gdata.Id("urn:ietf:params:xml:ns:yang:ietf-l3vpn-svc", "l3vpn-svc"): ttt.Container({yang.gdata.Id("urn:ietf:params:xml:ns:yang:ietf-l3vpn-svc", "vpn-services"): ttt.Container({yang.gdata.Id("urn:ietf:params:xml:ns:yang:ietf-l3vpn-svc", "vpn-service"): ttt.List(ttt.Transform(respnet.cfs.L3VpnVpnService, None, None, lower, log_handler), [yang.gdata.Id("urn:ietf:params:xml:ns:yang:ietf-l3vpn-svc", "vpn-id")])}), yang.gdata.Id("urn:ietf:params:xml:ns:yang:ietf-l3vpn-svc", "sites"): ttt.Container({yang.gdata.Id("urn:ietf:params:xml:ns:yang:ietf-l3vpn-svc", "site"): ttt.List(ttt.Transform(respnet.cfs.L3VpnSite, None, _build_target_links_ietf_l3vpn_svc__l3vpn_svc__sites__site_entry, lower, log_handler), [yang.gdata.Id("urn:ietf:params:xml:ns:yang:ietf-l3vpn-svc", "site-id")])})}, ns='urn:ietf:params:xml:ns:yang:ietf-l3vpn-svc', module='ietf-l3vpn-svc')})
+    return r
+
+def _build_target_links_ietf_l3vpn_svc__l3vpn_svc__sites__site_entry(conf: yang.gdata.Node) -> list[ttt.TaggedPath]:
+    res = []
+    # static link: global
+    res.append(ttt.TaggedPath('global', yang.gdata.FNode(yang.gdata.Id("urn:ietf:params:xml:ns:yang:ietf-l3vpn-svc", "global-settings"))))
+    # leafref link: vpn
+    _l1 = conf.get_opt_cnt(yang.gdata.Id("urn:ietf:params:xml:ns:yang:ietf-l3vpn-svc", "site-network-accesses"))?.get_opt_list(yang.gdata.Id("urn:ietf:params:xml:ns:yang:ietf-l3vpn-svc", "site-network-access"))
+    if _l1 is not None:
+        for _e1 in _l1.elements:
+            _v3 = _e1.get_opt_cnt(yang.gdata.Id("urn:ietf:params:xml:ns:yang:ietf-l3vpn-svc", "vpn-attachment"))?.get_opt_value(yang.gdata.Id("urn:ietf:params:xml:ns:yang:ietf-l3vpn-svc", "vpn-id"))
+            if _v3 is not None:
+                res.append(ttt.TaggedPath('vpn', yang.gdata.FNode(yang.gdata.Id("urn:ietf:params:xml:ns:yang:ietf-l3vpn-svc", "l3vpn-svc"), children=[yang.gdata.FNode(yang.gdata.Id("urn:ietf:params:xml:ns:yang:ietf-l3vpn-svc", "vpn-services"), children=[yang.gdata.FNode(yang.gdata.Id("urn:ietf:params:xml:ns:yang:ietf-l3vpn-svc", "vpn-service"), children=[yang.gdata.FNode(yang.gdata.Id("urn:ietf:params:xml:ns:yang:ietf-l3vpn-svc", "vpn-id"), value_match=_v3)])])])))
+    return res

--- a/snapshots/expected/test_ttt_links/gen_build_target_links
+++ b/snapshots/expected/test_ttt_links/gen_build_target_links
@@ -1,0 +1,12 @@
+def build_target_links_test(conf: yang.gdata.Node) -> list[ttt.TaggedPath]:
+    res = []
+    # static link: global
+    res.append(ttt.TaggedPath('global', yang.gdata.FNode(yang.gdata.Id("http://example.com/netinfra", "global-settings"))))
+    # leafref link: vpn
+    _l1 = conf.get_opt_cnt(yang.gdata.Id("urn:ietf:params:xml:ns:yang:ietf-l3vpn-svc", "site-network-accesses"))?.get_opt_list(yang.gdata.Id("urn:ietf:params:xml:ns:yang:ietf-l3vpn-svc", "site-network-access"))
+    if _l1 is not None:
+        for _e1 in _l1.elements:
+            _v3 = _e1.get_opt_cnt(yang.gdata.Id("urn:ietf:params:xml:ns:yang:ietf-l3vpn-svc", "vpn-attachment"))?.get_opt_value(yang.gdata.Id("urn:ietf:params:xml:ns:yang:ietf-l3vpn-svc", "vpn-id"))
+            if _v3 is not None:
+                res.append(ttt.TaggedPath('vpn', yang.gdata.FNode(yang.gdata.Id("urn:ietf:params:xml:ns:yang:ietf-l3vpn-svc", "l3vpn-svc"), children=[yang.gdata.FNode(yang.gdata.Id("urn:ietf:params:xml:ns:yang:ietf-l3vpn-svc", "vpn-services"), children=[yang.gdata.FNode(yang.gdata.Id("urn:ietf:params:xml:ns:yang:ietf-l3vpn-svc", "vpn-service"), children=[yang.gdata.FNode(yang.gdata.Id("urn:ietf:params:xml:ns:yang:ietf-l3vpn-svc", "vpn-id"), value_match=_v3)])])])))
+    return res

--- a/src/stratoweave/device_meta_config.act
+++ b/src/stratoweave/device_meta_config.act
@@ -300,6 +300,20 @@ def src_yang():
       function inputs with an additional read-only structure. The transform
       function may update this subtree by returning new data.";
   }
+  extension link {
+    description
+      "Declares a link demand from this transform towards another (linked)
+      transform. The argument is a tag that identifies the link. On a leafref
+      leaf, the link target is derived from the leafref path. On other nodes,
+      a nested sw:path substatement provides the target path.";
+    argument "tag";
+  }
+  extension path {
+    description
+      "Substatement of sw:link that provides an explicit absolute schema path
+      to the linked transform target.";
+    argument "path";
+  }
 }""")
     res.append(r"""module ietf-inet-types {
 

--- a/src/stratoweave/ttt.act
+++ b/src/stratoweave/ttt.act
@@ -1134,7 +1134,7 @@ class _TransformTransactionBase(_Transaction):
     me: str
     db: ?lmdb.Db
 
-    compute : proc(tid: str, merged: gdata.Node, out: ?Session) -> (gdata.Node, ?gdata.Node)
+    compute : proc(tid: str, merged: gdata.Node, linked: gdata.Node, out: ?Session) -> (gdata.Node, ?gdata.Node)
     clear : proc(tid: str, out: ?Session) -> None
     finalize : proc(tid: str) -> None
 
@@ -1191,7 +1191,7 @@ class _TransformTransactionBase(_Transaction):
                 upd = self.link_updates(tid, merged)
                 if not req:
                     linked = self.candidate_linked[tid]
-                    outmem = self.compute(tid, merged, out)                         # TODO: Insert linked as third argument
+                    outmem = self.compute(tid, merged, linked, out)
                     self.essays[tid] = outmem
                     newout = outmem.0
                     #print('   #', tid, '(Transform)', _format_path(self.path), 'OUTPUT\n       ', newout.prsrc(indent=4), err=True)
@@ -1413,8 +1413,8 @@ class _TransformTransaction(_TransformTransactionBase):
         self.function = function(log_handler)
         self.lower = lower
 
-    def compute(self, tid, merged, out):
-        newoutmem = self.function.transform_wrapper(merged, self.memory, self.dynstate)
+    def compute(self, tid, merged, linked, out):
+        newoutmem = self.function.transform_wrapper(merged, linked, self.memory, self.dynstate)
         newout = newoutmem.0
         res = difference(self.output, newout)
         if out is not None and res is not None:
@@ -1467,8 +1467,8 @@ class _TransformTransaction(_TransformTransactionBase):
             self.function.on_conf(self.get(), self.memory)
 
 class TransformFunction(object):
-    transform_wrapper: mut(gdata.Node, ?gdata.Node, ?gdata.Node) -> (gdata.Node, ?gdata.Node)
-    transform_xml: mut(xml.Node, ?gdata.Node, ?gdata.Node) -> (gdata.Node, ?gdata.Node)
+    transform_wrapper: mut(gdata.Node, gdata.Node, ?gdata.Node, ?gdata.Node) -> (gdata.Node, ?gdata.Node)
+    transform_xml: mut(xml.Node, gdata.Node, ?gdata.Node, ?gdata.Node) -> (gdata.Node, ?gdata.Node)
     _on_conf: ?proc(gdata.Node, ?gdata.Node) -> None
     logger: logging.Logger
 
@@ -1476,10 +1476,10 @@ class TransformFunction(object):
         self._on_conf = None
         self.logger = logging.Logger(log_handler)
 
-    def transform_wrapper(self, cfg, memory, dynstate):
+    def transform_wrapper(self, cfg, linked, memory, dynstate):
         return (gdata.Container(), None)
 
-    def transform_xml(self, cfg, memory, dynstate):
+    def transform_xml(self, cfg, linked, memory, dynstate):
         return gdata.Container(), None
 
     proc def init_dynstate(self, act: proc(TransformActorParams) -> ?proc(gdata.Node, ?gdata.Node) -> None, update_dynstate: proc(?gdata.Node)->None, path: Path):
@@ -1543,7 +1543,7 @@ class _RFSTransaction(_TransformTransactionBase):
         self.dev = dev_registry.get(self.devname)
         self.lower = lower
 
-    def compute(self, tid, merged, out):
+    def compute(self, tid, merged, linked, out):
         #print('####', tid, '(RFSTransform)', _format_path(self.path), 'compute', actorid(), err=True)
         dev_content = {
             gdata.Id(NS_stratoweave_device, "name"): gdata.Leaf(self.devname),
@@ -1689,7 +1689,7 @@ class _DeviceTransaction(_TransformTransactionBase):
         self.dev = dev_registry.get(devname_from_device_path(path))
         self.logger = logging.Logger(log_handler)
 
-    def compute(self, tid, merged, out):
+    def compute(self, tid, merged, linked, out):
         return merged, None
 
     def clear(self, tid, out):
@@ -1731,7 +1731,7 @@ class _DeviceConfigTransaction(_TransformTransactionBase):
         self.logger = logging.Logger(log_handler)
         self.cont = None
 
-    def compute(self, tid, merged, out):
+    def compute(self, tid, merged, linked, out):
         return merged, None
 
     def clear(self, tid, out):
@@ -1765,7 +1765,7 @@ class _DeviceConfigTransaction(_TransformTransactionBase):
 ################# Trivials #####################
 
 class PassThrough(TransformFunction):
-    def transform_wrapper(self, cfg, memory, dynstate):
+    def transform_wrapper(self, cfg, linked, memory, dynstate):
         return (cfg, memory)
 
 def Sink():

--- a/src/stratoweave/ttt.act
+++ b/src/stratoweave/ttt.act
@@ -1128,7 +1128,7 @@ class _TransformTransactionBase(_Transaction):
     subscribers: list[TaggedPath]                               # Active linked data subscribers (with tag)
     candidate_subscribers: dict[str, list[TaggedPath]]          # As above, per ongoing transaction
     @property
-    build_links: ?(gdata.Node) -> list[TaggedPath]
+    build_links: ?proc(gdata.Node) -> list[TaggedPath]
     fpath: gdata.FNode
 
     me: str
@@ -1378,9 +1378,9 @@ class TransformActorParams:
         self.dev = dev
 
 
-def Transform(function, act: ?(proc(TransformActorParams) -> ?proc(gdata.Node, ?gdata.Node) -> None)=None, lower: ?Layer=None, log_handler: ?logging.Handler=None) -> proc(?Path, ?Layer)->Node:
+def Transform(function, act: ?(proc(TransformActorParams) -> ?proc(gdata.Node, ?gdata.Node) -> None)=None, build_links: ?proc(gdata.Node) -> list[TaggedPath]=None, lower: ?Layer=None, log_handler: ?logging.Handler=None) -> proc(?Path, ?Layer)->Node:
     proc def _create_transform_node(path, lower):
-        transform = _Transform(path, function, None, lower, log_handler)
+        transform = _Transform(path, function, build_links, lower, log_handler)
         node = Node(transform)
         if act is not None:
             transform.init_dynstate(node, act)

--- a/src/stratoweave/ttt_gen.act
+++ b/src/stratoweave/ttt_gen.act
@@ -2,6 +2,7 @@
 import re
 import yang
 import yang.schema as schema
+import stratoweave.ttt_links as ttt_links
 
 
 def _fq_list_keys(l: schema.DList) -> str:
@@ -47,7 +48,7 @@ class TTTSrc(object):
         self.base_defs = base_defs
         self.act_defs = act_defs
 
-def children_to_tttsrc(sn: schema.DNodeInner, spath: list[schema.DNode]) -> TTTSrc:
+def children_to_tttsrc(sn: schema.DNodeInner, spath: list[schema.DNode], root: schema.DRoot) -> TTTSrc:
     input_classes = []
     state_classes = []
     imports = []
@@ -58,7 +59,7 @@ def children_to_tttsrc(sn: schema.DNodeInner, spath: list[schema.DNode]) -> TTTS
     for child in sn.children:
         if isinstance(child, schema.DLeaf):
             continue
-        res = dschema_to_tttsrc(child, spath + [child], set_ns=child.namespace!=sn.namespace)
+        res = dschema_to_tttsrc(child, spath + [child], root, set_ns=child.namespace!=sn.namespace)
         input_classes.extend(res.input_classes)
         state_classes.extend(res.state_classes)
         imports.extend(res.imports)
@@ -69,7 +70,7 @@ def children_to_tttsrc(sn: schema.DNodeInner, spath: list[schema.DNode]) -> TTTS
     children_src = ", ".join(elems)
     return TTTSrc(src=children_src, input_classes=input_classes, state_classes=state_classes, imports=imports, defs=defs, base_defs=base_defs, act_defs=act_defs)
 
-def dschema_to_tttsrc(sn: schema.DNode, spath: list[schema.DNode], indent=0, set_ns=True) -> TTTSrc:
+def dschema_to_tttsrc(sn: schema.DNode, spath: list[schema.DNode], root: schema.DRoot, indent=0, set_ns=True) -> TTTSrc:
     input_classes = []
     state_classes = []
     imports = []
@@ -155,6 +156,13 @@ def dschema_to_tttsrc(sn: schema.DNode, spath: list[schema.DNode], indent=0, set
         deserializer = root_path[:-1]
 
         if ext.name == "transform":
+            linked_fields = ttt_links.extract_links(sn, root)
+            if len(linked_fields) > 0:
+                build_links_fn = "_build_target_links_{input_class}"
+                defs.append("\n".join(ttt_links.gen_build_target_links(build_links_fn, linked_fields)))
+            else:
+                build_links_fn = "None"
+
             base_defs.append("""class {transform.name}(ttt.TransformFunction):
     transform: mut({input_class}{transform_extra_typed_params}) -> {transform_output}
 {type_helpers}
@@ -174,12 +182,16 @@ def dschema_to_tttsrc(sn: schema.DNode, spath: list[schema.DNode], indent=0, set
         {wrapper_return}
 """)
             if isinstance(sn, schema.DList):
-                src = "ttt.List(ttt.Transform({transform.fqname}, {transform_actor_ctor}, lower, log_handler), {_fq_list_keys(sn)}{nsq(sn)})"
+                src = "ttt.List(ttt.Transform({transform.fqname}, {transform_actor_ctor}, {build_links_fn}, lower, log_handler), {_fq_list_keys(sn)}{nsq(sn)})"
             else:
-                src = "ttt.Transform({transform.fqname}, {transform_actor_ctor}, lower, log_handler)"
+                src = "ttt.Transform({transform.fqname}, {transform_actor_ctor}, {build_links_fn}, lower, log_handler)"
             return TTTSrc(src=src, input_classes=input_classes, state_classes=state_classes, imports=imports, defs=defs, base_defs=base_defs, act_defs=act_defs)
 
         elif ext.name == "rfs-transform":
+            linked_fields = ttt_links.extract_links(sn, root)
+            if len(linked_fields) > 0:
+                raise ValueError("sw:link is not supported on rfs-transform at {schema.get_path(spath)}")
+
             base_defs.append("""class {transform.name}(ttt.RFSFunction):
     transform: mut({input_class}, ttt.DeviceInfo{transform_extra_typed_params}) -> {transform_output}
 {type_helpers}
@@ -221,7 +233,7 @@ def dschema_to_tttsrc(sn: schema.DNode, spath: list[schema.DNode], indent=0, set
                     return TTTSrc(src="ttt.List(ttt.DeviceConfig(dev_registry, log_handler), {_fq_list_keys(sn)}{nsq(sn)})", input_classes=input_classes, state_classes=state_classes, imports=imports, defs=defs, base_defs=base_defs, act_defs=act_defs)
 
         # List without an extension
-        children_res = children_to_tttsrc(sn, spath)
+        children_res = children_to_tttsrc(sn, spath, root)
         input_classes.extend(children_res.input_classes)
         state_classes.extend(children_res.state_classes)
         imports.extend(children_res.imports)
@@ -236,7 +248,7 @@ def dschema_to_tttsrc(sn: schema.DNode, spath: list[schema.DNode], indent=0, set
                 if ext.name == "transform" or ext.name == "rfs-transform":
                     return transform_ext_to_tttsrc(sn, ext)
         sn_children = sn.children
-        children_res = children_to_tttsrc(sn, spath)
+        children_res = children_to_tttsrc(sn, spath, root)
         input_classes.extend(children_res.input_classes)
         state_classes.extend(children_res.state_classes)
         imports.extend(children_res.imports)
@@ -247,8 +259,8 @@ def dschema_to_tttsrc(sn: schema.DNode, spath: list[schema.DNode], indent=0, set
 
     raise NotImplementedError("Unhandled schema type: {type(sn)}: {schema.get_path_name(spath)}")
 
-def ttt_prsrc(sn: schema.DNode, input_yang_module: str, output_yang_module: ?str) -> (base: str, ttt: str):
-    ts = dschema_to_tttsrc(sn, [sn])
+def ttt_prsrc(root: schema.DRoot, input_yang_module: str, output_yang_module: ?str) -> (base: str, ttt: str):
+    ts = dschema_to_tttsrc(root, [root], root)
 
     base_src = "# WARNING WARNING WARNING WARNING WARNING\n"
     base_src += "# DO NOT MODIFY THIS FILE!! This file is generated!\n"
@@ -278,6 +290,9 @@ def ttt_prsrc(sn: schema.DNode, input_yang_module: str, output_yang_module: ?str
     ttt_src += "\n"
     ttt_src += "def get_ttt(lower: ?ttt.Layer, dev_registry: swdev.DeviceRegistry, log_handler: ?logging.Handler=None) -> proc(?ttt.Path,?ttt.Layer)->ttt.Node:\n"
     ttt_src += "    r = {ts.src}\n    return r\n"
+    if len(ts.defs) > 0:
+        ttt_src += "\n"
+    ttt_src += "\n\n".join(ts.defs)
     if len(ts.act_defs) > 0:
         ttt_src += "\n"
     ttt_src += "\n\n".join(list(set(ts.act_defs)))

--- a/src/stratoweave/ttt_gen.act
+++ b/src/stratoweave/ttt_gen.act
@@ -108,9 +108,16 @@ def dschema_to_tttsrc(sn: schema.DNode, spath: list[schema.DNode], root: schema.
                             state_classes.append(_dynstate_class)
                             input_classes.append(_dynstate_class)
                             dynstate_class = _dynstate_class
+        linked_fields = ttt_links.extract_links(sn, root)
+        if ext.name == "rfs-transform" and len(linked_fields) > 0:
+            raise ValueError("sw:link is not supported on rfs-transform at {schema.get_path(spath)}")
+
         wrapper_extra_params = ", device_info" if ext.name == "rfs-transform" else ""
         wrapper_extra_models = "\n"
         transform_extra_typed_params = ""
+        if len(linked_fields) > 0:
+            wrapper_extra_params += ", linked"
+            transform_extra_typed_params += ", linked: yang.gdata.Node"
         if memory_class is not None:
             wrapper_extra_params += ", modeled_memory"
             wrapper_extra_models += "        modeled_memory = {memory_class}.from_gdata(memory) if memory is not None else None\n"
@@ -156,7 +163,6 @@ def dschema_to_tttsrc(sn: schema.DNode, spath: list[schema.DNode], root: schema.
         deserializer = root_path[:-1]
 
         if ext.name == "transform":
-            linked_fields = ttt_links.extract_links(sn, root)
             if len(linked_fields) > 0:
                 build_links_fn = "_build_target_links_{input_class}"
                 defs.append("\n".join(ttt_links.gen_build_target_links(build_links_fn, linked_fields)))
@@ -166,14 +172,14 @@ def dschema_to_tttsrc(sn: schema.DNode, spath: list[schema.DNode], root: schema.
             base_defs.append("""class {transform.name}(ttt.TransformFunction):
     transform: mut({input_class}{transform_extra_typed_params}) -> {transform_output}
 {type_helpers}
-    mut def transform_wrapper(self, i: yang.gdata.Node, memory: ?yang.gdata.Node, dynstate: ?yang.gdata.Node) -> (yang.gdata.Node, ?yang.gdata.Node):
+    mut def transform_wrapper(self, i: yang.gdata.Node, linked: yang.gdata.Node, memory: ?yang.gdata.Node, dynstate: ?yang.gdata.Node) -> (yang.gdata.Node, ?yang.gdata.Node):
         \"\"\"Wrap the user provided transform method to convert from gdata to
         modeled input and back to gdata
         \"\"\"
         modeled_input = {input_class}.from_gdata(i){wrapper_extra_models}
         {wrapper_return}
 
-    mut def transform_xml(self, i: xml.Node, memory: ?yang.gdata.Node, dynstate: ?yang.gdata.Node) -> (yang.gdata.Node, ?yang.gdata.Node):
+    mut def transform_xml(self, i: xml.Node, linked: yang.gdata.Node, memory: ?yang.gdata.Node, dynstate: ?yang.gdata.Node) -> (yang.gdata.Node, ?yang.gdata.Node):
         \"\"\"Wrap the user provided transform method to convert from XML to
         modeled input and return gdata
         \"\"\"
@@ -188,10 +194,6 @@ def dschema_to_tttsrc(sn: schema.DNode, spath: list[schema.DNode], root: schema.
             return TTTSrc(src=src, input_classes=input_classes, state_classes=state_classes, imports=imports, defs=defs, base_defs=base_defs, act_defs=act_defs)
 
         elif ext.name == "rfs-transform":
-            linked_fields = ttt_links.extract_links(sn, root)
-            if len(linked_fields) > 0:
-                raise ValueError("sw:link is not supported on rfs-transform at {schema.get_path(spath)}")
-
             base_defs.append("""class {transform.name}(ttt.RFSFunction):
     transform: mut({input_class}, ttt.DeviceInfo{transform_extra_typed_params}) -> {transform_output}
 {type_helpers}

--- a/src/stratoweave/ttt_links.act
+++ b/src/stratoweave/ttt_links.act
@@ -1,0 +1,278 @@
+
+import yang.schema as schema
+import yang.xpath as xpath
+
+
+class Link(value):
+    """Base IR node for a single link declaration within a transform.
+
+    filter_path is the exact schema path used to build the runtime gdata filter.
+    linked_input_path is the schema path to the root of the linked transform,
+    derived from filter_path by _find_linked_transform.
+    """
+    filter_path: list[schema.DNode]
+    linked_input_path: list[schema.DNode]
+
+    def __init__(self, filter_path: list[schema.DNode], linked_input_path: list[schema.DNode]):
+        self.filter_path = filter_path
+        self.linked_input_path = linked_input_path
+
+class StaticLink(Link):
+    """A link with a fixed filter path from a nested sw:path."""
+
+    def __init__(self, filter_path: list[schema.DNode], linked_input_path: list[schema.DNode]):
+        Link.__init__(self, filter_path, linked_input_path)
+
+class LeafrefLink(Link):
+    """A link whose filter value comes from a leafref source leaf."""
+    source_path_from_transform: list[schema.DNode]
+
+    def __init__(self, filter_path: list[schema.DNode], linked_input_path: list[schema.DNode], source_path_from_transform: list[schema.DNode]):
+        Link.__init__(self, filter_path, linked_input_path)
+        self.source_path_from_transform = source_path_from_transform
+
+class LinkedInput(value):
+    """Single tagged link with cardinality information."""
+    link: Link
+
+    def __init__(self, link: Link):
+        self.link = link
+
+class SingleLinkedInput(LinkedInput):
+    """Cardinality 1: exactly one linked input."""
+
+    def __init__(self, link: Link):
+        LinkedInput.__init__(self, link)
+
+class OptionalLinkedInput(LinkedInput):
+    """Cardinality 0..1: at most one linked input."""
+
+    def __init__(self, link: Link):
+        LinkedInput.__init__(self, link)
+
+class MultiLinkedInput(LinkedInput):
+    """Cardinality 0..n or 1..n: multiple linked inputs from a list traversal."""
+
+    def __init__(self, link: Link):
+        LinkedInput.__init__(self, link)
+
+def xpath_to_spath(root: schema.DRoot, path: xpath.AbsoluteLocationPath, context_module: str) -> list[schema.DNode]:
+    """Resolve an absolute XPath to a schema path (list of DNode from the root)
+
+    context_module is the module of the node that owns the path (e.g. the leafref's module).
+    Unprefixed steps are resolved in this module's namespace, matching the YANG leafref semantics.
+    """
+    n = root
+    result = []
+    for step in path.steps:
+        if isinstance(step, xpath.NodeTestStep):
+            if len(step.predicates) > 0:
+                raise ValueError("Unsupported: predicates in path step: {step}")
+            step_prefix = step.prefix
+            if step_prefix is not None:
+                n = n.get(step.name, prefix=step_prefix)
+            else:
+                # Unqualified (no prefix) nodes belong the namespace of the current node
+                n = n.get(step.name, module=context_module)
+            result.append(n)
+        else:
+            raise ValueError("Unsupported: non-NodeTestStep in path: {step}")
+    return result
+
+SW_NS = "http://stratoweave.org/yang/stratoweave.yang"
+
+def _find_linked_transform(filter_path: list[schema.DNode]) -> list[schema.DNode]:
+    """Find the linked transform by walking filter_path from the end.
+
+    Returns the prefix of filter_path up to and including the node that
+    carries sw:transform or sw:rfs-transform.
+    """
+    i = len(filter_path) - 1
+    while i >= 0:
+        for ext in filter_path[i].exts:
+            if ext.namespace == SW_NS and (ext.name == "transform" or ext.name == "rfs-transform"):
+                return filter_path[:i + 1]
+        i -= 1
+    raise ValueError("No sw:transform found along filter path: {schema.get_path(filter_path)}")
+
+def _subtree_has_link(sn: schema.DNode) -> bool:
+    """Return True if sn or any descendant carries sw:link."""
+    for ext in sn.exts:
+        if ext.namespace == SW_NS and ext.name == "link":
+            return True
+    if isinstance(sn, schema.DNodeInner):
+        for child in sn.children:
+            if _subtree_has_link(child):
+                return True
+    return False
+
+def _collect_links(sn: schema.DNode, root: schema.DRoot, path_from_transform: list[schema.DNode], links_by_tag: dict[str, Link]):
+    """Recursively find sw:link declarations in a transform subtree.
+
+    Walks the input schema tree under a transform node and collects one Link
+    per tag. Duplicate tags are not allowed. Nodes containing the sw:memory or
+    sw:dynstate extensions are also not allowed to contain links.
+    """
+    for ext in sn.exts:
+        if ext.namespace == SW_NS and ext.name == "link":
+            tag = ext.arg
+            if tag is not None:
+                link: ?Link = None
+                if isinstance(sn, schema.DLeaf):
+                    # Leafref link: resolve from the leaf's compiled type
+                    leaf_type = sn.type_
+                    if isinstance(leaf_type, schema.DTypeLeafref):
+                        filter_path = xpath_to_spath(root, leaf_type.path, sn.module)
+                        linked_input_path = _find_linked_transform(filter_path)
+                        link = LeafrefLink(filter_path, linked_input_path, path_from_transform)
+                    else:
+                        raise ValueError("sw:link on leaf {sn.name} requires leafref type")
+                else:
+                    # Static link: resolve the nested sw:path
+                    path_arg = None
+                    for subext in ext.exts:
+                        if subext.namespace == SW_NS and subext.name == "path":
+                            path_arg = subext.arg
+                    if path_arg is not None:
+                        parsed = xpath.try_parse_location_path(path_arg)
+                        if isinstance(parsed, xpath.AbsoluteLocationPath):
+                            filter_path = xpath_to_spath(root, parsed, sn.module)
+                            linked_input_path = _find_linked_transform(filter_path)
+                            link = StaticLink(filter_path, linked_input_path)
+                        else:
+                            raise ValueError("sw:path on node {sn.name} must be an absolute path, got: {path_arg}")
+                    else:
+                        raise ValueError("sw:link on non-leaf {sn.name} requires sw:path substatement")
+
+                if link is not None:
+                    if tag in links_by_tag:
+                        raise ValueError("Duplicate sw:link tag '{tag}' in transform subtree; only one declaration per tag is supported")
+                    links_by_tag[tag] = link
+            else:
+                raise ValueError("sw:link on node {sn.name} requires a tag argument")
+    if isinstance(sn, schema.DNodeInner):
+        for child in sn.children:
+            child_scope = None
+            for ext in child.exts:
+                if ext.namespace == SW_NS:
+                    if ext.name == "memory":
+                        child_scope = "sw:memory"
+                    elif ext.name == "dynstate":
+                        child_scope = "sw:dynstate"
+            if child_scope is not None:
+                if _subtree_has_link(child):
+                    raise ValueError("sw:link under {child_scope} is not supported; linked sources must be in the transform input subtree")
+                continue
+            _collect_links(child, root, path_from_transform + [child], links_by_tag)
+
+def extract_links(transform_node: schema.DNodeInner, root: schema.DRoot) -> dict[str, LinkedInput]:
+    """Extract sw:link declarations from a transform subtree.
+
+    Resolves each link against the compiled schema and wraps it in a
+    LinkedInput subtype based on cardinality:
+
+    - static links are always optional (target data may not exist)
+    - leafref links crossing a list produce multiple link demands
+    - leafref links without a list crossing are optional
+    """
+    links_by_tag: dict[str, Link] = {}
+    _collect_links(transform_node, root, [], links_by_tag)
+
+    result: dict[str, LinkedInput] = {}
+    for tag, link in links_by_tag.items():
+        if isinstance(link, StaticLink):
+            result[tag] = OptionalLinkedInput(link)
+        elif isinstance(link, LeafrefLink):
+            crosses_list = False
+            for step in link.source_path_from_transform:
+                if isinstance(step, schema.DList):
+                    crosses_list = True
+            if crosses_list:
+                result[tag] = MultiLinkedInput(link)
+            else:
+                result[tag] = OptionalLinkedInput(link)
+    return result
+
+def _gen_id(node: schema.DNode) -> str:
+    return 'yang.gdata.Id("{node.namespace}", "{node.name}")'
+
+def _gen_fnode(path: list[schema.DNode], value_match_var: ?str=None) -> str:
+    """Generate nested gdata.FNode(...) literal from a schema path."""
+    last = path[-1]
+    if value_match_var is not None:
+        s = "yang.gdata.FNode({_gen_id(last)}, value_match={value_match_var})"
+    else:
+        s = "yang.gdata.FNode({_gen_id(last)})"
+    i = len(path) - 2
+    while i >= 0:
+        step = path[i]
+        s = "yang.gdata.FNode({_gen_id(step)}, children=[{s}])"
+        i -= 1
+    return s
+
+def _gen_source_traversal(tag: str, link: LeafrefLink, indent: int) -> list[str]:
+    """Generate gdata traversal code that reads leafref source values.
+
+    Walks source_path_from_transform and emits get_opt_cnt / get_opt_list /
+    get_opt_value calls for each schema step. Consecutive container steps are
+    collapsed into a single optional chain (using ?.). List steps produce a loop
+    over elements. Once the source leaf is reached, its value is captured in a
+    _vN variable and embedded in an FNode filter expression.
+    """
+    lines = []
+    path = link.source_path_from_transform
+    cur = "conf"
+    depth = 0
+    ind = indent
+    chain_parts = []
+
+    for step in path:
+        qn = _gen_id(step)
+        if isinstance(step, schema.DLeaf):
+            chain_parts.append("get_opt_value({qn})")
+            vname = "_v{depth}"
+            lines.append("{' ' * ind}{vname} = {cur}.{"?.".join(chain_parts)}")
+            lines.append("{' ' * ind}if {vname} is not None:")
+            ind += 4
+            fnode = _gen_fnode(link.filter_path, value_match_var=vname)
+            lines.append("{' ' * ind}res.append(ttt.TaggedPath({repr(tag)}, {fnode}))")
+        elif isinstance(step, schema.DList):
+            chain_parts.append("get_opt_list({qn})")
+            lname = "_l{depth}"
+            lines.append("{' ' * ind}{lname} = {cur}.{"?.".join(chain_parts)}")
+            lines.append("{' ' * ind}if {lname} is not None:")
+            ind += 4
+            ename = "_e{depth}"
+            lines.append("{' ' * ind}for {ename} in {lname}.elements:")
+            ind += 4
+            cur = ename
+            chain_parts = []
+        elif isinstance(step, schema.DContainer):
+            chain_parts.append("get_opt_cnt({qn})")
+        depth += 1
+    return lines
+
+def gen_build_target_links(fname: str, linked_fields: dict[str, LinkedInput], indent=0) -> list[str]:
+    """Generate a function that computes a transform's link demands at runtime.
+
+    Emits a module-level build_target_links function with the given name. The
+    generated function traverses the transform input gdata subtree and returns
+    the list of gdata filters describing which linked transform inputs this
+    transform needs. Source leafref values are embedded in the FNode
+    expressions.
+    """
+    lines = []
+    lines.append("{' ' * indent}def {fname}(conf: yang.gdata.Node) -> list[ttt.TaggedPath]:")
+    body_indent = indent + 4
+    lines.append("{' ' * body_indent}res = []")
+    for tag, field in linked_fields.items():
+        link = field.link
+        if isinstance(link, StaticLink):
+            fnode = _gen_fnode(link.filter_path)
+            lines.append("{' ' * body_indent}# static link: {tag}")
+            lines.append("{' ' * body_indent}res.append(ttt.TaggedPath({repr(tag)}, {fnode}))")
+        elif isinstance(link, LeafrefLink):
+            lines.append("{' ' * body_indent}# leafref link: {tag}")
+            lines.extend(_gen_source_traversal(tag, link, body_indent))
+    lines.append("{' ' * body_indent}return res")
+    return lines

--- a/src/stratoweave/yang.act
+++ b/src/stratoweave/yang.act
@@ -45,6 +45,20 @@ stratoweave = r"""module stratoweave {
       function inputs with an additional read-only structure. The transform
       function may update this subtree by returning new data.";
   }
+  extension link {
+    description
+      "Declares a link demand from this transform towards another (linked)
+      transform. The argument is a tag that identifies the link. On a leafref
+      leaf, the link target is derived from the leafref path. On other nodes,
+      a nested sw:path substatement provides the target path.";
+    argument "tag";
+  }
+  extension path {
+    description
+      "Substatement of sw:link that provides an explicit absolute schema path
+      to the linked transform target.";
+    argument "path";
+  }
 }"""
 
 

--- a/src/test_ttt_gen.act
+++ b/src/test_ttt_gen.act
@@ -167,3 +167,79 @@ def _test_ttt_gen_invalid_transform_module_name():
     except ValueError as e:
         if "not a valid Acton name" not in e.error_message:
             raise e
+
+ys_linked_leafref_l3vpn = r"""module ietf-l3vpn-svc {
+  yang-version "1.1";
+  namespace "urn:ietf:params:xml:ns:yang:ietf-l3vpn-svc";
+  prefix "l3vpn-svc";
+  import stratoweave {
+    prefix sw;
+  }
+  container global-settings {
+    sw:transform respnet.cfs.GlobalSettings;
+
+    leaf asn {
+      type uint32;
+      mandatory true;
+    }
+  }
+  container l3vpn-svc {
+    container vpn-services {
+      list vpn-service {
+        key vpn-id;
+
+        sw:transform respnet.cfs.L3VpnVpnService;
+
+        leaf vpn-id {
+          type string;
+        }
+      }
+    }
+
+    container sites {
+      list site {
+        key site-id;
+
+        sw:transform respnet.cfs.L3VpnSite;
+        sw:link global {
+          // TODO: fix extension substatements such that *any* valid substatement is parsed
+          sw:path /global-settings;
+        }
+
+        leaf site-id {
+          type string;
+        }
+
+        container site-network-accesses {
+          list site-network-access {
+            key site-network-access-id;
+
+            leaf site-network-access-id {
+              type string;
+            }
+
+            container vpn-attachment {
+              leaf vpn-id {
+                sw:link vpn;
+                type leafref {
+                  path "/l3vpn-svc/vpn-services/vpn-service/vpn-id";
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}
+"""
+
+def _test_ttt_gen_linked_leafref_l3vpn_base():
+    y = yang.compile([ys_linked_leafref_l3vpn, swyang.stratoweave])
+    r = ttt_gen.ttt_prsrc(y, 'respnet.layers.y_0', 'respnet.layers.y_1_loose')
+    return r.base
+
+def _test_ttt_gen_linked_leafref_l3vpn_ttt():
+    y = yang.compile([ys_linked_leafref_l3vpn, swyang.stratoweave])
+    r = ttt_gen.ttt_prsrc(y, 'respnet.layers.y_0', 'respnet.layers.y_1_loose')
+    return r.ttt

--- a/src/test_ttt_layers.act
+++ b/src/test_ttt_layers.act
@@ -71,7 +71,7 @@ out1_2 = gdata.Container({
 })
 
 class TransF(ttt.TransformFunction):
-    def transform_wrapper(self, cfg, memory, dynstate):
+    def transform_wrapper(self, cfg, linked, memory, dynstate):
         """Simple transform that copies inputs to ouputs (sans keys)
 
         The input list layer is keyed on "name", the output on "id". This
@@ -174,7 +174,7 @@ out3 = gdata.Container({
 })
 
 class WriteDev(ttt.TransformFunction):
-    def transform_wrapper(self, cfg: gdata.Node, memory, dynstate):
+    def transform_wrapper(self, cfg: gdata.Node, linked: gdata.Node, memory, dynstate):
         i = cfg.get_int(q("a"))
         return gdata.Container({
             q('devices'): gdata.List([q("id")], [
@@ -210,7 +210,7 @@ cfg4 = gdata.Container({
 })
 
 class ServiceMap(ttt.TransformFunction):
-    def transform_wrapper(self, cfg, memory, dynstate):
+    def transform_wrapper(self, cfg, linked, memory, dynstate):
         ll = cfg.get_int(q("ll"))
         rr = cfg.get_int(q("rr"))
         return gdata.Container({
@@ -259,7 +259,7 @@ out5 = gdata.Container({
 
 
 class WriteDevs(ttt.TransformFunction):
-    def transform_wrapper(self, cfg: gdata.Node, memory, dynstate):
+    def transform_wrapper(self, cfg: gdata.Node, linked: gdata.Node, memory, dynstate):
         return out5, None
 
 actor _test_redundant_config(t: testing.AsyncT):

--- a/src/test_ttt_links.act
+++ b/src/test_ttt_links.act
@@ -1,0 +1,280 @@
+import testing
+
+import yang
+import yang.gdata as gdata
+import yang.schema as schema
+import yang.xpath as xpath
+import stratoweave.ttt_links as ttt_links
+import stratoweave.yang as swyang
+
+
+########################
+# Test YANG modules
+########################
+
+ys_netinfra = r"""module netinfra {
+  yang-version "1.1";
+  namespace "http://example.com/netinfra";
+  prefix "netinfra";
+  import stratoweave {
+    prefix sw;
+  }
+  container global-settings {
+    sw:transform respnet.cfs.GlobalSettings;
+
+    leaf asn {
+      type uint32;
+      mandatory true;
+    }
+  }
+}
+"""
+
+ys_linked_l3vpn = r"""module ietf-l3vpn-svc {
+  yang-version "1.1";
+  namespace "urn:ietf:params:xml:ns:yang:ietf-l3vpn-svc";
+  prefix "l3vpn-svc";
+  import stratoweave {
+    prefix sw;
+  }
+  import netinfra {
+    prefix netinfra;
+  }
+  container l3vpn-svc {
+    container vpn-services {
+      list vpn-service {
+        key vpn-id;
+
+        sw:transform respnet.cfs.L3VpnVpnService;
+
+        leaf vpn-id {
+          type string;
+        }
+      }
+    }
+
+    container sites {
+      list site {
+        key site-id;
+
+        sw:transform respnet.cfs.L3VpnSite;
+        sw:link global {
+          // TODO: fix extension substatements such that *any* valid substatement is parsed
+          sw:path /netinfra:global-settings;
+        }
+
+        leaf site-id {
+          type string;
+        }
+
+        container site-network-accesses {
+          list site-network-access {
+            key site-network-access-id;
+
+            leaf site-network-access-id {
+              type string;
+            }
+
+            container vpn-attachment {
+              leaf vpn-id {
+                sw:link vpn;
+                type leafref {
+                  path "/l3vpn-svc/vpn-services/vpn-service/vpn-id";
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}
+"""
+
+ys_link_in_memory = r"""module link-in-memory {
+  yang-version "1.1";
+  namespace "http://example.com/link-in-memory";
+  prefix "lim";
+  import stratoweave {
+    prefix sw;
+  }
+
+  container targets {
+    list target {
+      key id;
+
+      sw:transform respnet.cfs.Target;
+
+      leaf id {
+        type string;
+      }
+    }
+  }
+
+  container service {
+    sw:transform respnet.cfs.Service;
+
+    leaf name {
+      type string;
+    }
+
+    container memory {
+      sw:memory;
+
+      leaf target-id {
+        sw:link peer;
+        type leafref {
+          path "/targets/target/id";
+        }
+      }
+    }
+  }
+}
+"""
+
+ys_link_in_dynstate = r"""module link-in-dynstate {
+  yang-version "1.1";
+  namespace "http://example.com/link-in-dynstate";
+  prefix "lid";
+  import stratoweave {
+    prefix sw;
+  }
+
+  container targets {
+    list target {
+      key id;
+
+      sw:transform respnet.cfs.Target;
+
+      leaf id {
+        type string;
+      }
+    }
+  }
+
+  container service {
+    sw:transform respnet.cfs.Service;
+
+    leaf name {
+      type string;
+    }
+
+    container dynstate {
+      sw:dynstate;
+
+      leaf target-id {
+        sw:link peer;
+        type leafref {
+          path "/targets/target/id";
+        }
+      }
+    }
+  }
+}
+"""
+
+########################
+# Helpers
+########################
+
+def _find_child(parent: schema.DNodeInner, name: str) -> schema.DNode:
+    for child in parent.children:
+        if child.name == name:
+            return child
+    raise ValueError("Child not found: " + name)
+
+def _as_inner(node: schema.DNode) -> schema.DNodeInner:
+    if isinstance(node, schema.DNodeInner):
+        return node
+    raise ValueError("Expected DNodeInner")
+
+def _as_leaf(node: schema.DNode) -> schema.DLeaf:
+    if isinstance(node, schema.DLeaf):
+        return node
+    raise ValueError("Expected DLeaf")
+
+
+########################
+# Tests
+########################
+
+def _test_resolve_schema_path_leafref():
+    """xpath_to_spath produces the same nodes as manual navigation for the vpn-id leafref."""
+    y = yang.compile([ys_netinfra, ys_linked_l3vpn, swyang.stratoweave])
+
+    # Get the leafref path from the compiled schema
+    l3vpn_svc = _as_inner(_find_child(y, "l3vpn-svc"))
+    sites = _as_inner(_find_child(l3vpn_svc, "sites"))
+    site = _as_inner(_find_child(sites, "site"))
+    sna_cnt = _as_inner(_find_child(site, "site-network-accesses"))
+    sna_list_node = _find_child(sna_cnt, "site-network-access")
+    sna_inner = _as_inner(sna_list_node)
+    vpn_attachment = _as_inner(_find_child(sna_inner, "vpn-attachment"))
+    vpn_id_source = _as_leaf(_find_child(vpn_attachment, "vpn-id"))
+    leafref_type = vpn_id_source.type_
+    if isinstance(leafref_type, schema.DTypeLeafref):
+        resolved = ttt_links.xpath_to_spath(y, leafref_type.path, vpn_id_source.module)
+        testing.assertEqual(schema.get_path(resolved), "l3vpn-svc/vpn-services/vpn-service/vpn-id")
+    else:
+        testing.error("Expected DTypeLeafref")
+
+
+def _test_extract_links():
+    """extract_links produces the expected IR from the compiled schema."""
+    y = yang.compile([ys_netinfra, ys_linked_l3vpn, swyang.stratoweave])
+
+    # Find the site transform node
+    l3vpn_svc = _as_inner(_find_child(y, "l3vpn-svc"))
+    sites = _as_inner(_find_child(l3vpn_svc, "sites"))
+    site = _as_inner(_find_child(sites, "site"))
+
+    extracted = ttt_links.extract_links(site, y)
+
+    # global: static link -> OptionalLinkedFieldIR
+    testing.assertEqual("global" in extracted, True)
+    global_field = extracted["global"]
+    testing.assertEqual(isinstance(global_field, ttt_links.OptionalLinkedInput), True)
+    global_link = global_field.link
+    testing.assertEqual(isinstance(global_link, ttt_links.StaticLink), True)
+    testing.assertEqual(schema.get_path(global_link.filter_path), "global-settings")
+    testing.assertEqual(schema.get_path(global_link.linked_input_path), "global-settings")
+
+    # vpn: leafref link -> MultiLinkedFieldIR
+    testing.assertEqual("vpn" in extracted, True)
+    vpn_field = extracted["vpn"]
+    testing.assertEqual(isinstance(vpn_field, ttt_links.MultiLinkedInput), True)
+    vpn_link = vpn_field.link
+    testing.assertEqual(isinstance(vpn_link, ttt_links.LeafrefLink), True)
+    if isinstance(vpn_link, ttt_links.LeafrefLink):
+        testing.assertEqual(schema.get_path(vpn_link.filter_path), "l3vpn-svc/vpn-services/vpn-service/vpn-id")
+        testing.assertEqual(schema.get_path(vpn_link.linked_input_path), "l3vpn-svc/vpn-services/vpn-service")
+        testing.assertEqual(schema.get_path(vpn_link.source_path_from_transform), "site-network-accesses/site-network-access/vpn-attachment/vpn-id")
+
+def _test_extract_links_rejects_links_in_memory():
+    """Links under sw:memory are rejected because build_target_links only sees conf."""
+    y = yang.compile([ys_link_in_memory, swyang.stratoweave])
+    service = _as_inner(_find_child(y, "service"))
+    try:
+        ttt_links.extract_links(service, y)
+        testing.error("Expected extract_links to reject sw:link under sw:memory")
+    except ValueError as e:
+        testing.assertEqual("sw:memory" in e.error_message, True)
+
+def _test_extract_links_rejects_links_in_dynstate():
+    """Links under sw:dynstate are rejected because build_target_links only sees conf."""
+    y = yang.compile([ys_link_in_dynstate, swyang.stratoweave])
+    service = _as_inner(_find_child(y, "service"))
+    try:
+        ttt_links.extract_links(service, y)
+        testing.error("Expected extract_links to reject sw:link under sw:dynstate")
+    except ValueError as e:
+        testing.assertEqual("sw:dynstate" in e.error_message, True)
+
+def _test_gen_build_target_links():
+    y = yang.compile([ys_netinfra, ys_linked_l3vpn, swyang.stratoweave])
+    l3vpn_svc = _as_inner(_find_child(y, "l3vpn-svc"))
+    sites = _as_inner(_find_child(l3vpn_svc, "sites"))
+    site = _as_inner(_find_child(sites, "site"))
+    extracted = ttt_links.extract_links(site, y)
+    lines = ttt_links.gen_build_target_links("build_target_links_test", extracted)
+    return "\n".join(lines)

--- a/src/test_ttt_persistence.act
+++ b/src/test_ttt_persistence.act
@@ -278,7 +278,7 @@ removed_live_root = ttt.Container({
 
 
 class PersistMemoryTransform(ttt.TransformFunction):
-    def transform_wrapper(self, cfg: gdata.Node, memory: ?gdata.Node, dynstate: ?gdata.Node):
+    def transform_wrapper(self, cfg: gdata.Node, linked: gdata.Node, memory: ?gdata.Node, dynstate: ?gdata.Node):
         if memory is not None and memory == gdata.Leaf(42):
             return (cfg, memory)
         if cfg == gdata.Leaf(42):
@@ -287,7 +287,7 @@ class PersistMemoryTransform(ttt.TransformFunction):
 
 
 class PersistDynstateTransform(ttt.TransformFunction):
-    def transform_wrapper(self, cfg: gdata.Node, memory: ?gdata.Node, dynstate: ?gdata.Node):
+    def transform_wrapper(self, cfg: gdata.Node, linked: gdata.Node, memory: ?gdata.Node, dynstate: ?gdata.Node):
         if dynstate is not None and dynstate == gdata.Leaf(41):
             if memory is not None and memory == gdata.Leaf(40):
                 return (cfg, gdata.Leaf(42))

--- a/src/test_ttt_transform.act
+++ b/src/test_ttt_transform.act
@@ -589,7 +589,7 @@ actor spurious_config(t: testing.AsyncT):
 ########################
 
 class MemoryTransform(ttt.TransformFunction):
-    def transform_wrapper(self, cfg: gdata.Node, memory: ?gdata.Node, dynstate: ?gdata.Node):
+    def transform_wrapper(self, cfg: gdata.Node, linked: gdata.Node, memory: ?gdata.Node, dynstate: ?gdata.Node):
         if memory is not None and isinstance(memory, gdata.Leaf):
             _memory: gdata.Leaf = memory
             val = _memory.val
@@ -622,7 +622,7 @@ actor transform_memory(t: testing.AsyncT):
 ########################
 
 class FailingTransform(ttt.TransformFunction):
-    def transform_wrapper(self, cfg: gdata.Node, memory: ?gdata.Node, dynstate: ?gdata.Node):
+    def transform_wrapper(self, cfg: gdata.Node, linked: gdata.Node, memory: ?gdata.Node, dynstate: ?gdata.Node):
         raise AssertionError("Test transform error")
 
 actor transform_exception(t: testing.AsyncT):
@@ -658,7 +658,7 @@ actor DynstateActor(path: ttt.Path, update_dynstate: proc(?adata.MNode)->None, t
                 t.success()
 
 class DynstateTransform(ttt.TransformFunction):
-    def transform_wrapper(self, cfg: gdata.Node, memory: ?gdata.Node, dynstate: ?gdata.Node):
+    def transform_wrapper(self, cfg: gdata.Node, linked: gdata.Node, memory: ?gdata.Node, dynstate: ?gdata.Node):
         if dynstate is not None and dynstate == gdata.Leaf(41):
             return (cfg, gdata.Leaf(42))
         elif cfg is not None and cfg == gdata.Leaf(39):


### PR DESCRIPTION
This branch includes changes to test the linked inputs functionality end to end:

- generate `_build_target_links_<transform>` functions in *t_X.act* and pass them to `ttt.Transform()`,
- accept `linked: gdata.Node` argument in `TransformFunction.transform_wrapper()`,
- and pass the `linked` argument to the user transform function.

The transforms in minisys were extended with two canonical linked input examples. I also added the missing bit of passing the linked input through TTT `configure -> compute -> transform_wrapper`, though I am not sure I did that correctly. @nordlander PTAL