### PR TITLE
Proceed in spite of errors

### DIFF
--- a/src/stratoweave/ttt.act
+++ b/src/stratoweave/ttt.act
@@ -128,24 +128,26 @@ class LinkUpdate():
         return v == s if isinstance(v, str) else False
 
 class CfgResult():
-    pass
-
-class CfgOk(CfgResult):
     empty: bool
     requests: list[LinkRequest]
     updates: list[LinkUpdate]
-    def __init__(self, empty=False, requests=[], updates=[]):
+    errors: list[Exception]
+    def __init__(self, empty=False, requests=[], updates=[], errors=[]):
         self.empty = empty
         self.requests = requests
         self.updates = updates
+        self.errors = errors
     def __str__(self):
-        return 'CfgOk(empty=True)' if self.empty else 'CfgOk()'
+        if self.errors:
+            return 'CfgError(' + str(self.errors) + ')'
+        else:
+            return 'CfgOk(empty=True)' if self.empty else 'CfgOk()'
 
-class CfgError(CfgResult):
-    def __init__(self, exception: Exception):
-        self.exception = exception
-    def __str__(self):
-        return 'CfgError(' + str(self.exception) + ')'
+def CfgOk(empty=False, requests=[], updates=[]):
+    return CfgResult(empty, requests, updates, [])
+
+def CfgError(exception: Exception):
+    return CfgResult(empty=False, requests=[], updates=[], errors=[exception])
 
 
 class Path():
@@ -450,11 +452,6 @@ actor Session(name: str, rootnode: Node, lowerlayer: ?Layer, db: ?lmdb.Db, dbuf_
                     return
             else:
                 raise ValueError("Missing DB buffer for staged DB flush")
-        else:
-            commit(tid, True)
-            edit_config_finish("Ok", True)
-            return
-
         commit(tid, True)
         edit_config_finish("Ok", True)
 
@@ -465,29 +462,26 @@ actor Session(name: str, rootnode: Node, lowerlayer: ?Layer, db: ?lmdb.Db, dbuf_
         configure(tid, {'_': diff})
         res = apply(tid, force)
         #print('   #', tid, '(Layer)', name, 'EDIT_CONFIG', 'PREP RESULT', res, err=True)
-        requests, updates = (res.requests, res.updates) if isinstance(res, CfgOk) else ([], [])
-        while requests or updates:
-            res = root.linkage(tid, requests, updates, lower, dbuf)
-            requests, updates = (res.requests, res.updates) if isinstance(res, CfgOk) else ([], [])
-        if isinstance(res, CfgOk):
+        while res.requests or res.updates:
+            res = root.linkage(tid, res.requests, res.updates, lower, dbuf)
+        if not res.errors:
             done_cont = done
             comp_cont = complete
             lock(tid, edit_config_cont)                                     # yield await
         else:
-            result = res.exception if isinstance(res, CfgError) else 'Ok'
             if done is not None:
-                done(result)
+                done(res.errors[0])
             if complete is not None:
-                complete(result)
+                complete(res.errors[0])
 
     def edit_config_cont(res):
         #print('####', tid_state, '(Layer)', name, 'edit_config_cont', err=True)
         if tid_state is not None:
-            if isinstance(res, CfgOk):
+            if not res.errors:
                 _flush_dbuffer_then_commit()
             else:
                 commit(tid_state, False)
-                edit_config_finish(res.exception if isinstance(res, CfgError) else 'Ok', False)
+                edit_config_finish(res.errors[0], False)
 
     def edit_config_finish(result: value, ok: bool):
         if tid_state is not None:
@@ -512,7 +506,7 @@ actor Session(name: str, rootnode: Node, lowerlayer: ?Layer, db: ?lmdb.Db, dbuf_
         buf = {}
         #print('   #', tid, '(Layer)', name, 'APPLY\n' + per_src(diff), err=True)
         res = root.configure(tid, diff, lower, force, dbuf)
-        if not isinstance(res, CfgError) and lower is not None:
+        if not res.errors and lower is not None:
             res = lower.apply(tid, force=False)
         #print('   #', tid, '(Layer)', name, 'APPLY RESULT', res, err=True)
         return res
@@ -523,9 +517,9 @@ actor Session(name: str, rootnode: Node, lowerlayer: ?Layer, db: ?lmdb.Db, dbuf_
         if buf:                                         # An upper layer has re-configured
             #print('####', tid, '(Layer)', name, 'LOCK RE-APPLY', err=True)
             res = apply(tid, force=False)
-            if isinstance(res, Exception):
+            if res.errors:
                 if done is not None:
-                    done(CfgError(res))
+                    done(res)
                 return
         tid_state = tid
         lock_cont = done
@@ -565,12 +559,12 @@ actor Session(name: str, rootnode: Node, lowerlayer: ?Layer, db: ?lmdb.Db, dbuf_
         tid = 'tr' + actorid()
         #print('####', tid, '(Layer)', name, 'recompute', actorid(), err=True)
         res = apply(tid, force)
-        if isinstance(res, CfgOk):
+        if not res.errors:
             done_cont = done
             comp_cont = complete
             lock(tid, edit_config_cont)                                     # yield await
         else:
-            result = res.exception if isinstance(res, CfgError) else 'Ok'
+            result = res.errors[0]
             if done is not None:
                 done(result)
             if complete is not None:
@@ -694,15 +688,13 @@ class _ContainerTransaction(_Transaction):
         empty = True
         requests = []
         updates = []
+        errors = []
         for r in results.values():
-            if isinstance(r, CfgError):
-                #print('   # ...... (Container)', _format_path(self.path), 'ANALYZE ERROR:', r, err=True)
-                return r
-            if isinstance(r, CfgOk):
-                empty = empty and r.empty
-                requests += r.requests
-                updates += r.updates
-        r = CfgOk(empty, requests, updates)
+            empty = empty and r.empty
+            requests += r.requests
+            updates += r.updates
+            errors += r.errors
+        r = CfgResult(empty, requests, updates, errors)
         #print('   # ...... (Container)', _format_path(self.path), 'ANALYZE RESULT:', r, err=True)
         return r
 
@@ -979,7 +971,7 @@ class _ListTransaction(_Transaction):
 
         def op(key, res):
             path = _db_path(self.path) + [key]
-            if isinstance(res, CfgOk) and not res.empty and key in leaves_by_key:
+            if not res.errors and not res.empty and key in leaves_by_key:
                 return swdb.put_op(path, swdb.ATTR_KEYS, gdata.Container(leaves_by_key[key]))
             else:
                 return swdb.del_op(path, swdb.ATTR_KEYS)
@@ -991,16 +983,14 @@ class _ListTransaction(_Transaction):
         empty = True
         requests = []
         updates = []
+        errors = []
         for r in results.values():
-            if isinstance(r, CfgError):
-                #print('   # ...... (List)', _format_path(self.path), 'ANALYZE ERROR:', r, err=True)
-                return r
-            if isinstance(r, CfgOk):
-                empty = empty and r.empty
-                requests += r.requests
-                updates += r.updates
+            empty = empty and r.empty
+            requests += r.requests
+            updates += r.updates
+            errors += r.errors
         #print('   # ...... (List)', _format_path(self.path), 'ANALYZE RESULT:', res, err=True)
-        return CfgOk(empty, requests, updates)
+        return CfgResult(empty, requests, updates, errors)
 
     def linkage(self, tid, requests, updates, out, dbuf):
         results = {}
@@ -1051,7 +1041,7 @@ class _ListTransaction(_Transaction):
             tr.commit(tid, ok)
         deletes = set()
         for key,res in self.accum.items():
-            if isinstance(res, CfgOk) and res.empty:
+            if res.empty:
                 #print('   #', tid, '(List)', _format_path(self.path), 'DELETE ELEMENT', key, err=True)
                 deletes.add(key)
         self.liststate.release(tid, ok, deletes)

--- a/src/stratoweave/ttt.act
+++ b/src/stratoweave/ttt.act
@@ -289,7 +289,7 @@ actor Transaction(impl: _Transaction):
     def commit(tid, ok):
         impl.commit(tid, ok)
 
-    def wait_complete(tid, done):
+    def wait_complete(tid, done:action(value)->None):
         impl.wait_complete(self, tid, done)
 
     def wait_complete_cont(res):
@@ -422,7 +422,7 @@ actor Session(name: str, rootnode: Node, lowerlayer: ?Layer, db: ?lmdb.Db, dbuf_
                     after swdb.WRITE_RETRY_DELAY: _flush_dbuffer_then_commit()
                     return None
                 commit(tid, False)
-                edit_config_finish(e, False)
+                edit_config_finish(e)
                 return None
 
         proc def _flush_write_txn(tid: str, dbuf: swdb.Buffer, dbtr: swdb.WriteTransaction):
@@ -436,24 +436,18 @@ actor Session(name: str, rootnode: Node, lowerlayer: ?Layer, db: ?lmdb.Db, dbuf_
                 except Exception:
                     pass
                 commit(tid, False)
-                edit_config_finish(e, False)
+                edit_config_finish(e)
                 return
 
         if tid_state is not None:
-            tid = tid_state
-        else:
-            return
-        if db is not None:
-            if dbuf is not None:
-                dbtr = _begin_write(tid, db)
+            if db is not None and dbuf is not None:
+                dbtr = _begin_write(tid_state, db)
                 if dbtr is not None:
-                    _flush_write_txn(tid, dbuf, dbtr)
+                    _flush_write_txn(tid_state, dbuf, dbtr)
                 else:
                     return
-            else:
-                raise ValueError("Missing DB buffer for staged DB flush")
-        commit(tid, True)
-        edit_config_finish("Ok", True)
+            commit(tid_state, True)
+            edit_config_finish("Ok")
 
     # yield action
     def edit_config(diff, done: ?action(value)->None=None, complete: ?action(value)->None=None, force=False):
@@ -481,17 +475,17 @@ actor Session(name: str, rootnode: Node, lowerlayer: ?Layer, db: ?lmdb.Db, dbuf_
                 _flush_dbuffer_then_commit()
             else:
                 commit(tid_state, False)
-                edit_config_finish(res.errors[0], False)
+                edit_config_finish(res.errors[0])
 
-    def edit_config_finish(result: value, ok: bool):
+    def edit_config_finish(result: value):
         if tid_state is not None:
             if done_cont is not None:
                 done_cont(result)
             if comp_cont is not None:
-                if ok:
-                    wait_complete(comp_cont)
-                else:
+                if isinstance(result, Exception):
                     comp_cont(result)
+                else:
+                    wait_complete(comp_cont)
         done_cont = None
         comp_cont = None
         tid_state = None
@@ -547,14 +541,14 @@ actor Session(name: str, rootnode: Node, lowerlayer: ?Layer, db: ?lmdb.Db, dbuf_
         if lower is not None:
             lower.commit(tid, ok)
 
-    def wait_complete(done:action(CfgResult)->None):
+    def wait_complete(done:action(value)->None):
         #print('####', tid_state, '(Layer)', name, 'wait_complete', err=True)
         if tid_state is not None:
             if lower is not None:
                 lower.wait_complete(done)
             else:
-                root.wait_complete(tid_state, lambda r: done(CfgError(r) if isinstance(r, Exception) else CfgOk()))
-
+                root.wait_complete(tid_state, lambda res: done((res.errors[0] if res.errors else "Ok") if isinstance(res, CfgResult) else res))
+    
     def recompute(done: ?action(value)->None=None, complete: ?action(value)->None=None, force=False):
         tid = 'tr' + actorid()
         #print('####', tid, '(Layer)', name, 'recompute', actorid(), err=True)

--- a/src/test_ttt_container.act
+++ b/src/test_ttt_container.act
@@ -118,8 +118,7 @@ actor all_delete(t: testing.AsyncT):
         t1.configure("1", {"srcA": gdata.Absent()})
 
         def cont2(r):
-            if isinstance(r, ttt.CfgOk):
-                testing.assertEqual(r.empty, True)
+            testing.assertEqual(r.empty, True)
             t1.commit("1", True)
             out2 = t1.get()
             exp2 = gdata.Container({
@@ -170,8 +169,7 @@ actor nested_delete(t: testing.AsyncT):
         t1.configure("1", {"srcA": gdata.Absent()})
 
         def cont2(r):
-            if isinstance(r, ttt.CfgOk):
-                testing.assertEqual(r.empty, True)
+            testing.assertEqual(r.empty, True)
             t1.commit("1", True)
             out2 = t1.get()
             exp2 = gdata.Container({
@@ -373,11 +371,11 @@ actor config_failure(t: testing.AsyncT):
     await async t1.configure("1", {'srcA': a0}, None)
     await async t2.configure("2", {'srcB': a1}, None)
 
-    def cont1(_r: value):
+    def cont1(_r: ttt.CfgResult):
         t1.commit("1", True)
 
-        def cont2(_r: value):
-            if isinstance(_r, ttt.CfgError):
+        def cont2(_r: ttt.CfgResult):
+            if _r.errors:
                 t2.configure("2", {'srcB': b1}, None)
             t2.commit("2", True)
             r = t2.get()

--- a/src/test_ttt_persistence.act
+++ b/src/test_ttt_persistence.act
@@ -387,7 +387,7 @@ actor BusyWriterWaitFlow(t: testing.EnvT, fs: file.FS, db_path: str, db: lmdb.Db
         await async held_txn.abort()
 
     def after_commit(r: value) -> None:
-        if not isinstance(r, ttt.CfgOk):
+        if isinstance(r, Exception):
             raise AssertionError("Expected successful completion after waiting for busy DB writer, got {r}")
         testing.assertEqual(released, True)
         testing.assertEqual(layer.get(), persist_cfg)
@@ -436,7 +436,7 @@ actor dbuffer_refreshes_on_lock_reconfigure(t: testing.EnvT):
     t2buf: swdb.Buffer = swdb.Buffer()
 
     def is_cfg_ok(r: value) -> bool:
-        return isinstance(r, ttt.CfgOk)
+        return not isinstance(r, Exception)
 
     def after_t1_lock(r: value) -> None:
         if not is_cfg_ok(r):
@@ -525,7 +525,7 @@ actor persist_transform_state_snapshot(t: testing.EnvT):
         flow.after_settled()
 
     def after_initial_commit(r: value) -> None:
-        if not isinstance(r, ttt.CfgOk):
+        if isinstance(r, Exception):
             raise AssertionError("Expected successful initial stateful completion, got {r}")
         root1 = expect(root, "Missing captured stateful transform root")
         root1.newtrans().restore(swdb.ATTR_DYNSTATE, None, gdata.Leaf(41).to_json_str(pretty=False).encode())
@@ -609,7 +609,7 @@ actor reject_db_persist_failure_without_committing_memory(t: testing.EnvT):
     var layer = ttt.Layer("struct", struct_root, None, db)
 
     def after_recovery(r: value) -> None:
-        if not isinstance(r, ttt.CfgOk):
+        if isinstance(r, Exception):
             raise AssertionError("Expected successful recovery completion after DB persist failure, got {r}")
         testing.assertEqual(layer.get(), struct_tree)
         read_txn = db.begin_read()
@@ -643,7 +643,7 @@ actor restore_transform_memory_round_trip(t: testing.EnvT):
     var restored = ttt.Layer("memory", ttt.Transform(PersistMemoryTransform), None, db)
 
     def after_recommit(r: value) -> None:
-        if not isinstance(r, ttt.CfgOk):
+        if isinstance(r, Exception):
             raise AssertionError("Expected successful recommit completion after restore, got {r}")
         testing.assertEqual(restored.get(), memory_cfg_updated)
         await async db.close()
@@ -678,7 +678,7 @@ actor restore_transform_dynstate_round_trip(t: testing.EnvT):
         return expect(root, "Missing captured stateful transform root")
 
     def after_recommit(r: value) -> None:
-        if not isinstance(r, ttt.CfgOk):
+        if isinstance(r, Exception):
             raise AssertionError("Expected successful dynstate recommit completion after restore, got {r}")
         testing.assertEqual(restored.get(), stateful_cfg_updated)
         await async db.close()
@@ -697,7 +697,7 @@ actor restore_transform_dynstate_round_trip(t: testing.EnvT):
         restored.edit_config(stateful_cfg_updated, None, after_recommit)
 
     def after_initial_commit(r: value) -> None:
-        if not isinstance(r, ttt.CfgOk):
+        if isinstance(r, Exception):
             raise AssertionError("Expected successful initial dynstate completion, got {r}")
         root1 = expect(root, "Missing captured stateful transform root")
         root1.newtrans().restore(swdb.ATTR_DYNSTATE, None, gdata.Leaf(41).to_json_str(pretty=False).encode())
@@ -842,7 +842,7 @@ actor restore_exact_layer_name_prefix_round_trip(t: testing.EnvT):
         t.success()
 
     def after_foobar_commit(r: value) -> None:
-        if not isinstance(r, ttt.CfgOk):
+        if isinstance(r, Exception):
             raise AssertionError("Expected successful foobar completion, got {r}")
         await async db.close()
         db = lmdb.Db(cap, db_path)
@@ -855,7 +855,7 @@ actor restore_exact_layer_name_prefix_round_trip(t: testing.EnvT):
         cleanup_success()
 
     def after_foo_commit(r: value) -> None:
-        if not isinstance(r, ttt.CfgOk):
+        if isinstance(r, Exception):
             raise AssertionError("Expected successful foo completion, got {r}")
         foobar_layer.edit_config(foobar_cfg, None, after_foobar_commit)
 

--- a/src/test_ttt_persistence.act
+++ b/src/test_ttt_persistence.act
@@ -387,7 +387,7 @@ actor BusyWriterWaitFlow(t: testing.EnvT, fs: file.FS, db_path: str, db: lmdb.Db
         await async held_txn.abort()
 
     def after_commit(r: value) -> None:
-        if isinstance(r, Exception):
+        if not isinstance(r, str):
             raise AssertionError("Expected successful completion after waiting for busy DB writer, got {r}")
         testing.assertEqual(released, True)
         testing.assertEqual(layer.get(), persist_cfg)
@@ -435,10 +435,10 @@ actor dbuffer_refreshes_on_lock_reconfigure(t: testing.EnvT):
     t1buf: swdb.Buffer = swdb.Buffer()
     t2buf: swdb.Buffer = swdb.Buffer()
 
-    def is_cfg_ok(r: value) -> bool:
-        return not isinstance(r, Exception)
+    def is_cfg_ok(r: ttt.CfgResult) -> bool:
+        return not r.errors
 
-    def after_t1_lock(r: value) -> None:
+    def after_t1_lock(r: ttt.CfgResult) -> None:
         if not is_cfg_ok(r):
             raise AssertionError("Expected successful t1 lock after reconfigure, got {r}")
         write_txn = db.begin_write()
@@ -460,13 +460,13 @@ actor dbuffer_refreshes_on_lock_reconfigure(t: testing.EnvT):
         await async fs.rmdir(db_path)
         t.success()
 
-    def after_t2_lock(r: value) -> None:
+    def after_t2_lock(r: ttt.CfgResult) -> None:
         if not is_cfg_ok(r):
             raise AssertionError("Expected successful t2 lock, got {r}")
         tr.commit("2", True)
         tr.lock("1", None, after_t1_lock, t1buf)
 
-    def after_seed_lock(r: value) -> None:
+    def after_seed_lock(r: ttt.CfgResult) -> None:
         if not is_cfg_ok(r):
             raise AssertionError("Expected successful seed lock, got {r}")
         tr.commit("0", True)
@@ -525,7 +525,7 @@ actor persist_transform_state_snapshot(t: testing.EnvT):
         flow.after_settled()
 
     def after_initial_commit(r: value) -> None:
-        if isinstance(r, Exception):
+        if not isinstance(r, str):
             raise AssertionError("Expected successful initial stateful completion, got {r}")
         root1 = expect(root, "Missing captured stateful transform root")
         root1.newtrans().restore(swdb.ATTR_DYNSTATE, None, gdata.Leaf(41).to_json_str(pretty=False).encode())
@@ -609,7 +609,7 @@ actor reject_db_persist_failure_without_committing_memory(t: testing.EnvT):
     var layer = ttt.Layer("struct", struct_root, None, db)
 
     def after_recovery(r: value) -> None:
-        if isinstance(r, Exception):
+        if not isinstance(r, str):
             raise AssertionError("Expected successful recovery completion after DB persist failure, got {r}")
         testing.assertEqual(layer.get(), struct_tree)
         read_txn = db.begin_read()
@@ -643,7 +643,7 @@ actor restore_transform_memory_round_trip(t: testing.EnvT):
     var restored = ttt.Layer("memory", ttt.Transform(PersistMemoryTransform), None, db)
 
     def after_recommit(r: value) -> None:
-        if isinstance(r, Exception):
+        if not isinstance(r, str):
             raise AssertionError("Expected successful recommit completion after restore, got {r}")
         testing.assertEqual(restored.get(), memory_cfg_updated)
         await async db.close()
@@ -678,7 +678,7 @@ actor restore_transform_dynstate_round_trip(t: testing.EnvT):
         return expect(root, "Missing captured stateful transform root")
 
     def after_recommit(r: value) -> None:
-        if isinstance(r, Exception):
+        if not isinstance(r, str):
             raise AssertionError("Expected successful dynstate recommit completion after restore, got {r}")
         testing.assertEqual(restored.get(), stateful_cfg_updated)
         await async db.close()
@@ -697,7 +697,7 @@ actor restore_transform_dynstate_round_trip(t: testing.EnvT):
         restored.edit_config(stateful_cfg_updated, None, after_recommit)
 
     def after_initial_commit(r: value) -> None:
-        if isinstance(r, Exception):
+        if not isinstance(r, str):
             raise AssertionError("Expected successful initial dynstate completion, got {r}")
         root1 = expect(root, "Missing captured stateful transform root")
         root1.newtrans().restore(swdb.ATTR_DYNSTATE, None, gdata.Leaf(41).to_json_str(pretty=False).encode())
@@ -842,7 +842,7 @@ actor restore_exact_layer_name_prefix_round_trip(t: testing.EnvT):
         t.success()
 
     def after_foobar_commit(r: value) -> None:
-        if isinstance(r, Exception):
+        if not isinstance(r, str):
             raise AssertionError("Expected successful foobar completion, got {r}")
         await async db.close()
         db = lmdb.Db(cap, db_path)
@@ -855,7 +855,7 @@ actor restore_exact_layer_name_prefix_round_trip(t: testing.EnvT):
         cleanup_success()
 
     def after_foo_commit(r: value) -> None:
-        if isinstance(r, Exception):
+        if not isinstance(r, str):
             raise AssertionError("Expected successful foo completion, got {r}")
         foobar_layer.edit_config(foobar_cfg, None, after_foobar_commit)
 

--- a/src/test_ttt_transform.act
+++ b/src/test_ttt_transform.act
@@ -422,11 +422,11 @@ actor config_failure(t: testing.AsyncT):
     t1.configure("1", {'srcA': a0}, None)
     t2.configure("2", {'srcB': a1}, None)
 
-    def cont1(_r: value):
+    def cont1(_r: ttt.CfgResult):
         t1.commit("1", True)
 
-        def cont2(_r: value):
-            if isinstance(_r, ttt.CfgError):
+        def cont2(_r: ttt.CfgResult):
+            if _r.errors:
                 t2.configure("2", {'srcB': b1}, None)
             t2.commit("2", True)
             r = t2.get()


### PR DESCRIPTION
Internal reorganization: ttt now proceeds to the linkage phase even if configure has detected errors, so that transforms whose valididy depend on links are given a chance to rerun in the correct link context.