### PR TITLE
Typed subscription interface

### DIFF
--- a/Build.act
+++ b/Build.act
@@ -23,8 +23,8 @@ dependencies = {
     ),
     "yang": (
         repo_url="https://github.com/stratoweave/acton-yang.git",
-        url="https://github.com/stratoweave/acton-yang/archive/95ce4ae083a3920a98f6f984c91bd3d09f556231.zip",
-        hash="N-V-__8AADv1IgCnOSwFc0GTl0aUtxRAgC-Cs46To6-U5G-k"
+        url="https://github.com/stratoweave/acton-yang/archive/03f119b0ea5e0b5ec011c4ec5f40ded46e669d48.zip",
+        hash="N-V-__8AAPyoJADQo_3fWXRV1q1GP_RcEBE_jqaeXIwx4NDp"
     )
 }
 zig_dependencies = {}

--- a/docs/subscriptions.md
+++ b/docs/subscriptions.md
@@ -14,18 +14,150 @@ The callback receives one merged gdata tree for that owner.
 The public shape is intentionally small:
 
 ```acton
-subs = yang.gdata.SubscriptionManager(
+import yang.gdata as gdata
+import mini.devices.ietf_oper as ietf_oper
+
+subs = gdata.SubscriptionManager(
     dev.tree_provider(),
     "base-config",
     on_state,
 )
 
 want = set([
-    yang.gdata.SubscriptionSpec(_system_state_filter(), period=0.05)
+    ietf_oper.subs.system_state.clock.subscribe(depth=1, period=0.05)
 ])
 
 subs.declare(want)
 ```
+
+## Generated Subscription Helpers
+
+Generated operational device modules such as `mini.devices.ietf_oper`
+also expose a typed path API for building subscription filters. The
+generated `_oper` module combines the config-false operational adata
+tree with the `SubscriptionNode` helpers used for subscriptions.
+
+Start from the generated root:
+
+```acton
+import mini.devices.ietf_oper as ietf_oper
+
+sub = ietf_oper.subs
+```
+
+The generated module builds one shared filter path tree as the
+`subs` module constant, rather than constructing a fresh helper tree
+for each use.
+
+### Subscribe To A Whole Subtree
+
+Call `subscribe(...)` directly on a path to subscribe to everything
+below that node:
+
+```acton
+# /system-state/clock
+spec = sub.system_state.clock.subscribe(period=0.05)
+```
+
+### Subscribe To Direct Children Only
+
+Use `depth=1` when you want the direct children of a container or list
+entry, rather than the whole subtree:
+
+```acton
+# /system-state/clock/current-datetime
+# /system-state/clock/boot-datetime
+spec = sub.system_state.clock.subscribe(depth=1, period=0.05)
+```
+
+`depth` currently only supports `1`.
+
+### Subscribe To One Keyed List Entry
+
+Use `entry(...)` on generated list paths to add key predicates without
+writing `FNode` filters manually:
+
+```acton
+iface = sub.interfaces.interface.entry("eth0")
+
+# /interfaces/interface[name="eth0"]
+spec = iface.subscribe(period=1.0)
+```
+
+### Select Specific Children
+
+Use `select=[...]` to keep the list entry or container as the anchor,
+but only subscribe to specific descendants below it:
+
+```acton
+iface = sub.interfaces.interface.entry("eth0")
+
+spec = iface.subscribe(
+    select=[iface.statistics, iface.ipv4],
+    period=1.0,
+)
+```
+
+Every selected path must be below the anchor used for `subscribe(...)`.
+
+### Merge Overlapping Descendants
+
+Selected descendants from the same subtree are merged into one filter:
+
+```acton
+iface = sub.interfaces.interface.entry("eth0")
+
+spec = iface.subscribe(
+    select=[
+        iface.statistics.in_octets,
+        iface.statistics.out_octets,
+    ],
+    period=1.0,
+)
+```
+
+This produces one `statistics` branch with both leaves below it.
+
+### Inspect The Raw Filter
+
+Use `filt()` when you want the raw `FNode` without immediately wrapping
+it in a `SubscriptionSpec`:
+
+```acton
+clock_filt = sub.system_state.clock.filt()
+spec = gdata.SubscriptionSpec(clock_filt, period=0.05)
+```
+
+This is useful in tests and when integrating with older code that still
+constructs `SubscriptionSpec` directly.
+
+### Declare Multiple Filters For One Owner
+
+`SubscriptionManager` still works on a set of `SubscriptionSpec`
+objects, so you can mix several generated filters in one declaration:
+
+```acton
+iface = sub.interfaces.interface.entry("eth0")
+
+want = set([
+    sub.system_state.clock.subscribe(depth=1, period=0.05),
+    iface.subscribe(select=[iface.statistics, iface.ipv4], period=1.0),
+])
+
+subs.declare(want)
+```
+
+### On-Change Subscriptions
+
+Omitting `period` creates an on-change `SubscriptionSpec`:
+
+```acton
+spec = sub.system_state.clock.subscribe(depth=1)
+```
+
+The generated filter helper supports this directly. The current
+`NetconfDriver` limitation still applies, so on-change subscriptions are
+not yet accepted there.
 
 ## `SubscriptionSpec`
 

--- a/gen_adata/Build.act
+++ b/gen_adata/Build.act
@@ -3,8 +3,8 @@ fingerprint = 0x7d1c1e932a731ef0
 dependencies = {
     "yang": (
         repo_url="https://github.com/stratoweave/acton-yang.git",
-        url="https://github.com/stratoweave/acton-yang/archive/95ce4ae083a3920a98f6f984c91bd3d09f556231.zip",
-        hash="N-V-__8AADv1IgCnOSwFc0GTl0aUtxRAgC-Cs46To6-U5G-k"
+        url="https://github.com/stratoweave/acton-yang/archive/03f119b0ea5e0b5ec011c4ec5f40ded46e669d48.zip",
+        hash="N-V-__8AAPyoJADQo_3fWXRV1q1GP_RcEBE_jqaeXIwx4NDp"
     )
 }
 zig_dependencies = {}

--- a/minisys/Build.act
+++ b/minisys/Build.act
@@ -3,6 +3,11 @@ fingerprint = 0xf1e1a54ca50c7652
 dependencies = {
     "stratoweave": (
         path="../"
+    ),
+    "yang": (
+        repo_url="https://github.com/stratoweave/acton-yang.git",
+        url="https://github.com/stratoweave/acton-yang/archive/03f119b0ea5e0b5ec011c4ec5f40ded46e669d48.zip",
+        hash="N-V-__8AAPyoJADQo_3fWXRV1q1GP_RcEBE_jqaeXIwx4NDp"
     )
 }
 zig_dependencies = {}

--- a/minisys/gen/Build.act
+++ b/minisys/gen/Build.act
@@ -3,6 +3,11 @@ fingerprint = 0xce9cb6d95c842d39
 dependencies = {
     "stratoweave": (
         path="../../"
+    ),
+    "yang": (
+        repo_url="https://github.com/stratoweave/acton-yang.git",
+        url="https://github.com/stratoweave/acton-yang/archive/03f119b0ea5e0b5ec011c4ec5f40ded46e669d48.zip",
+        hash="N-V-__8AAPyoJADQo_3fWXRV1q1GP_RcEBE_jqaeXIwx4NDp"
     )
 }
 zig_dependencies = {}

--- a/minisys/src/mini/devices/ietf_oper.act
+++ b/minisys/src/mini/devices/ietf_oper.act
@@ -10,6 +10,7 @@ from yang.identityref import Identityref, PartialIdentityref
 from yang.pattern import YangPattern
 from yang.schema import *
 from yang.type import Decimal, Ranges
+from yang.sdata import SubscriptionPath, SubscriptionNode
 
 # == This file is generated ==
 
@@ -873,14 +874,20 @@ SRC_DNODE_CHILD_4 = DLeaf(module='ietf-netconf-acm', namespace='urn:ietf:params:
 
 SRC_DNODE_CHILD_5 = DLeaf(module='ietf-netconf-acm', namespace='urn:ietf:params:xml:ns:yang:ietf-netconf-acm', prefix='nacm', name='enable-external-groups', config=True, description="Controls whether the server uses the groups reported by the\nNETCONF transport layer when it assigns the user to a set of\nNACM groups.  If this leaf has the value 'false', any group\nnames reported by the transport layer are ignored by the\nserver.", default='true', mandatory=False, type_=DTypeBoolean(name='boolean', description=None, reference=None, exts=[], builtin_type='boolean', default=None))
 
-SRC_DNODE_CHILD_6 = DContainer(module='ietf-netconf-acm', namespace='urn:ietf:params:xml:ns:yang:ietf-netconf-acm', prefix='nacm', name='groups', config=True, description='NETCONF access control groups.', presence=False, children=[
+SRC_DNODE_CHILD_6 = DLeaf(module='ietf-netconf-acm', namespace='urn:ietf:params:xml:ns:yang:ietf-netconf-acm', prefix='nacm', name='denied-operations', config=False, description='Number of times since the server last restarted that a\nprotocol operation request was denied.', mandatory=True, type_=DTypeIntegerUnsigned(name='yang:zero-based-counter32', description="The zero-based-counter32 type represents a counter32\nthat has the defined 'initial' value zero.\n\nA schema node of this type will be set to zero (0) on creation\nand will thereafter increase monotonically until it reaches\na maximum value of 2^32-1 (4294967295 decimal), when it\nwraps around and starts increasing again from zero.\n\nProvided that an application discovers a new schema node\nof this type within the minimum time to wrap, it can use the\n'initial' value as a delta.  It is important for a management\nstation to be aware of this minimum time and the actual time\nbetween polls, and to discard data if the actual time is too\nlong or there is no defined minimum time.\n\nIn the value set and its semantics, this type is equivalent\nto the ZeroBasedCounter32 textual convention of the SMIv2.", reference='RFC 4502: Remote Network Monitoring Management Information\n          Base Version 2', exts=[], builtin_type='uint32', default='0', ranges=Ranges([(0, 4294967295)])))
+
+SRC_DNODE_CHILD_7 = DLeaf(module='ietf-netconf-acm', namespace='urn:ietf:params:xml:ns:yang:ietf-netconf-acm', prefix='nacm', name='denied-data-writes', config=False, description='Number of times since the server last restarted that a\nprotocol operation request to alter\na configuration datastore was denied.', mandatory=True, type_=DTypeIntegerUnsigned(name='yang:zero-based-counter32', description="The zero-based-counter32 type represents a counter32\nthat has the defined 'initial' value zero.\n\nA schema node of this type will be set to zero (0) on creation\nand will thereafter increase monotonically until it reaches\na maximum value of 2^32-1 (4294967295 decimal), when it\nwraps around and starts increasing again from zero.\n\nProvided that an application discovers a new schema node\nof this type within the minimum time to wrap, it can use the\n'initial' value as a delta.  It is important for a management\nstation to be aware of this minimum time and the actual time\nbetween polls, and to discard data if the actual time is too\nlong or there is no defined minimum time.\n\nIn the value set and its semantics, this type is equivalent\nto the ZeroBasedCounter32 textual convention of the SMIv2.", reference='RFC 4502: Remote Network Monitoring Management Information\n          Base Version 2', exts=[], builtin_type='uint32', default='0', ranges=Ranges([(0, 4294967295)])))
+
+SRC_DNODE_CHILD_8 = DLeaf(module='ietf-netconf-acm', namespace='urn:ietf:params:xml:ns:yang:ietf-netconf-acm', prefix='nacm', name='denied-notifications', config=False, description='Number of times since the server last restarted that\na notification was dropped for a subscription because\naccess to the event type was denied.', mandatory=True, type_=DTypeIntegerUnsigned(name='yang:zero-based-counter32', description="The zero-based-counter32 type represents a counter32\nthat has the defined 'initial' value zero.\n\nA schema node of this type will be set to zero (0) on creation\nand will thereafter increase monotonically until it reaches\na maximum value of 2^32-1 (4294967295 decimal), when it\nwraps around and starts increasing again from zero.\n\nProvided that an application discovers a new schema node\nof this type within the minimum time to wrap, it can use the\n'initial' value as a delta.  It is important for a management\nstation to be aware of this minimum time and the actual time\nbetween polls, and to discard data if the actual time is too\nlong or there is no defined minimum time.\n\nIn the value set and its semantics, this type is equivalent\nto the ZeroBasedCounter32 textual convention of the SMIv2.", reference='RFC 4502: Remote Network Monitoring Management Information\n          Base Version 2', exts=[], builtin_type='uint32', default='0', ranges=Ranges([(0, 4294967295)])))
+
+SRC_DNODE_CHILD_9 = DContainer(module='ietf-netconf-acm', namespace='urn:ietf:params:xml:ns:yang:ietf-netconf-acm', prefix='nacm', name='groups', config=True, description='NETCONF access control groups.', presence=False, children=[
     DList(module='ietf-netconf-acm', namespace='urn:ietf:params:xml:ns:yang:ietf-netconf-acm', prefix='nacm', name='group', key=['name'], config=True, description='One NACM group entry.  This list will only contain\nconfigured entries, not any entries learned from\nany transport protocols.', min_elements=0, ordered_by='system', children=[
         DLeaf(module='ietf-netconf-acm', namespace='urn:ietf:params:xml:ns:yang:ietf-netconf-acm', prefix='nacm', name='name', config=True, description='Group name associated with this entry.', mandatory=False, type_=DTypeString(name='group-name-type', description='Name of administrative group to which\nusers can be assigned.', reference=None, exts=[], builtin_type='string', default=None, length=Ranges([(1, 9223372036854775807)]), patterns=[YangPattern(yang_regex='[^\\*].*', pcre='^([^\\*].*)$', invert=False)])),
         DLeafList(module='ietf-netconf-acm', namespace='urn:ietf:params:xml:ns:yang:ietf-netconf-acm', prefix='nacm', name='user-name', config=True, description='Each entry identifies the username of\na member of the group associated with\nthis entry.', min_elements=0, ordered_by='system', type_=DTypeString(name='user-name-type', description='General-purpose username string.', reference=None, exts=[], builtin_type='string', default=None, length=Ranges([(1, 9223372036854775807)]), patterns=[]))
     ])
 ])
 
-SRC_DNODE_CHILD_7 = DList(module='ietf-netconf-acm', namespace='urn:ietf:params:xml:ns:yang:ietf-netconf-acm', prefix='nacm', name='rule-list', key=['name'], config=True, description='An ordered collection of access control rules.', min_elements=0, ordered_by='user', children=[
+SRC_DNODE_CHILD_10 = DList(module='ietf-netconf-acm', namespace='urn:ietf:params:xml:ns:yang:ietf-netconf-acm', prefix='nacm', name='rule-list', key=['name'], config=True, description='An ordered collection of access control rules.', min_elements=0, ordered_by='user', children=[
     DLeaf(module='ietf-netconf-acm', namespace='urn:ietf:params:xml:ns:yang:ietf-netconf-acm', prefix='nacm', name='name', config=True, description='Arbitrary name assigned to the rule-list.', mandatory=False, type_=DTypeString(name='string', description=None, reference=None, exts=[], builtin_type='string', default=None, length=Ranges([(1, 9223372036854775807)]), patterns=[])),
     DLeafList(module='ietf-netconf-acm', namespace='urn:ietf:params:xml:ns:yang:ietf-netconf-acm', prefix='nacm', name='group', config=True, description="List of administrative groups that will be\nassigned the associated access rights\ndefined by the 'rule' list.\n\nThe string '*' indicates that all groups apply to the\nentry.", min_elements=0, ordered_by='system', type_=DTypeUnion(name='union', description=None, reference=None, exts=[], builtin_type='union', default=None, types=[DTypeString(name='matchall-string-type', description="The string containing a single asterisk '*' is used\nto conceptually represent all possible values\nfor the particular leaf using this data type.", reference=None, exts=[], builtin_type='string', default=None, length=None, patterns=[YangPattern(yang_regex='\\*', pcre='^(\\*)$', invert=False)]), DTypeString(name='group-name-type', description='Name of administrative group to which\nusers can be assigned.', reference=None, exts=[], builtin_type='string', default=None, length=Ranges([(1, 9223372036854775807)]), patterns=[YangPattern(yang_regex='[^\\*].*', pcre='^([^\\*].*)$', invert=False)])])),
     DList(module='ietf-netconf-acm', namespace='urn:ietf:params:xml:ns:yang:ietf-netconf-acm', prefix='nacm', name='rule', key=['name'], config=True, description="One access control rule.\n\nRules are processed in user-defined order until a match is\nfound.  A rule matches if 'module-name', 'rule-type', and\n'access-operations' match the request.  If a rule\nmatches, the 'action' leaf determines whether or not\naccess is granted.", min_elements=0, ordered_by='user', children=[
@@ -897,20 +904,20 @@ SRC_DNODE_CHILD_7 = DList(module='ietf-netconf-acm', namespace='urn:ietf:params:
 
 SRC_DNODE_CHILD_0 = DContainer(module='ietf-netconf-acm', namespace='urn:ietf:params:xml:ns:yang:ietf-netconf-acm', prefix='nacm', name='nacm', config=True, description='Parameters for NETCONF access control model.', presence=False, exts=[
         DExt(module='ietf-netconf-acm', namespace='urn:ietf:params:xml:ns:yang:ietf-netconf-acm', prefix='nacm', name='default-deny-all', arg=None, exts=[])
-    ], children=[SRC_DNODE_CHILD_1, SRC_DNODE_CHILD_2, SRC_DNODE_CHILD_3, SRC_DNODE_CHILD_4, SRC_DNODE_CHILD_5, SRC_DNODE_CHILD_6, SRC_DNODE_CHILD_7])
+    ], children=[SRC_DNODE_CHILD_1, SRC_DNODE_CHILD_2, SRC_DNODE_CHILD_3, SRC_DNODE_CHILD_4, SRC_DNODE_CHILD_5, SRC_DNODE_CHILD_6, SRC_DNODE_CHILD_7, SRC_DNODE_CHILD_8, SRC_DNODE_CHILD_9, SRC_DNODE_CHILD_10])
 
-SRC_DNODE_CHILD_9 = DLeaf(module='ietf-system', namespace='urn:ietf:params:xml:ns:yang:ietf-system', prefix='sys', name='contact', config=True, description='The administrator contact information for the system.\n\nA server implementation MAY map this leaf to the sysContact\nMIB object.  Such an implementation needs to use some\nmechanism to handle the differences in size and characters\nallowed between this leaf and sysContact.  The definition of\nsuch a mechanism is outside the scope of this document.', mandatory=False, reference='RFC 3418: Management Information Base (MIB) for the\n          Simple Network Management Protocol (SNMP)\n          SNMPv2-MIB.sysContact', type_=DTypeString(name='string', description=None, reference=None, exts=[], builtin_type='string', default=None, length=None, patterns=[]))
+SRC_DNODE_CHILD_12 = DLeaf(module='ietf-system', namespace='urn:ietf:params:xml:ns:yang:ietf-system', prefix='sys', name='contact', config=True, description='The administrator contact information for the system.\n\nA server implementation MAY map this leaf to the sysContact\nMIB object.  Such an implementation needs to use some\nmechanism to handle the differences in size and characters\nallowed between this leaf and sysContact.  The definition of\nsuch a mechanism is outside the scope of this document.', mandatory=False, reference='RFC 3418: Management Information Base (MIB) for the\n          Simple Network Management Protocol (SNMP)\n          SNMPv2-MIB.sysContact', type_=DTypeString(name='string', description=None, reference=None, exts=[], builtin_type='string', default=None, length=None, patterns=[]))
 
-SRC_DNODE_CHILD_10 = DLeaf(module='ietf-system', namespace='urn:ietf:params:xml:ns:yang:ietf-system', prefix='sys', name='hostname', config=True, description='The name of the host.  This name can be a single domain\nlabel or the fully qualified domain name of the host.', mandatory=False, type_=DTypeString(name='inet:domain-name', description='The domain-name type represents a DNS domain name.  The\nname SHOULD be fully qualified whenever possible.\n\nInternet domain names are only loosely specified.  Section\n3.5 of RFC 1034 recommends a syntax (modified in Section\n2.1 of RFC 1123).  The pattern above is intended to allow\nfor current practice in domain name use, and some possible\nfuture expansion.  It is designed to hold various types of\ndomain names, including names used for A or AAAA records\n(host names) and other records, such as SRV records.  Note\nthat Internet host names have a stricter syntax (described\nin RFC 952) than the DNS recommendations in RFCs 1034 and\n1123, and that systems that want to store host names in\nschema nodes using the domain-name type are recommended to\nadhere to this stricter standard to ensure interoperability.\n\nThe encoding of DNS names in the DNS protocol is limited\nto 255 characters.  Since the encoding consists of labels\nprefixed by a length bytes and there is a trailing NULL\nbyte, only 253 characters can appear in the textual dotted\nnotation.\n\nThe description clause of schema nodes using the domain-name\ntype MUST describe when and how these names are resolved to\nIP addresses.  Note that the resolution of a domain-name value\nmay require to query multiple DNS records (e.g., A for IPv4\nand AAAA for IPv6).  The order of the resolution process and\nwhich DNS record takes precedence can either be defined\nexplicitly or may depend on the configuration of the\nresolver.\n\nDomain-name values use the US-ASCII encoding.  Their canonical\nformat uses lowercase US-ASCII characters.  Internationalized\ndomain names MUST be A-labels as per RFC 5890.', reference='RFC  952: DoD Internet Host Table Specification\nRFC 1034: Domain Names - Concepts and Facilities\nRFC 1123: Requirements for Internet Hosts -- Application\n          and Support\nRFC 2782: A DNS RR for specifying the location of services\n          (DNS SRV)\nRFC 5890: Internationalized Domain Names in Applications\n          (IDNA): Definitions and Document Framework', exts=[], builtin_type='string', default=None, length=Ranges([(1, 253)]), patterns=[YangPattern(yang_regex='((([a-zA-Z0-9_]([a-zA-Z0-9\\-_]){{0,61}})?[a-zA-Z0-9]\\.)*([a-zA-Z0-9_]([a-zA-Z0-9\\-_]){{0,61}})?[a-zA-Z0-9]\\.?)|\\.', pcre='^(((([a-zA-Z0-9_]([a-zA-Z0-9\\-_]){{0,61}})?[a-zA-Z0-9]\\.)*([a-zA-Z0-9_]([a-zA-Z0-9\\-_]){{0,61}})?[a-zA-Z0-9]\\.?)|\\.)$', invert=False)]))
+SRC_DNODE_CHILD_13 = DLeaf(module='ietf-system', namespace='urn:ietf:params:xml:ns:yang:ietf-system', prefix='sys', name='hostname', config=True, description='The name of the host.  This name can be a single domain\nlabel or the fully qualified domain name of the host.', mandatory=False, type_=DTypeString(name='inet:domain-name', description='The domain-name type represents a DNS domain name.  The\nname SHOULD be fully qualified whenever possible.\n\nInternet domain names are only loosely specified.  Section\n3.5 of RFC 1034 recommends a syntax (modified in Section\n2.1 of RFC 1123).  The pattern above is intended to allow\nfor current practice in domain name use, and some possible\nfuture expansion.  It is designed to hold various types of\ndomain names, including names used for A or AAAA records\n(host names) and other records, such as SRV records.  Note\nthat Internet host names have a stricter syntax (described\nin RFC 952) than the DNS recommendations in RFCs 1034 and\n1123, and that systems that want to store host names in\nschema nodes using the domain-name type are recommended to\nadhere to this stricter standard to ensure interoperability.\n\nThe encoding of DNS names in the DNS protocol is limited\nto 255 characters.  Since the encoding consists of labels\nprefixed by a length bytes and there is a trailing NULL\nbyte, only 253 characters can appear in the textual dotted\nnotation.\n\nThe description clause of schema nodes using the domain-name\ntype MUST describe when and how these names are resolved to\nIP addresses.  Note that the resolution of a domain-name value\nmay require to query multiple DNS records (e.g., A for IPv4\nand AAAA for IPv6).  The order of the resolution process and\nwhich DNS record takes precedence can either be defined\nexplicitly or may depend on the configuration of the\nresolver.\n\nDomain-name values use the US-ASCII encoding.  Their canonical\nformat uses lowercase US-ASCII characters.  Internationalized\ndomain names MUST be A-labels as per RFC 5890.', reference='RFC  952: DoD Internet Host Table Specification\nRFC 1034: Domain Names - Concepts and Facilities\nRFC 1123: Requirements for Internet Hosts -- Application\n          and Support\nRFC 2782: A DNS RR for specifying the location of services\n          (DNS SRV)\nRFC 5890: Internationalized Domain Names in Applications\n          (IDNA): Definitions and Document Framework', exts=[], builtin_type='string', default=None, length=Ranges([(1, 253)]), patterns=[YangPattern(yang_regex='((([a-zA-Z0-9_]([a-zA-Z0-9\\-_]){{0,61}})?[a-zA-Z0-9]\\.)*([a-zA-Z0-9_]([a-zA-Z0-9\\-_]){{0,61}})?[a-zA-Z0-9]\\.?)|\\.', pcre='^(((([a-zA-Z0-9_]([a-zA-Z0-9\\-_]){{0,61}})?[a-zA-Z0-9]\\.)*([a-zA-Z0-9_]([a-zA-Z0-9\\-_]){{0,61}})?[a-zA-Z0-9]\\.?)|\\.)$', invert=False)]))
 
-SRC_DNODE_CHILD_11 = DLeaf(module='ietf-system', namespace='urn:ietf:params:xml:ns:yang:ietf-system', prefix='sys', name='location', config=True, description='The system location.\n\nA server implementation MAY map this leaf to the sysLocation\nMIB object.  Such an implementation needs to use some\nmechanism to handle the differences in size and characters\nallowed between this leaf and sysLocation.  The definition\nof such a mechanism is outside the scope of this document.', mandatory=False, reference='RFC 3418: Management Information Base (MIB) for the\n          Simple Network Management Protocol (SNMP)\n          SNMPv2-MIB.sysLocation', type_=DTypeString(name='string', description=None, reference=None, exts=[], builtin_type='string', default=None, length=None, patterns=[]))
+SRC_DNODE_CHILD_14 = DLeaf(module='ietf-system', namespace='urn:ietf:params:xml:ns:yang:ietf-system', prefix='sys', name='location', config=True, description='The system location.\n\nA server implementation MAY map this leaf to the sysLocation\nMIB object.  Such an implementation needs to use some\nmechanism to handle the differences in size and characters\nallowed between this leaf and sysLocation.  The definition\nof such a mechanism is outside the scope of this document.', mandatory=False, reference='RFC 3418: Management Information Base (MIB) for the\n          Simple Network Management Protocol (SNMP)\n          SNMPv2-MIB.sysLocation', type_=DTypeString(name='string', description=None, reference=None, exts=[], builtin_type='string', default=None, length=None, patterns=[]))
 
-SRC_DNODE_CHILD_12 = DContainer(module='ietf-system', namespace='urn:ietf:params:xml:ns:yang:ietf-system', prefix='sys', name='clock', config=True, description='Configuration of the system date and time properties.', presence=False, children=[
+SRC_DNODE_CHILD_15 = DContainer(module='ietf-system', namespace='urn:ietf:params:xml:ns:yang:ietf-system', prefix='sys', name='clock', config=True, description='Configuration of the system date and time properties.', presence=False, children=[
     DLeaf(module='ietf-system', namespace='urn:ietf:params:xml:ns:yang:ietf-system', prefix='sys', name='timezone-name', config=True, description="The TZ database name to use for the system, such\nas 'Europe/Stockholm'.", mandatory=False, type_=DTypeString(name='timezone-name', description="A time zone name as used by the Time Zone Database,\nsometimes referred to as the 'Olson Database'.\n\nThe exact set of valid values is an implementation-specific\nmatter.  Client discovery of the exact set of time zone names\nfor a particular server is out of scope.", reference='RFC 6557: Procedures for Maintaining the Time Zone Database', exts=[], builtin_type='string', default=None, length=None, patterns=[])),
     DLeaf(module='ietf-system', namespace='urn:ietf:params:xml:ns:yang:ietf-system', prefix='sys', name='timezone-utc-offset', config=True, description="The number of minutes to add to UTC time to\nidentify the time zone for this system.  For example,\n'UTC - 8:00 hours' would be represented as '-480'.\nNote that automatic daylight saving time adjustment\nis not provided if this object is used.", mandatory=False, type_=DTypeIntegerSigned(name='int16', description=None, reference=None, exts=[], builtin_type='int16', default=None, ranges=Ranges([(-1500, 1500)])), units='minutes')
 ])
 
-SRC_DNODE_CHILD_13 = DContainer(module='ietf-system', namespace='urn:ietf:params:xml:ns:yang:ietf-system', prefix='sys', name='ntp', config=True, description='Configuration of the NTP client.', if_feature=['ntp'], presence=True, children=[
+SRC_DNODE_CHILD_16 = DContainer(module='ietf-system', namespace='urn:ietf:params:xml:ns:yang:ietf-system', prefix='sys', name='ntp', config=True, description='Configuration of the NTP client.', if_feature=['ntp'], presence=True, children=[
     DLeaf(module='ietf-system', namespace='urn:ietf:params:xml:ns:yang:ietf-system', prefix='sys', name='enabled', config=True, description="Indicates that the system should attempt to\nsynchronize the system clock with an NTP server\nfrom the 'ntp/server' list.", default='true', mandatory=False, type_=DTypeBoolean(name='boolean', description=None, reference=None, exts=[], builtin_type='boolean', default=None)),
     DList(module='ietf-system', namespace='urn:ietf:params:xml:ns:yang:ietf-system', prefix='sys', name='server', key=['name'], config=True, description="List of NTP servers to use for system clock\nsynchronization.  If '/system/ntp/enabled'\nis 'true', then the system will attempt to\ncontact and utilize the specified NTP servers.", min_elements=0, ordered_by='system', children=[
         DLeaf(module='ietf-system', namespace='urn:ietf:params:xml:ns:yang:ietf-system', prefix='sys', name='name', config=True, description='An arbitrary name for the NTP server.', mandatory=False, type_=DTypeString(name='string', description=None, reference=None, exts=[], builtin_type='string', default=None, length=None, patterns=[])),
@@ -924,7 +931,7 @@ SRC_DNODE_CHILD_13 = DContainer(module='ietf-system', namespace='urn:ietf:params
     ])
 ])
 
-SRC_DNODE_CHILD_14 = DContainer(module='ietf-system', namespace='urn:ietf:params:xml:ns:yang:ietf-system', prefix='sys', name='dns-resolver', config=True, description='Configuration of the DNS resolver.', presence=False, children=[
+SRC_DNODE_CHILD_17 = DContainer(module='ietf-system', namespace='urn:ietf:params:xml:ns:yang:ietf-system', prefix='sys', name='dns-resolver', config=True, description='Configuration of the DNS resolver.', presence=False, children=[
     DLeafList(module='ietf-system', namespace='urn:ietf:params:xml:ns:yang:ietf-system', prefix='sys', name='search', config=True, description='An ordered list of domains to search when resolving\na host name.', min_elements=0, ordered_by='user', type_=DTypeString(name='inet:domain-name', description='The domain-name type represents a DNS domain name.  The\nname SHOULD be fully qualified whenever possible.\n\nInternet domain names are only loosely specified.  Section\n3.5 of RFC 1034 recommends a syntax (modified in Section\n2.1 of RFC 1123).  The pattern above is intended to allow\nfor current practice in domain name use, and some possible\nfuture expansion.  It is designed to hold various types of\ndomain names, including names used for A or AAAA records\n(host names) and other records, such as SRV records.  Note\nthat Internet host names have a stricter syntax (described\nin RFC 952) than the DNS recommendations in RFCs 1034 and\n1123, and that systems that want to store host names in\nschema nodes using the domain-name type are recommended to\nadhere to this stricter standard to ensure interoperability.\n\nThe encoding of DNS names in the DNS protocol is limited\nto 255 characters.  Since the encoding consists of labels\nprefixed by a length bytes and there is a trailing NULL\nbyte, only 253 characters can appear in the textual dotted\nnotation.\n\nThe description clause of schema nodes using the domain-name\ntype MUST describe when and how these names are resolved to\nIP addresses.  Note that the resolution of a domain-name value\nmay require to query multiple DNS records (e.g., A for IPv4\nand AAAA for IPv6).  The order of the resolution process and\nwhich DNS record takes precedence can either be defined\nexplicitly or may depend on the configuration of the\nresolver.\n\nDomain-name values use the US-ASCII encoding.  Their canonical\nformat uses lowercase US-ASCII characters.  Internationalized\ndomain names MUST be A-labels as per RFC 5890.', reference='RFC  952: DoD Internet Host Table Specification\nRFC 1034: Domain Names - Concepts and Facilities\nRFC 1123: Requirements for Internet Hosts -- Application\n          and Support\nRFC 2782: A DNS RR for specifying the location of services\n          (DNS SRV)\nRFC 5890: Internationalized Domain Names in Applications\n          (IDNA): Definitions and Document Framework', exts=[], builtin_type='string', default=None, length=Ranges([(1, 253)]), patterns=[YangPattern(yang_regex='((([a-zA-Z0-9_]([a-zA-Z0-9\\-_]){{0,61}})?[a-zA-Z0-9]\\.)*([a-zA-Z0-9_]([a-zA-Z0-9\\-_]){{0,61}})?[a-zA-Z0-9]\\.?)|\\.', pcre='^(((([a-zA-Z0-9_]([a-zA-Z0-9\\-_]){{0,61}})?[a-zA-Z0-9]\\.)*([a-zA-Z0-9_]([a-zA-Z0-9\\-_]){{0,61}})?[a-zA-Z0-9]\\.?)|\\.)$', invert=False)])),
     DList(module='ietf-system', namespace='urn:ietf:params:xml:ns:yang:ietf-system', prefix='sys', name='server', key=['name'], config=True, description="List of the DNS servers that the resolver should query.\n\nWhen the resolver is invoked by a calling application, it\nsends the query to the first name server in this list.  If\nno response has been received within 'timeout' seconds,\nthe resolver continues with the next server in the list.\nIf no response is received from any server, the resolver\ncontinues with the first server again.  When the resolver\nhas traversed the list 'attempts' times without receiving\nany response, it gives up and returns an error to the\ncalling application.\n\nImplementations MAY limit the number of entries in this\nlist.", min_elements=0, ordered_by='user', children=[
         DLeaf(module='ietf-system', namespace='urn:ietf:params:xml:ns:yang:ietf-system', prefix='sys', name='name', config=True, description='An arbitrary name for the DNS server.', mandatory=False, type_=DTypeString(name='string', description=None, reference=None, exts=[], builtin_type='string', default=None, length=None, patterns=[])),
@@ -939,7 +946,7 @@ SRC_DNODE_CHILD_14 = DContainer(module='ietf-system', namespace='urn:ietf:params
     ])
 ])
 
-SRC_DNODE_CHILD_15 = DContainer(module='ietf-system', namespace='urn:ietf:params:xml:ns:yang:ietf-system', prefix='sys', name='radius', config=True, description='Configuration of the RADIUS client.', if_feature=['radius'], presence=False, children=[
+SRC_DNODE_CHILD_18 = DContainer(module='ietf-system', namespace='urn:ietf:params:xml:ns:yang:ietf-system', prefix='sys', name='radius', config=True, description='Configuration of the RADIUS client.', if_feature=['radius'], presence=False, children=[
     DList(module='ietf-system', namespace='urn:ietf:params:xml:ns:yang:ietf-system', prefix='sys', name='server', key=['name'], config=True, description="List of RADIUS servers used by the device.\n\nWhen the RADIUS client is invoked by a calling\napplication, it sends the query to the first server in\nthis list.  If no response has been received within\n'timeout' seconds, the client continues with the next\nserver in the list.  If no response is received from any\nserver, the client continues with the first server again.\nWhen the client has traversed the list 'attempts' times\nwithout receiving any response, it gives up and returns an\nerror to the calling application.", min_elements=0, ordered_by='user', children=[
         DLeaf(module='ietf-system', namespace='urn:ietf:params:xml:ns:yang:ietf-system', prefix='sys', name='name', config=True, description='An arbitrary name for the RADIUS server.', mandatory=False, type_=DTypeString(name='string', description=None, reference=None, exts=[], builtin_type='string', default=None, length=None, patterns=[])),
         DContainer(module='ietf-system', namespace='urn:ietf:params:xml:ns:yang:ietf-system', prefix='sys', name='udp', config=True, description='Contains UDP-specific configuration parameters\nfor RADIUS.', presence=False, children=[
@@ -957,7 +964,7 @@ SRC_DNODE_CHILD_15 = DContainer(module='ietf-system', namespace='urn:ietf:params
     ])
 ])
 
-SRC_DNODE_CHILD_16 = DContainer(module='ietf-system', namespace='urn:ietf:params:xml:ns:yang:ietf-system', prefix='sys', name='authentication', config=True, description='The authentication configuration subtree.', if_feature=['authentication'], presence=False, exts=[
+SRC_DNODE_CHILD_19 = DContainer(module='ietf-system', namespace='urn:ietf:params:xml:ns:yang:ietf-system', prefix='sys', name='authentication', config=True, description='The authentication configuration subtree.', if_feature=['authentication'], presence=False, exts=[
         DExt(module='ietf-netconf-acm', namespace='urn:ietf:params:xml:ns:yang:ietf-netconf-acm', prefix='nacm', name='default-deny-write', arg=None, exts=[])
     ], children=[
     DLeafList(module='ietf-system', namespace='urn:ietf:params:xml:ns:yang:ietf-system', prefix='sys', name='user-authentication-order', config=True, description="When the device authenticates a user with a password,\nit tries the authentication methods in this leaf-list in\norder.  If authentication with one method fails, the next\nmethod is used.  If no method succeeds, the user is\ndenied access.\n\nAn empty user-authentication-order leaf-list still allows\nauthentication of users using mechanisms that do not\ninvolve a password.\n\nIf the 'radius-authentication' feature is advertised by\nthe NETCONF server, the 'radius' identity can be added to\nthis list.\n\nIf the 'local-users' feature is advertised by the\nNETCONF server, the 'local-users' identity can be\nadded to this list.", min_elements=0, must=[
@@ -974,19 +981,65 @@ DMust(condition='(. != "sys:radius" or ../../radius/server)', description="When 
     ])
 ])
 
-SRC_DNODE_CHILD_8 = DContainer(module='ietf-system', namespace='urn:ietf:params:xml:ns:yang:ietf-system', prefix='sys', name='system', config=True, description='System group configuration.', presence=False, children=[SRC_DNODE_CHILD_9, SRC_DNODE_CHILD_10, SRC_DNODE_CHILD_11, SRC_DNODE_CHILD_12, SRC_DNODE_CHILD_13, SRC_DNODE_CHILD_14, SRC_DNODE_CHILD_15, SRC_DNODE_CHILD_16])
+SRC_DNODE_CHILD_11 = DContainer(module='ietf-system', namespace='urn:ietf:params:xml:ns:yang:ietf-system', prefix='sys', name='system', config=True, description='System group configuration.', presence=False, children=[SRC_DNODE_CHILD_12, SRC_DNODE_CHILD_13, SRC_DNODE_CHILD_14, SRC_DNODE_CHILD_15, SRC_DNODE_CHILD_16, SRC_DNODE_CHILD_17, SRC_DNODE_CHILD_18, SRC_DNODE_CHILD_19])
 
-SRC_DNODE_CHILD_19 = DLeaf(module='ietf-interfaces', namespace='urn:ietf:params:xml:ns:yang:ietf-interfaces', prefix='if', name='name', config=True, description="The name of the interface.\n\nA device MAY restrict the allowed values for this leaf,\npossibly depending on the type of the interface.\nFor system-controlled interfaces, this leaf is the\ndevice-specific name of the interface.\n\nIf a client tries to create configuration for a\nsystem-controlled interface that is not present in the\noperational state, the server MAY reject the request if\nthe implementation does not support pre-provisioning of\ninterfaces or if the name refers to an interface that can\nnever exist in the system.  A Network Configuration\nProtocol (NETCONF) server MUST reply with an rpc-error\nwith the error-tag 'invalid-value' in this case.\n\nIf the device supports pre-provisioning of interface\nconfiguration, the 'pre-provisioning' feature is\nadvertised.\n\nIf the device allows arbitrarily named user-controlled\ninterfaces, the 'arbitrary-names' feature is advertised.\n\nWhen a configured user-controlled interface is created by\nthe system, it is instantiated with the same name in the\noperational state.\n\nA server implementation MAY map this leaf to the ifName\nMIB object.  Such an implementation needs to use some\nmechanism to handle the differences in size and characters\nallowed between this leaf and ifName.  The definition of\nsuch a mechanism is outside the scope of this document.", mandatory=False, reference='RFC 2863: The Interfaces Group MIB - ifName', type_=DTypeString(name='string', description=None, reference=None, exts=[], builtin_type='string', default=None, length=None, patterns=[]))
+SRC_DNODE_CHILD_20 = DContainer(module='ietf-system', namespace='urn:ietf:params:xml:ns:yang:ietf-system', prefix='sys', name='system-state', config=False, description='System group operational state.', presence=False, children=[
+    DContainer(module='ietf-system', namespace='urn:ietf:params:xml:ns:yang:ietf-system', prefix='sys', name='platform', config=False, description='Contains vendor-specific information for\nidentifying the system platform and operating system.', presence=False, reference='IEEE Std 1003.1-2008 - sys/utsname.h', children=[
+        DLeaf(module='ietf-system', namespace='urn:ietf:params:xml:ns:yang:ietf-system', prefix='sys', name='os-name', config=False, description="The name of the operating system in use -\nfor example, 'Linux'.", mandatory=False, reference='IEEE Std 1003.1-2008 - utsname.sysname', type_=DTypeString(name='string', description=None, reference=None, exts=[], builtin_type='string', default=None, length=None, patterns=[])),
+        DLeaf(module='ietf-system', namespace='urn:ietf:params:xml:ns:yang:ietf-system', prefix='sys', name='os-release', config=False, description='The current release level of the operating\nsystem in use.  This string MAY indicate\nthe OS source code revision.', mandatory=False, reference='IEEE Std 1003.1-2008 - utsname.release', type_=DTypeString(name='string', description=None, reference=None, exts=[], builtin_type='string', default=None, length=None, patterns=[])),
+        DLeaf(module='ietf-system', namespace='urn:ietf:params:xml:ns:yang:ietf-system', prefix='sys', name='os-version', config=False, description='The current version level of the operating\nsystem in use.  This string MAY indicate\nthe specific OS build date and target variant\ninformation.', mandatory=False, reference='IEEE Std 1003.1-2008 - utsname.version', type_=DTypeString(name='string', description=None, reference=None, exts=[], builtin_type='string', default=None, length=None, patterns=[])),
+        DLeaf(module='ietf-system', namespace='urn:ietf:params:xml:ns:yang:ietf-system', prefix='sys', name='machine', config=False, description='A vendor-specific identifier string representing\nthe hardware in use.', mandatory=False, reference='IEEE Std 1003.1-2008 - utsname.machine', type_=DTypeString(name='string', description=None, reference=None, exts=[], builtin_type='string', default=None, length=None, patterns=[]))
+    ]),
+    DContainer(module='ietf-system', namespace='urn:ietf:params:xml:ns:yang:ietf-system', prefix='sys', name='clock', config=False, description='Monitoring of the system date and time properties.', presence=False, children=[
+        DLeaf(module='ietf-system', namespace='urn:ietf:params:xml:ns:yang:ietf-system', prefix='sys', name='current-datetime', config=False, description='The current system date and time.', mandatory=False, type_=DTypeString(name='yang:date-and-time', description="The date-and-time type is a profile of the ISO 8601\nstandard for representation of dates and times using the\nGregorian calendar.  The profile is defined by the\ndate-time production in Section 5.6 of RFC 3339.\n\nThe date-and-time type is compatible with the dateTime XML\nschema type with the following notable exceptions:\n\n(a) The date-and-time type does not allow negative years.\n\n(b) The date-and-time time-offset -00:00 indicates an unknown\n    time zone (see RFC 3339) while -00:00 and +00:00 and Z\n    all represent the same time zone in dateTime.\n\n(c) The canonical format (see below) of data-and-time values\n    differs from the canonical format used by the dateTime XML\n    schema type, which requires all times to be in UTC using\n    the time-offset 'Z'.\n\nThis type is not equivalent to the DateAndTime textual\nconvention of the SMIv2 since RFC 3339 uses a different\nseparator between full-date and full-time and provides\nhigher resolution of time-secfrac.\n\nThe canonical format for date-and-time values with a known time\nzone uses a numeric time zone offset that is calculated using\nthe device's configured known offset to UTC time.  A change of\nthe device's offset to UTC time will cause date-and-time values\nto change accordingly.  Such changes might happen periodically\nin case a server follows automatically daylight saving time\n(DST) time zone offset changes.  The canonical format for\ndate-and-time values with an unknown time zone (usually\nreferring to the notion of local time) uses the time-offset\n-00:00.", reference='RFC 3339: Date and Time on the Internet: Timestamps\nRFC 2579: Textual Conventions for SMIv2\nXSD-TYPES: XML Schema Part 2: Datatypes Second Edition', exts=[], builtin_type='string', default=None, length=None, patterns=[YangPattern(yang_regex='\\d{{4}}-\\d{{2}}-\\d{{2}}T\\d{{2}}:\\d{{2}}:\\d{{2}}(\\.\\d+)?(Z|[\\+\\-]\\d{{2}}:\\d{{2}})', pcre='^(\\p{{Nd}}{{4}}-\\p{{Nd}}{{2}}-\\p{{Nd}}{{2}}T\\p{{Nd}}{{2}}:\\p{{Nd}}{{2}}:\\p{{Nd}}{{2}}(\\.\\p{{Nd}}+)?(Z|[\\+\\-]\\p{{Nd}}{{2}}:\\p{{Nd}}{{2}}))$', invert=False)])),
+        DLeaf(module='ietf-system', namespace='urn:ietf:params:xml:ns:yang:ietf-system', prefix='sys', name='boot-datetime', config=False, description='The system date and time when the system last restarted.', mandatory=False, type_=DTypeString(name='yang:date-and-time', description="The date-and-time type is a profile of the ISO 8601\nstandard for representation of dates and times using the\nGregorian calendar.  The profile is defined by the\ndate-time production in Section 5.6 of RFC 3339.\n\nThe date-and-time type is compatible with the dateTime XML\nschema type with the following notable exceptions:\n\n(a) The date-and-time type does not allow negative years.\n\n(b) The date-and-time time-offset -00:00 indicates an unknown\n    time zone (see RFC 3339) while -00:00 and +00:00 and Z\n    all represent the same time zone in dateTime.\n\n(c) The canonical format (see below) of data-and-time values\n    differs from the canonical format used by the dateTime XML\n    schema type, which requires all times to be in UTC using\n    the time-offset 'Z'.\n\nThis type is not equivalent to the DateAndTime textual\nconvention of the SMIv2 since RFC 3339 uses a different\nseparator between full-date and full-time and provides\nhigher resolution of time-secfrac.\n\nThe canonical format for date-and-time values with a known time\nzone uses a numeric time zone offset that is calculated using\nthe device's configured known offset to UTC time.  A change of\nthe device's offset to UTC time will cause date-and-time values\nto change accordingly.  Such changes might happen periodically\nin case a server follows automatically daylight saving time\n(DST) time zone offset changes.  The canonical format for\ndate-and-time values with an unknown time zone (usually\nreferring to the notion of local time) uses the time-offset\n-00:00.", reference='RFC 3339: Date and Time on the Internet: Timestamps\nRFC 2579: Textual Conventions for SMIv2\nXSD-TYPES: XML Schema Part 2: Datatypes Second Edition', exts=[], builtin_type='string', default=None, length=None, patterns=[YangPattern(yang_regex='\\d{{4}}-\\d{{2}}-\\d{{2}}T\\d{{2}}:\\d{{2}}:\\d{{2}}(\\.\\d+)?(Z|[\\+\\-]\\d{{2}}:\\d{{2}})', pcre='^(\\p{{Nd}}{{4}}-\\p{{Nd}}{{2}}-\\p{{Nd}}{{2}}T\\p{{Nd}}{{2}}:\\p{{Nd}}{{2}}:\\p{{Nd}}{{2}}(\\.\\p{{Nd}}+)?(Z|[\\+\\-]\\p{{Nd}}{{2}}:\\p{{Nd}}{{2}}))$', invert=False)]))
+    ])
+])
 
-SRC_DNODE_CHILD_20 = DLeaf(module='ietf-interfaces', namespace='urn:ietf:params:xml:ns:yang:ietf-interfaces', prefix='if', name='description', config=True, description="A textual description of the interface.\n\nA server implementation MAY map this leaf to the ifAlias\nMIB object.  Such an implementation needs to use some\nmechanism to handle the differences in size and characters\nallowed between this leaf and ifAlias.  The definition of\nsuch a mechanism is outside the scope of this document.\n\nSince ifAlias is defined to be stored in non-volatile\nstorage, the MIB implementation MUST map ifAlias to the\nvalue of 'description' in the persistently stored\nconfiguration.", mandatory=False, reference='RFC 2863: The Interfaces Group MIB - ifAlias', type_=DTypeString(name='string', description=None, reference=None, exts=[], builtin_type='string', default=None, length=None, patterns=[]))
+SRC_DNODE_CHILD_23 = DLeaf(module='ietf-interfaces', namespace='urn:ietf:params:xml:ns:yang:ietf-interfaces', prefix='if', name='name', config=True, description="The name of the interface.\n\nA device MAY restrict the allowed values for this leaf,\npossibly depending on the type of the interface.\nFor system-controlled interfaces, this leaf is the\ndevice-specific name of the interface.\n\nIf a client tries to create configuration for a\nsystem-controlled interface that is not present in the\noperational state, the server MAY reject the request if\nthe implementation does not support pre-provisioning of\ninterfaces or if the name refers to an interface that can\nnever exist in the system.  A Network Configuration\nProtocol (NETCONF) server MUST reply with an rpc-error\nwith the error-tag 'invalid-value' in this case.\n\nIf the device supports pre-provisioning of interface\nconfiguration, the 'pre-provisioning' feature is\nadvertised.\n\nIf the device allows arbitrarily named user-controlled\ninterfaces, the 'arbitrary-names' feature is advertised.\n\nWhen a configured user-controlled interface is created by\nthe system, it is instantiated with the same name in the\noperational state.\n\nA server implementation MAY map this leaf to the ifName\nMIB object.  Such an implementation needs to use some\nmechanism to handle the differences in size and characters\nallowed between this leaf and ifName.  The definition of\nsuch a mechanism is outside the scope of this document.", mandatory=False, reference='RFC 2863: The Interfaces Group MIB - ifName', type_=DTypeString(name='string', description=None, reference=None, exts=[], builtin_type='string', default=None, length=None, patterns=[]))
 
-SRC_DNODE_CHILD_21 = DLeaf(module='ietf-interfaces', namespace='urn:ietf:params:xml:ns:yang:ietf-interfaces', prefix='if', name='type', config=True, description="The type of the interface.\n\nWhen an interface entry is created, a server MAY\ninitialize the type leaf with a valid value, e.g., if it\nis possible to derive the type from the name of the\ninterface.\n\nIf a client tries to set the type of an interface to a\nvalue that can never be used by the system, e.g., if the\ntype is not supported or if the type does not match the\nname of the interface, the server MUST reject the request.\nA NETCONF server MUST reply with an rpc-error with the\nerror-tag 'invalid-value' in this case.", mandatory=True, reference='RFC 2863: The Interfaces Group MIB - ifType', type_=DTypeIdentityref(name='identityref', description=None, reference=None, exts=[], builtin_type='identityref', default=None, identity_bases=[_base_ietf_interfaces_interface_type], identities=_identities))
+SRC_DNODE_CHILD_24 = DLeaf(module='ietf-interfaces', namespace='urn:ietf:params:xml:ns:yang:ietf-interfaces', prefix='if', name='description', config=True, description="A textual description of the interface.\n\nA server implementation MAY map this leaf to the ifAlias\nMIB object.  Such an implementation needs to use some\nmechanism to handle the differences in size and characters\nallowed between this leaf and ifAlias.  The definition of\nsuch a mechanism is outside the scope of this document.\n\nSince ifAlias is defined to be stored in non-volatile\nstorage, the MIB implementation MUST map ifAlias to the\nvalue of 'description' in the persistently stored\nconfiguration.", mandatory=False, reference='RFC 2863: The Interfaces Group MIB - ifAlias', type_=DTypeString(name='string', description=None, reference=None, exts=[], builtin_type='string', default=None, length=None, patterns=[]))
 
-SRC_DNODE_CHILD_22 = DLeaf(module='ietf-interfaces', namespace='urn:ietf:params:xml:ns:yang:ietf-interfaces', prefix='if', name='enabled', config=True, description="This leaf contains the configured, desired state of the\ninterface.\n\nSystems that implement the IF-MIB use the value of this\nleaf in the intended configuration to set\nIF-MIB.ifAdminStatus to 'up' or 'down' after an ifEntry\nhas been initialized, as described in RFC 2863.\n\nChanges in this leaf in the intended configuration are\nreflected in ifAdminStatus.", default='true', mandatory=False, reference='RFC 2863: The Interfaces Group MIB - ifAdminStatus', type_=DTypeBoolean(name='boolean', description=None, reference=None, exts=[], builtin_type='boolean', default=None))
+SRC_DNODE_CHILD_25 = DLeaf(module='ietf-interfaces', namespace='urn:ietf:params:xml:ns:yang:ietf-interfaces', prefix='if', name='type', config=True, description="The type of the interface.\n\nWhen an interface entry is created, a server MAY\ninitialize the type leaf with a valid value, e.g., if it\nis possible to derive the type from the name of the\ninterface.\n\nIf a client tries to set the type of an interface to a\nvalue that can never be used by the system, e.g., if the\ntype is not supported or if the type does not match the\nname of the interface, the server MUST reject the request.\nA NETCONF server MUST reply with an rpc-error with the\nerror-tag 'invalid-value' in this case.", mandatory=True, reference='RFC 2863: The Interfaces Group MIB - ifType', type_=DTypeIdentityref(name='identityref', description=None, reference=None, exts=[], builtin_type='identityref', default=None, identity_bases=[_base_ietf_interfaces_interface_type], identities=_identities))
 
-SRC_DNODE_CHILD_23 = DLeaf(module='ietf-interfaces', namespace='urn:ietf:params:xml:ns:yang:ietf-interfaces', prefix='if', name='link-up-down-trap-enable', config=True, description="Controls whether linkUp/linkDown SNMP notifications\nshould be generated for this interface.\n\nIf this node is not configured, the value 'enabled' is\noperationally used by the server for interfaces that do\nnot operate on top of any other interface (i.e., there are\nno 'lower-layer-if' entries), and 'disabled' otherwise.", if_feature=['if-mib'], mandatory=False, reference='RFC 2863: The Interfaces Group MIB -\n          ifLinkUpDownTrapEnable', type_=DTypeEnum(name='enumeration', description=None, reference=None, exts=[], builtin_type='enumeration', default=None, name_to_val={'enabled':1, 'disabled':2}))
+SRC_DNODE_CHILD_26 = DLeaf(module='ietf-interfaces', namespace='urn:ietf:params:xml:ns:yang:ietf-interfaces', prefix='if', name='enabled', config=True, description="This leaf contains the configured, desired state of the\ninterface.\n\nSystems that implement the IF-MIB use the value of this\nleaf in the intended configuration to set\nIF-MIB.ifAdminStatus to 'up' or 'down' after an ifEntry\nhas been initialized, as described in RFC 2863.\n\nChanges in this leaf in the intended configuration are\nreflected in ifAdminStatus.", default='true', mandatory=False, reference='RFC 2863: The Interfaces Group MIB - ifAdminStatus', type_=DTypeBoolean(name='boolean', description=None, reference=None, exts=[], builtin_type='boolean', default=None))
 
-SRC_DNODE_CHILD_24 = DContainer(module='ietf-ip', namespace='urn:ietf:params:xml:ns:yang:ietf-ip', prefix='ip', name='ipv4', config=True, description='Parameters for the IPv4 address family.', presence=True, children=[
+SRC_DNODE_CHILD_27 = DLeaf(module='ietf-interfaces', namespace='urn:ietf:params:xml:ns:yang:ietf-interfaces', prefix='if', name='link-up-down-trap-enable', config=True, description="Controls whether linkUp/linkDown SNMP notifications\nshould be generated for this interface.\n\nIf this node is not configured, the value 'enabled' is\noperationally used by the server for interfaces that do\nnot operate on top of any other interface (i.e., there are\nno 'lower-layer-if' entries), and 'disabled' otherwise.", if_feature=['if-mib'], mandatory=False, reference='RFC 2863: The Interfaces Group MIB -\n          ifLinkUpDownTrapEnable', type_=DTypeEnum(name='enumeration', description=None, reference=None, exts=[], builtin_type='enumeration', default=None, name_to_val={'enabled':1, 'disabled':2}))
+
+SRC_DNODE_CHILD_28 = DLeaf(module='ietf-interfaces', namespace='urn:ietf:params:xml:ns:yang:ietf-interfaces', prefix='if', name='admin-status', config=False, description='The desired state of the interface.\n\nThis leaf has the same read semantics as ifAdminStatus.', if_feature=['if-mib'], mandatory=True, reference='RFC 2863: The Interfaces Group MIB - ifAdminStatus', type_=DTypeEnum(name='enumeration', description=None, reference=None, exts=[], builtin_type='enumeration', default=None, name_to_val={'up':1, 'down':2, 'testing':3}))
+
+SRC_DNODE_CHILD_29 = DLeaf(module='ietf-interfaces', namespace='urn:ietf:params:xml:ns:yang:ietf-interfaces', prefix='if', name='oper-status', config=False, description='The current operational state of the interface.\n\nThis leaf has the same semantics as ifOperStatus.', mandatory=True, reference='RFC 2863: The Interfaces Group MIB - ifOperStatus', type_=DTypeEnum(name='enumeration', description=None, reference=None, exts=[], builtin_type='enumeration', default=None, name_to_val={'up':1, 'down':2, 'testing':3, 'unknown':4, 'dormant':5, 'not-present':6, 'lower-layer-down':7}))
+
+SRC_DNODE_CHILD_30 = DLeaf(module='ietf-interfaces', namespace='urn:ietf:params:xml:ns:yang:ietf-interfaces', prefix='if', name='last-change', config=False, description='The time the interface entered its current operational\nstate.  If the current state was entered prior to the\nlast re-initialization of the local network management\nsubsystem, then this node is not present.', mandatory=False, reference='RFC 2863: The Interfaces Group MIB - ifLastChange', type_=DTypeString(name='yang:date-and-time', description="The date-and-time type is a profile of the ISO 8601\nstandard for representation of dates and times using the\nGregorian calendar.  The profile is defined by the\ndate-time production in Section 5.6 of RFC 3339.\n\nThe date-and-time type is compatible with the dateTime XML\nschema type with the following notable exceptions:\n\n(a) The date-and-time type does not allow negative years.\n\n(b) The date-and-time time-offset -00:00 indicates an unknown\n    time zone (see RFC 3339) while -00:00 and +00:00 and Z\n    all represent the same time zone in dateTime.\n\n(c) The canonical format (see below) of data-and-time values\n    differs from the canonical format used by the dateTime XML\n    schema type, which requires all times to be in UTC using\n    the time-offset 'Z'.\n\nThis type is not equivalent to the DateAndTime textual\nconvention of the SMIv2 since RFC 3339 uses a different\nseparator between full-date and full-time and provides\nhigher resolution of time-secfrac.\n\nThe canonical format for date-and-time values with a known time\nzone uses a numeric time zone offset that is calculated using\nthe device's configured known offset to UTC time.  A change of\nthe device's offset to UTC time will cause date-and-time values\nto change accordingly.  Such changes might happen periodically\nin case a server follows automatically daylight saving time\n(DST) time zone offset changes.  The canonical format for\ndate-and-time values with an unknown time zone (usually\nreferring to the notion of local time) uses the time-offset\n-00:00.", reference='RFC 3339: Date and Time on the Internet: Timestamps\nRFC 2579: Textual Conventions for SMIv2\nXSD-TYPES: XML Schema Part 2: Datatypes Second Edition', exts=[], builtin_type='string', default=None, length=None, patterns=[YangPattern(yang_regex='\\d{{4}}-\\d{{2}}-\\d{{2}}T\\d{{2}}:\\d{{2}}:\\d{{2}}(\\.\\d+)?(Z|[\\+\\-]\\d{{2}}:\\d{{2}})', pcre='^(\\p{{Nd}}{{4}}-\\p{{Nd}}{{2}}-\\p{{Nd}}{{2}}T\\p{{Nd}}{{2}}:\\p{{Nd}}{{2}}:\\p{{Nd}}{{2}}(\\.\\p{{Nd}}+)?(Z|[\\+\\-]\\p{{Nd}}{{2}}:\\p{{Nd}}{{2}}))$', invert=False)]))
+
+SRC_DNODE_CHILD_31 = DLeaf(module='ietf-interfaces', namespace='urn:ietf:params:xml:ns:yang:ietf-interfaces', prefix='if', name='if-index', config=False, description='The ifIndex value for the ifEntry represented by this\ninterface.', if_feature=['if-mib'], mandatory=True, reference='RFC 2863: The Interfaces Group MIB - ifIndex', type_=DTypeIntegerSigned(name='int32', description=None, reference=None, exts=[], builtin_type='int32', default=None, ranges=Ranges([(1, 2147483647)])))
+
+SRC_DNODE_CHILD_32 = DLeaf(module='ietf-interfaces', namespace='urn:ietf:params:xml:ns:yang:ietf-interfaces', prefix='if', name='phys-address', config=False, description="The interface's address at its protocol sub-layer.  For\nexample, for an 802.x interface, this object normally\ncontains a Media Access Control (MAC) address.  The\ninterface's media-specific modules must define the bit\nand byte ordering and the format of the value of this\nobject.  For interfaces that do not have such an address\n(e.g., a serial line), this node is not present.", mandatory=False, reference='RFC 2863: The Interfaces Group MIB - ifPhysAddress', type_=DTypeString(name='yang:phys-address', description='Represents media- or physical-level addresses represented\nas a sequence octets, each octet represented by two hexadecimal\nnumbers.  Octets are separated by colons.  The canonical\nrepresentation uses lowercase characters.\n\nIn the value set and its semantics, this type is equivalent\nto the PhysAddress textual convention of the SMIv2.', reference='RFC 2579: Textual Conventions for SMIv2', exts=[], builtin_type='string', default=None, length=None, patterns=[YangPattern(yang_regex='([0-9a-fA-F]{{2}}(:[0-9a-fA-F]{{2}})*)?', pcre='^(([0-9a-fA-F]{{2}}(:[0-9a-fA-F]{{2}})*)?)$', invert=False)]))
+
+SRC_DNODE_CHILD_33 = DLeafList(module='ietf-interfaces', namespace='urn:ietf:params:xml:ns:yang:ietf-interfaces', prefix='if', name='higher-layer-if', config=False, description='A list of references to interfaces layered on top of this\ninterface.', min_elements=0, ordered_by='system', reference='RFC 2863: The Interfaces Group MIB - ifStackTable', type_=DTypeLeafref(name='interface-ref', description='This type is used by data models that need to reference\ninterfaces.', reference=None, exts=[], builtin_type='leafref', default=None, path=yang.xpath.AbsoluteLocationPath([yang.xpath.NodeTestStep('if', 'interfaces', []), yang.xpath.NodeTestStep('if', 'interface', []), yang.xpath.NodeTestStep('if', 'name', [])]), require_instance=False, target_type=DTypeString(name='string', description=None, reference=None, exts=[], builtin_type='string', default=None, length=None, patterns=[])))
+
+SRC_DNODE_CHILD_34 = DLeafList(module='ietf-interfaces', namespace='urn:ietf:params:xml:ns:yang:ietf-interfaces', prefix='if', name='lower-layer-if', config=False, description='A list of references to interfaces layered underneath this\ninterface.', min_elements=0, ordered_by='system', reference='RFC 2863: The Interfaces Group MIB - ifStackTable', type_=DTypeLeafref(name='interface-ref', description='This type is used by data models that need to reference\ninterfaces.', reference=None, exts=[], builtin_type='leafref', default=None, path=yang.xpath.AbsoluteLocationPath([yang.xpath.NodeTestStep('if', 'interfaces', []), yang.xpath.NodeTestStep('if', 'interface', []), yang.xpath.NodeTestStep('if', 'name', [])]), require_instance=False, target_type=DTypeString(name='string', description=None, reference=None, exts=[], builtin_type='string', default=None, length=None, patterns=[])))
+
+SRC_DNODE_CHILD_35 = DLeaf(module='ietf-interfaces', namespace='urn:ietf:params:xml:ns:yang:ietf-interfaces', prefix='if', name='speed', config=False, description="An estimate of the interface's current bandwidth in bits\nper second.  For interfaces that do not vary in\nbandwidth or for those where no accurate estimation can\nbe made, this node should contain the nominal bandwidth.\nFor interfaces that have no concept of bandwidth, this\nnode is not present.", mandatory=False, reference='RFC 2863: The Interfaces Group MIB -\n          ifSpeed, ifHighSpeed', type_=DTypeIntegerUnsigned(name='yang:gauge64', description='The gauge64 type represents a non-negative integer, which\nmay increase or decrease, but shall never exceed a maximum\nvalue, nor fall below a minimum value.  The maximum value\ncannot be greater than 2^64-1 (18446744073709551615), and\nthe minimum value cannot be smaller than 0.  The value of\na gauge64 has its maximum value whenever the information\nbeing modeled is greater than or equal to its maximum\nvalue, and has its minimum value whenever the information\nbeing modeled is smaller than or equal to its minimum value.\nIf the information being modeled subsequently decreases\nbelow (increases above) the maximum (minimum) value, the\ngauge64 also decreases (increases).\n\nIn the value set and its semantics, this type is equivalent\nto the CounterBasedGauge64 SMIv2 textual convention defined\nin RFC 2856', reference='RFC 2856: Textual Conventions for Additional High Capacity\n          Data Types', exts=[], builtin_type='uint64', default=None, ranges=Ranges([(0, 18446744073709551615)])), units='bits/second')
+
+SRC_DNODE_CHILD_36 = DContainer(module='ietf-interfaces', namespace='urn:ietf:params:xml:ns:yang:ietf-interfaces', prefix='if', name='statistics', config=False, description='A collection of interface-related statistics objects.', presence=False, children=[
+    DLeaf(module='ietf-interfaces', namespace='urn:ietf:params:xml:ns:yang:ietf-interfaces', prefix='if', name='discontinuity-time', config=False, description="The time on the most recent occasion at which any one or\nmore of this interface's counters suffered a\ndiscontinuity.  If no such discontinuities have occurred\nsince the last re-initialization of the local management\nsubsystem, then this node contains the time the local\nmanagement subsystem re-initialized itself.", mandatory=True, type_=DTypeString(name='yang:date-and-time', description="The date-and-time type is a profile of the ISO 8601\nstandard for representation of dates and times using the\nGregorian calendar.  The profile is defined by the\ndate-time production in Section 5.6 of RFC 3339.\n\nThe date-and-time type is compatible with the dateTime XML\nschema type with the following notable exceptions:\n\n(a) The date-and-time type does not allow negative years.\n\n(b) The date-and-time time-offset -00:00 indicates an unknown\n    time zone (see RFC 3339) while -00:00 and +00:00 and Z\n    all represent the same time zone in dateTime.\n\n(c) The canonical format (see below) of data-and-time values\n    differs from the canonical format used by the dateTime XML\n    schema type, which requires all times to be in UTC using\n    the time-offset 'Z'.\n\nThis type is not equivalent to the DateAndTime textual\nconvention of the SMIv2 since RFC 3339 uses a different\nseparator between full-date and full-time and provides\nhigher resolution of time-secfrac.\n\nThe canonical format for date-and-time values with a known time\nzone uses a numeric time zone offset that is calculated using\nthe device's configured known offset to UTC time.  A change of\nthe device's offset to UTC time will cause date-and-time values\nto change accordingly.  Such changes might happen periodically\nin case a server follows automatically daylight saving time\n(DST) time zone offset changes.  The canonical format for\ndate-and-time values with an unknown time zone (usually\nreferring to the notion of local time) uses the time-offset\n-00:00.", reference='RFC 3339: Date and Time on the Internet: Timestamps\nRFC 2579: Textual Conventions for SMIv2\nXSD-TYPES: XML Schema Part 2: Datatypes Second Edition', exts=[], builtin_type='string', default=None, length=None, patterns=[YangPattern(yang_regex='\\d{{4}}-\\d{{2}}-\\d{{2}}T\\d{{2}}:\\d{{2}}:\\d{{2}}(\\.\\d+)?(Z|[\\+\\-]\\d{{2}}:\\d{{2}})', pcre='^(\\p{{Nd}}{{4}}-\\p{{Nd}}{{2}}-\\p{{Nd}}{{2}}T\\p{{Nd}}{{2}}:\\p{{Nd}}{{2}}:\\p{{Nd}}{{2}}(\\.\\p{{Nd}}+)?(Z|[\\+\\-]\\p{{Nd}}{{2}}:\\p{{Nd}}{{2}}))$', invert=False)])),
+    DLeaf(module='ietf-interfaces', namespace='urn:ietf:params:xml:ns:yang:ietf-interfaces', prefix='if', name='in-octets', config=False, description="The total number of octets received on the interface,\nincluding framing characters.\n\nDiscontinuities in the value of this counter can occur\nat re-initialization of the management system and at\nother times as indicated by the value of\n'discontinuity-time'.", mandatory=False, reference='RFC 2863: The Interfaces Group MIB - ifHCInOctets', type_=DTypeIntegerUnsigned(name='yang:counter64', description="The counter64 type represents a non-negative integer\nthat monotonically increases until it reaches a\nmaximum value of 2^64-1 (18446744073709551615 decimal),\nwhen it wraps around and starts increasing again from zero.\n\nCounters have no defined 'initial' value, and thus, a\nsingle value of a counter has (in general) no information\ncontent.  Discontinuities in the monotonically increasing\nvalue normally occur at re-initialization of the\nmanagement system, and at other times as specified in the\ndescription of a schema node using this type.  If such\nother times can occur, for example, the creation of\na schema node of type counter64 at times other than\nre-initialization, then a corresponding schema node\nshould be defined, with an appropriate type, to indicate\nthe last discontinuity.\n\nThe counter64 type should not be used for configuration\nschema nodes.  A default statement SHOULD NOT be used in\ncombination with the type counter64.\n\nIn the value set and its semantics, this type is equivalent\nto the Counter64 type of the SMIv2.", reference='RFC 2578: Structure of Management Information Version 2\n          (SMIv2)', exts=[], builtin_type='uint64', default=None, ranges=Ranges([(0, 18446744073709551615)]))),
+    DLeaf(module='ietf-interfaces', namespace='urn:ietf:params:xml:ns:yang:ietf-interfaces', prefix='if', name='in-unicast-pkts', config=False, description="The number of packets, delivered by this sub-layer to a\nhigher (sub-)layer, that were not addressed to a\nmulticast or broadcast address at this sub-layer.\n\nDiscontinuities in the value of this counter can occur\nat re-initialization of the management system and at\nother times as indicated by the value of\n'discontinuity-time'.", mandatory=False, reference='RFC 2863: The Interfaces Group MIB - ifHCInUcastPkts', type_=DTypeIntegerUnsigned(name='yang:counter64', description="The counter64 type represents a non-negative integer\nthat monotonically increases until it reaches a\nmaximum value of 2^64-1 (18446744073709551615 decimal),\nwhen it wraps around and starts increasing again from zero.\n\nCounters have no defined 'initial' value, and thus, a\nsingle value of a counter has (in general) no information\ncontent.  Discontinuities in the monotonically increasing\nvalue normally occur at re-initialization of the\nmanagement system, and at other times as specified in the\ndescription of a schema node using this type.  If such\nother times can occur, for example, the creation of\na schema node of type counter64 at times other than\nre-initialization, then a corresponding schema node\nshould be defined, with an appropriate type, to indicate\nthe last discontinuity.\n\nThe counter64 type should not be used for configuration\nschema nodes.  A default statement SHOULD NOT be used in\ncombination with the type counter64.\n\nIn the value set and its semantics, this type is equivalent\nto the Counter64 type of the SMIv2.", reference='RFC 2578: Structure of Management Information Version 2\n          (SMIv2)', exts=[], builtin_type='uint64', default=None, ranges=Ranges([(0, 18446744073709551615)]))),
+    DLeaf(module='ietf-interfaces', namespace='urn:ietf:params:xml:ns:yang:ietf-interfaces', prefix='if', name='in-broadcast-pkts', config=False, description="The number of packets, delivered by this sub-layer to a\nhigher (sub-)layer, that were addressed to a broadcast\naddress at this sub-layer.\n\nDiscontinuities in the value of this counter can occur\nat re-initialization of the management system and at\nother times as indicated by the value of\n'discontinuity-time'.", mandatory=False, reference='RFC 2863: The Interfaces Group MIB -\n          ifHCInBroadcastPkts', type_=DTypeIntegerUnsigned(name='yang:counter64', description="The counter64 type represents a non-negative integer\nthat monotonically increases until it reaches a\nmaximum value of 2^64-1 (18446744073709551615 decimal),\nwhen it wraps around and starts increasing again from zero.\n\nCounters have no defined 'initial' value, and thus, a\nsingle value of a counter has (in general) no information\ncontent.  Discontinuities in the monotonically increasing\nvalue normally occur at re-initialization of the\nmanagement system, and at other times as specified in the\ndescription of a schema node using this type.  If such\nother times can occur, for example, the creation of\na schema node of type counter64 at times other than\nre-initialization, then a corresponding schema node\nshould be defined, with an appropriate type, to indicate\nthe last discontinuity.\n\nThe counter64 type should not be used for configuration\nschema nodes.  A default statement SHOULD NOT be used in\ncombination with the type counter64.\n\nIn the value set and its semantics, this type is equivalent\nto the Counter64 type of the SMIv2.", reference='RFC 2578: Structure of Management Information Version 2\n          (SMIv2)', exts=[], builtin_type='uint64', default=None, ranges=Ranges([(0, 18446744073709551615)]))),
+    DLeaf(module='ietf-interfaces', namespace='urn:ietf:params:xml:ns:yang:ietf-interfaces', prefix='if', name='in-multicast-pkts', config=False, description="The number of packets, delivered by this sub-layer to a\nhigher (sub-)layer, that were addressed to a multicast\naddress at this sub-layer.  For a MAC-layer protocol,\nthis includes both Group and Functional addresses.\n\nDiscontinuities in the value of this counter can occur\nat re-initialization of the management system and at\nother times as indicated by the value of\n'discontinuity-time'.", mandatory=False, reference='RFC 2863: The Interfaces Group MIB -\n          ifHCInMulticastPkts', type_=DTypeIntegerUnsigned(name='yang:counter64', description="The counter64 type represents a non-negative integer\nthat monotonically increases until it reaches a\nmaximum value of 2^64-1 (18446744073709551615 decimal),\nwhen it wraps around and starts increasing again from zero.\n\nCounters have no defined 'initial' value, and thus, a\nsingle value of a counter has (in general) no information\ncontent.  Discontinuities in the monotonically increasing\nvalue normally occur at re-initialization of the\nmanagement system, and at other times as specified in the\ndescription of a schema node using this type.  If such\nother times can occur, for example, the creation of\na schema node of type counter64 at times other than\nre-initialization, then a corresponding schema node\nshould be defined, with an appropriate type, to indicate\nthe last discontinuity.\n\nThe counter64 type should not be used for configuration\nschema nodes.  A default statement SHOULD NOT be used in\ncombination with the type counter64.\n\nIn the value set and its semantics, this type is equivalent\nto the Counter64 type of the SMIv2.", reference='RFC 2578: Structure of Management Information Version 2\n          (SMIv2)', exts=[], builtin_type='uint64', default=None, ranges=Ranges([(0, 18446744073709551615)]))),
+    DLeaf(module='ietf-interfaces', namespace='urn:ietf:params:xml:ns:yang:ietf-interfaces', prefix='if', name='in-discards', config=False, description="The number of inbound packets that were chosen to be\ndiscarded even though no errors had been detected to\nprevent their being deliverable to a higher-layer\nprotocol.  One possible reason for discarding such a\npacket could be to free up buffer space.\n\nDiscontinuities in the value of this counter can occur\nat re-initialization of the management system and at\nother times as indicated by the value of\n'discontinuity-time'.", mandatory=False, reference='RFC 2863: The Interfaces Group MIB - ifInDiscards', type_=DTypeIntegerUnsigned(name='yang:counter32', description="The counter32 type represents a non-negative integer\nthat monotonically increases until it reaches a\nmaximum value of 2^32-1 (4294967295 decimal), when it\nwraps around and starts increasing again from zero.\n\nCounters have no defined 'initial' value, and thus, a\nsingle value of a counter has (in general) no information\ncontent.  Discontinuities in the monotonically increasing\nvalue normally occur at re-initialization of the\nmanagement system, and at other times as specified in the\ndescription of a schema node using this type.  If such\nother times can occur, for example, the creation of\na schema node of type counter32 at times other than\nre-initialization, then a corresponding schema node\nshould be defined, with an appropriate type, to indicate\nthe last discontinuity.\n\nThe counter32 type should not be used for configuration\nschema nodes.  A default statement SHOULD NOT be used in\ncombination with the type counter32.\n\nIn the value set and its semantics, this type is equivalent\nto the Counter32 type of the SMIv2.", reference='RFC 2578: Structure of Management Information Version 2\n          (SMIv2)', exts=[], builtin_type='uint32', default=None, ranges=Ranges([(0, 4294967295)]))),
+    DLeaf(module='ietf-interfaces', namespace='urn:ietf:params:xml:ns:yang:ietf-interfaces', prefix='if', name='in-errors', config=False, description="For packet-oriented interfaces, the number of inbound\npackets that contained errors preventing them from being\ndeliverable to a higher-layer protocol.  For character-\noriented or fixed-length interfaces, the number of\ninbound transmission units that contained errors\npreventing them from being deliverable to a higher-layer\nprotocol.\n\nDiscontinuities in the value of this counter can occur\nat re-initialization of the management system and at\nother times as indicated by the value of\n'discontinuity-time'.", mandatory=False, reference='RFC 2863: The Interfaces Group MIB - ifInErrors', type_=DTypeIntegerUnsigned(name='yang:counter32', description="The counter32 type represents a non-negative integer\nthat monotonically increases until it reaches a\nmaximum value of 2^32-1 (4294967295 decimal), when it\nwraps around and starts increasing again from zero.\n\nCounters have no defined 'initial' value, and thus, a\nsingle value of a counter has (in general) no information\ncontent.  Discontinuities in the monotonically increasing\nvalue normally occur at re-initialization of the\nmanagement system, and at other times as specified in the\ndescription of a schema node using this type.  If such\nother times can occur, for example, the creation of\na schema node of type counter32 at times other than\nre-initialization, then a corresponding schema node\nshould be defined, with an appropriate type, to indicate\nthe last discontinuity.\n\nThe counter32 type should not be used for configuration\nschema nodes.  A default statement SHOULD NOT be used in\ncombination with the type counter32.\n\nIn the value set and its semantics, this type is equivalent\nto the Counter32 type of the SMIv2.", reference='RFC 2578: Structure of Management Information Version 2\n          (SMIv2)', exts=[], builtin_type='uint32', default=None, ranges=Ranges([(0, 4294967295)]))),
+    DLeaf(module='ietf-interfaces', namespace='urn:ietf:params:xml:ns:yang:ietf-interfaces', prefix='if', name='in-unknown-protos', config=False, description="For packet-oriented interfaces, the number of packets\nreceived via the interface that were discarded because\nof an unknown or unsupported protocol.  For\ncharacter-oriented or fixed-length interfaces that\nsupport protocol multiplexing, the number of\ntransmission units received via the interface that were\ndiscarded because of an unknown or unsupported protocol.\nFor any interface that does not support protocol\nmultiplexing, this counter is not present.\n\nDiscontinuities in the value of this counter can occur\nat re-initialization of the management system and at\nother times as indicated by the value of\n'discontinuity-time'.", mandatory=False, reference='RFC 2863: The Interfaces Group MIB - ifInUnknownProtos', type_=DTypeIntegerUnsigned(name='yang:counter32', description="The counter32 type represents a non-negative integer\nthat monotonically increases until it reaches a\nmaximum value of 2^32-1 (4294967295 decimal), when it\nwraps around and starts increasing again from zero.\n\nCounters have no defined 'initial' value, and thus, a\nsingle value of a counter has (in general) no information\ncontent.  Discontinuities in the monotonically increasing\nvalue normally occur at re-initialization of the\nmanagement system, and at other times as specified in the\ndescription of a schema node using this type.  If such\nother times can occur, for example, the creation of\na schema node of type counter32 at times other than\nre-initialization, then a corresponding schema node\nshould be defined, with an appropriate type, to indicate\nthe last discontinuity.\n\nThe counter32 type should not be used for configuration\nschema nodes.  A default statement SHOULD NOT be used in\ncombination with the type counter32.\n\nIn the value set and its semantics, this type is equivalent\nto the Counter32 type of the SMIv2.", reference='RFC 2578: Structure of Management Information Version 2\n          (SMIv2)', exts=[], builtin_type='uint32', default=None, ranges=Ranges([(0, 4294967295)]))),
+    DLeaf(module='ietf-interfaces', namespace='urn:ietf:params:xml:ns:yang:ietf-interfaces', prefix='if', name='out-octets', config=False, description="The total number of octets transmitted out of the\ninterface, including framing characters.\n\nDiscontinuities in the value of this counter can occur\nat re-initialization of the management system and at\nother times as indicated by the value of\n'discontinuity-time'.", mandatory=False, reference='RFC 2863: The Interfaces Group MIB - ifHCOutOctets', type_=DTypeIntegerUnsigned(name='yang:counter64', description="The counter64 type represents a non-negative integer\nthat monotonically increases until it reaches a\nmaximum value of 2^64-1 (18446744073709551615 decimal),\nwhen it wraps around and starts increasing again from zero.\n\nCounters have no defined 'initial' value, and thus, a\nsingle value of a counter has (in general) no information\ncontent.  Discontinuities in the monotonically increasing\nvalue normally occur at re-initialization of the\nmanagement system, and at other times as specified in the\ndescription of a schema node using this type.  If such\nother times can occur, for example, the creation of\na schema node of type counter64 at times other than\nre-initialization, then a corresponding schema node\nshould be defined, with an appropriate type, to indicate\nthe last discontinuity.\n\nThe counter64 type should not be used for configuration\nschema nodes.  A default statement SHOULD NOT be used in\ncombination with the type counter64.\n\nIn the value set and its semantics, this type is equivalent\nto the Counter64 type of the SMIv2.", reference='RFC 2578: Structure of Management Information Version 2\n          (SMIv2)', exts=[], builtin_type='uint64', default=None, ranges=Ranges([(0, 18446744073709551615)]))),
+    DLeaf(module='ietf-interfaces', namespace='urn:ietf:params:xml:ns:yang:ietf-interfaces', prefix='if', name='out-unicast-pkts', config=False, description="The total number of packets that higher-level protocols\nrequested be transmitted and that were not addressed\nto a multicast or broadcast address at this sub-layer,\nincluding those that were discarded or not sent.\n\nDiscontinuities in the value of this counter can occur\nat re-initialization of the management system and at\nother times as indicated by the value of\n'discontinuity-time'.", mandatory=False, reference='RFC 2863: The Interfaces Group MIB - ifHCOutUcastPkts', type_=DTypeIntegerUnsigned(name='yang:counter64', description="The counter64 type represents a non-negative integer\nthat monotonically increases until it reaches a\nmaximum value of 2^64-1 (18446744073709551615 decimal),\nwhen it wraps around and starts increasing again from zero.\n\nCounters have no defined 'initial' value, and thus, a\nsingle value of a counter has (in general) no information\ncontent.  Discontinuities in the monotonically increasing\nvalue normally occur at re-initialization of the\nmanagement system, and at other times as specified in the\ndescription of a schema node using this type.  If such\nother times can occur, for example, the creation of\na schema node of type counter64 at times other than\nre-initialization, then a corresponding schema node\nshould be defined, with an appropriate type, to indicate\nthe last discontinuity.\n\nThe counter64 type should not be used for configuration\nschema nodes.  A default statement SHOULD NOT be used in\ncombination with the type counter64.\n\nIn the value set and its semantics, this type is equivalent\nto the Counter64 type of the SMIv2.", reference='RFC 2578: Structure of Management Information Version 2\n          (SMIv2)', exts=[], builtin_type='uint64', default=None, ranges=Ranges([(0, 18446744073709551615)]))),
+    DLeaf(module='ietf-interfaces', namespace='urn:ietf:params:xml:ns:yang:ietf-interfaces', prefix='if', name='out-broadcast-pkts', config=False, description="The total number of packets that higher-level protocols\nrequested be transmitted and that were addressed to a\nbroadcast address at this sub-layer, including those\nthat were discarded or not sent.\n\nDiscontinuities in the value of this counter can occur\nat re-initialization of the management system and at\nother times as indicated by the value of\n'discontinuity-time'.", mandatory=False, reference='RFC 2863: The Interfaces Group MIB -\n          ifHCOutBroadcastPkts', type_=DTypeIntegerUnsigned(name='yang:counter64', description="The counter64 type represents a non-negative integer\nthat monotonically increases until it reaches a\nmaximum value of 2^64-1 (18446744073709551615 decimal),\nwhen it wraps around and starts increasing again from zero.\n\nCounters have no defined 'initial' value, and thus, a\nsingle value of a counter has (in general) no information\ncontent.  Discontinuities in the monotonically increasing\nvalue normally occur at re-initialization of the\nmanagement system, and at other times as specified in the\ndescription of a schema node using this type.  If such\nother times can occur, for example, the creation of\na schema node of type counter64 at times other than\nre-initialization, then a corresponding schema node\nshould be defined, with an appropriate type, to indicate\nthe last discontinuity.\n\nThe counter64 type should not be used for configuration\nschema nodes.  A default statement SHOULD NOT be used in\ncombination with the type counter64.\n\nIn the value set and its semantics, this type is equivalent\nto the Counter64 type of the SMIv2.", reference='RFC 2578: Structure of Management Information Version 2\n          (SMIv2)', exts=[], builtin_type='uint64', default=None, ranges=Ranges([(0, 18446744073709551615)]))),
+    DLeaf(module='ietf-interfaces', namespace='urn:ietf:params:xml:ns:yang:ietf-interfaces', prefix='if', name='out-multicast-pkts', config=False, description="The total number of packets that higher-level protocols\nrequested be transmitted and that were addressed to a\nmulticast address at this sub-layer, including those\nthat were discarded or not sent.  For a MAC-layer\nprotocol, this includes both Group and Functional\naddresses.\n\nDiscontinuities in the value of this counter can occur\nat re-initialization of the management system and at\nother times as indicated by the value of\n'discontinuity-time'.", mandatory=False, reference='RFC 2863: The Interfaces Group MIB -\n          ifHCOutMulticastPkts', type_=DTypeIntegerUnsigned(name='yang:counter64', description="The counter64 type represents a non-negative integer\nthat monotonically increases until it reaches a\nmaximum value of 2^64-1 (18446744073709551615 decimal),\nwhen it wraps around and starts increasing again from zero.\n\nCounters have no defined 'initial' value, and thus, a\nsingle value of a counter has (in general) no information\ncontent.  Discontinuities in the monotonically increasing\nvalue normally occur at re-initialization of the\nmanagement system, and at other times as specified in the\ndescription of a schema node using this type.  If such\nother times can occur, for example, the creation of\na schema node of type counter64 at times other than\nre-initialization, then a corresponding schema node\nshould be defined, with an appropriate type, to indicate\nthe last discontinuity.\n\nThe counter64 type should not be used for configuration\nschema nodes.  A default statement SHOULD NOT be used in\ncombination with the type counter64.\n\nIn the value set and its semantics, this type is equivalent\nto the Counter64 type of the SMIv2.", reference='RFC 2578: Structure of Management Information Version 2\n          (SMIv2)', exts=[], builtin_type='uint64', default=None, ranges=Ranges([(0, 18446744073709551615)]))),
+    DLeaf(module='ietf-interfaces', namespace='urn:ietf:params:xml:ns:yang:ietf-interfaces', prefix='if', name='out-discards', config=False, description="The number of outbound packets that were chosen to be\ndiscarded even though no errors had been detected to\nprevent their being transmitted.  One possible reason\nfor discarding such a packet could be to free up buffer\nspace.\n\nDiscontinuities in the value of this counter can occur\nat re-initialization of the management system and at\nother times as indicated by the value of\n'discontinuity-time'.", mandatory=False, reference='RFC 2863: The Interfaces Group MIB - ifOutDiscards', type_=DTypeIntegerUnsigned(name='yang:counter32', description="The counter32 type represents a non-negative integer\nthat monotonically increases until it reaches a\nmaximum value of 2^32-1 (4294967295 decimal), when it\nwraps around and starts increasing again from zero.\n\nCounters have no defined 'initial' value, and thus, a\nsingle value of a counter has (in general) no information\ncontent.  Discontinuities in the monotonically increasing\nvalue normally occur at re-initialization of the\nmanagement system, and at other times as specified in the\ndescription of a schema node using this type.  If such\nother times can occur, for example, the creation of\na schema node of type counter32 at times other than\nre-initialization, then a corresponding schema node\nshould be defined, with an appropriate type, to indicate\nthe last discontinuity.\n\nThe counter32 type should not be used for configuration\nschema nodes.  A default statement SHOULD NOT be used in\ncombination with the type counter32.\n\nIn the value set and its semantics, this type is equivalent\nto the Counter32 type of the SMIv2.", reference='RFC 2578: Structure of Management Information Version 2\n          (SMIv2)', exts=[], builtin_type='uint32', default=None, ranges=Ranges([(0, 4294967295)]))),
+    DLeaf(module='ietf-interfaces', namespace='urn:ietf:params:xml:ns:yang:ietf-interfaces', prefix='if', name='out-errors', config=False, description="For packet-oriented interfaces, the number of outbound\npackets that could not be transmitted because of errors.\nFor character-oriented or fixed-length interfaces, the\nnumber of outbound transmission units that could not be\ntransmitted because of errors.\n\nDiscontinuities in the value of this counter can occur\nat re-initialization of the management system and at\nother times as indicated by the value of\n'discontinuity-time'.", mandatory=False, reference='RFC 2863: The Interfaces Group MIB - ifOutErrors', type_=DTypeIntegerUnsigned(name='yang:counter32', description="The counter32 type represents a non-negative integer\nthat monotonically increases until it reaches a\nmaximum value of 2^32-1 (4294967295 decimal), when it\nwraps around and starts increasing again from zero.\n\nCounters have no defined 'initial' value, and thus, a\nsingle value of a counter has (in general) no information\ncontent.  Discontinuities in the monotonically increasing\nvalue normally occur at re-initialization of the\nmanagement system, and at other times as specified in the\ndescription of a schema node using this type.  If such\nother times can occur, for example, the creation of\na schema node of type counter32 at times other than\nre-initialization, then a corresponding schema node\nshould be defined, with an appropriate type, to indicate\nthe last discontinuity.\n\nThe counter32 type should not be used for configuration\nschema nodes.  A default statement SHOULD NOT be used in\ncombination with the type counter32.\n\nIn the value set and its semantics, this type is equivalent\nto the Counter32 type of the SMIv2.", reference='RFC 2578: Structure of Management Information Version 2\n          (SMIv2)', exts=[], builtin_type='uint32', default=None, ranges=Ranges([(0, 4294967295)])))
+])
+
+SRC_DNODE_CHILD_37 = DContainer(module='ietf-ip', namespace='urn:ietf:params:xml:ns:yang:ietf-ip', prefix='ip', name='ipv4', config=True, description='Parameters for the IPv4 address family.', presence=True, children=[
     DLeaf(module='ietf-ip', namespace='urn:ietf:params:xml:ns:yang:ietf-ip', prefix='ip', name='enabled', config=True, description='Controls whether IPv4 is enabled or disabled on this\ninterface.  When IPv4 is enabled, this interface is\nconnected to an IPv4 stack, and the interface can send\nand receive IPv4 packets.', default='true', mandatory=False, type_=DTypeBoolean(name='boolean', description=None, reference=None, exts=[], builtin_type='boolean', default=None)),
     DLeaf(module='ietf-ip', namespace='urn:ietf:params:xml:ns:yang:ietf-ip', prefix='ip', name='forwarding', config=True, description='Controls IPv4 packet forwarding of datagrams received by,\nbut not addressed to, this interface.  IPv4 routers\nforward datagrams.  IPv4 hosts do not (except those\nsource-routed via the host).', default='false', mandatory=False, type_=DTypeBoolean(name='boolean', description=None, reference=None, exts=[], builtin_type='boolean', default=None)),
     DLeaf(module='ietf-ip', namespace='urn:ietf:params:xml:ns:yang:ietf-ip', prefix='ip', name='mtu', config=True, description="The size, in octets, of the largest IPv4 packet that the\ninterface will send and receive.\n\nThe server may restrict the allowed values for this leaf,\ndepending on the interface's type.\n\nIf this leaf is not configured, the operationally used MTU\ndepends on the interface's type.", mandatory=False, reference='RFC 791: Internet Protocol', type_=DTypeIntegerUnsigned(name='uint16', description=None, reference=None, exts=[], builtin_type='uint16', default=None, ranges=Ranges([(68, 65535)])), units='octets'),
@@ -995,44 +1048,134 @@ SRC_DNODE_CHILD_24 = DContainer(module='ietf-ip', namespace='urn:ietf:params:xml
         DLeaf(module='ietf-ip', namespace='urn:ietf:params:xml:ns:yang:ietf-ip', prefix='ip', name='prefix-length', config=True, description='The length of the subnet prefix.', mandatory=False, type_=DTypeIntegerUnsigned(name='uint8', description=None, reference=None, exts=[], builtin_type='uint8', default=None, ranges=Ranges([(0, 32)]))),
         DLeaf(module='ietf-ip', namespace='urn:ietf:params:xml:ns:yang:ietf-ip', prefix='ip', name='netmask', config=True, description='The subnet specified as a netmask.', if_feature=[
 'ipv4-non-contiguous-netmasks'
-            ], mandatory=False, type_=DTypeString(name='yang:dotted-quad', description="An unsigned 32-bit number expressed in the dotted-quad\nnotation, i.e., four octets written as decimal numbers\nand separated with the '.' (full stop) character.", reference=None, exts=[], builtin_type='string', default=None, length=None, patterns=[YangPattern(yang_regex='(([0-9]|[1-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5])\\.){{3}}([0-9]|[1-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5])', pcre='^((([0-9]|[1-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5])\\.){{3}}([0-9]|[1-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5]))$', invert=False)]))
+            ], mandatory=False, type_=DTypeString(name='yang:dotted-quad', description="An unsigned 32-bit number expressed in the dotted-quad\nnotation, i.e., four octets written as decimal numbers\nand separated with the '.' (full stop) character.", reference=None, exts=[], builtin_type='string', default=None, length=None, patterns=[YangPattern(yang_regex='(([0-9]|[1-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5])\\.){{3}}([0-9]|[1-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5])', pcre='^((([0-9]|[1-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5])\\.){{3}}([0-9]|[1-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5]))$', invert=False)])),
+        DLeaf(module='ietf-ip', namespace='urn:ietf:params:xml:ns:yang:ietf-ip', prefix='ip', name='origin', config=False, description='The origin of this address.', mandatory=False, type_=DTypeEnum(name='ip-address-origin', description='The origin of an address.', reference=None, exts=[], builtin_type='enumeration', default=None, name_to_val={'other':0, 'static':1, 'dhcp':2, 'link-layer':3, 'random':4}))
     ]),
     DList(module='ietf-ip', namespace='urn:ietf:params:xml:ns:yang:ietf-ip', prefix='ip', name='neighbor', key=['ip'], config=True, description='A list of mappings from IPv4 addresses to\nlink-layer addresses.\n\nEntries in this list in the intended configuration are\nused as static entries in the ARP Cache.\n\nIn the operational state, this list represents the ARP\nCache.', min_elements=0, ordered_by='system', reference='RFC 826: An Ethernet Address Resolution Protocol', children=[
         DLeaf(module='ietf-ip', namespace='urn:ietf:params:xml:ns:yang:ietf-ip', prefix='ip', name='ip', config=True, description='The IPv4 address of the neighbor node.', mandatory=False, type_=DTypeString(name='inet:ipv4-address-no-zone', description='An IPv4 address without a zone index.  This type, derived from\nipv4-address, may be used in situations where the zone is\nknown from the context and hence no zone index is needed.', reference=None, exts=[], builtin_type='string', default=None, length=None, patterns=[YangPattern(yang_regex='(([0-9]|[1-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5])\\.){{3}}([0-9]|[1-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5])(%[\\p{{N}}\\p{{L}}]+)?', pcre='^((([0-9]|[1-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5])\\.){{3}}([0-9]|[1-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5])(%[\\p{{N}}\\p{{L}}]+)?)$', invert=False), YangPattern(yang_regex='[0-9\\.]*', pcre='^([0-9\\.]*)$', invert=False)])),
-        DLeaf(module='ietf-ip', namespace='urn:ietf:params:xml:ns:yang:ietf-ip', prefix='ip', name='link-layer-address', config=True, description='The link-layer address of the neighbor node.', mandatory=True, type_=DTypeString(name='yang:phys-address', description='Represents media- or physical-level addresses represented\nas a sequence octets, each octet represented by two hexadecimal\nnumbers.  Octets are separated by colons.  The canonical\nrepresentation uses lowercase characters.\n\nIn the value set and its semantics, this type is equivalent\nto the PhysAddress textual convention of the SMIv2.', reference='RFC 2579: Textual Conventions for SMIv2', exts=[], builtin_type='string', default=None, length=None, patterns=[YangPattern(yang_regex='([0-9a-fA-F]{{2}}(:[0-9a-fA-F]{{2}})*)?', pcre='^(([0-9a-fA-F]{{2}}(:[0-9a-fA-F]{{2}})*)?)$', invert=False)]))
+        DLeaf(module='ietf-ip', namespace='urn:ietf:params:xml:ns:yang:ietf-ip', prefix='ip', name='link-layer-address', config=True, description='The link-layer address of the neighbor node.', mandatory=True, type_=DTypeString(name='yang:phys-address', description='Represents media- or physical-level addresses represented\nas a sequence octets, each octet represented by two hexadecimal\nnumbers.  Octets are separated by colons.  The canonical\nrepresentation uses lowercase characters.\n\nIn the value set and its semantics, this type is equivalent\nto the PhysAddress textual convention of the SMIv2.', reference='RFC 2579: Textual Conventions for SMIv2', exts=[], builtin_type='string', default=None, length=None, patterns=[YangPattern(yang_regex='([0-9a-fA-F]{{2}}(:[0-9a-fA-F]{{2}})*)?', pcre='^(([0-9a-fA-F]{{2}}(:[0-9a-fA-F]{{2}})*)?)$', invert=False)])),
+        DLeaf(module='ietf-ip', namespace='urn:ietf:params:xml:ns:yang:ietf-ip', prefix='ip', name='origin', config=False, description='The origin of this neighbor entry.', mandatory=False, type_=DTypeEnum(name='neighbor-origin', description='The origin of a neighbor entry.', reference=None, exts=[], builtin_type='enumeration', default=None, name_to_val={'other':0, 'static':1, 'dynamic':2}))
     ])
 ])
 
-SRC_DNODE_CHILD_25 = DContainer(module='ietf-ip', namespace='urn:ietf:params:xml:ns:yang:ietf-ip', prefix='ip', name='ipv6', config=True, description='Parameters for the IPv6 address family.', presence=True, children=[
-    DLeaf(module='ietf-ip', namespace='urn:ietf:params:xml:ns:yang:ietf-ip', prefix='ip', name='enabled', config=True, description='Controls whether IPv6 is enabled or disabled on this\ninterface.  When IPv6 is enabled, this interface is\nconnected to an IPv6 stack, and the interface can send\nand receive IPv6 packets.', default='true', mandatory=False, type_=DTypeBoolean(name='boolean', description=None, reference=None, exts=[], builtin_type='boolean', default=None)),
-    DLeaf(module='ietf-ip', namespace='urn:ietf:params:xml:ns:yang:ietf-ip', prefix='ip', name='forwarding', config=True, description='Controls IPv6 packet forwarding of datagrams received by,\nbut not addressed to, this interface.  IPv6 routers\nforward datagrams.  IPv6 hosts do not (except those\nsource-routed via the host).', default='false', mandatory=False, reference='RFC 4861: Neighbor Discovery for IP version 6 (IPv6)\n          Section 6.2.1, IsRouter', type_=DTypeBoolean(name='boolean', description=None, reference=None, exts=[], builtin_type='boolean', default=None)),
-    DLeaf(module='ietf-ip', namespace='urn:ietf:params:xml:ns:yang:ietf-ip', prefix='ip', name='mtu', config=True, description="The size, in octets, of the largest IPv6 packet that the\ninterface will send and receive.\n\nThe server may restrict the allowed values for this leaf,\ndepending on the interface's type.\n\nIf this leaf is not configured, the operationally used MTU\ndepends on the interface's type.", mandatory=False, reference='RFC 8200: Internet Protocol, Version 6 (IPv6)\n          Specification\n          Section 5', type_=DTypeIntegerUnsigned(name='uint32', description=None, reference=None, exts=[], builtin_type='uint32', default=None, ranges=Ranges([(1280, 4294967295)])), units='octets'),
-    DList(module='ietf-ip', namespace='urn:ietf:params:xml:ns:yang:ietf-ip', prefix='ip', name='address', key=['ip'], config=True, description='The list of IPv6 addresses on the interface.', min_elements=0, ordered_by='system', children=[
-        DLeaf(module='ietf-ip', namespace='urn:ietf:params:xml:ns:yang:ietf-ip', prefix='ip', name='ip', config=True, description='The IPv6 address on the interface.', mandatory=False, type_=DTypeString(name='inet:ipv6-address-no-zone', description='An IPv6 address without a zone index.  This type, derived from\nipv6-address, may be used in situations where the zone is\nknown from the context and hence no zone index is needed.', reference='RFC 4291: IP Version 6 Addressing Architecture\nRFC 4007: IPv6 Scoped Address Architecture\nRFC 5952: A Recommendation for IPv6 Address Text\n          Representation', exts=[], builtin_type='string', default=None, length=None, patterns=[YangPattern(yang_regex='((:|[0-9a-fA-F]{{0,4}}):)([0-9a-fA-F]{{0,4}}:){{0,5}}((([0-9a-fA-F]{{0,4}}:)?(:|[0-9a-fA-F]{{0,4}}))|(((25[0-5]|2[0-4][0-9]|[01]?[0-9]?[0-9])\\.){{3}}(25[0-5]|2[0-4][0-9]|[01]?[0-9]?[0-9])))(%[\\p{{N}}\\p{{L}}]+)?', pcre='^(((:|[0-9a-fA-F]{{0,4}}):)([0-9a-fA-F]{{0,4}}:){{0,5}}((([0-9a-fA-F]{{0,4}}:)?(:|[0-9a-fA-F]{{0,4}}))|(((25[0-5]|2[0-4][0-9]|[01]?[0-9]?[0-9])\\.){{3}}(25[0-5]|2[0-4][0-9]|[01]?[0-9]?[0-9])))(%[\\p{{N}}\\p{{L}}]+)?)$', invert=False), YangPattern(yang_regex='(([^:]+:){{6}}(([^:]+:[^:]+)|(.*\\..*)))|((([^:]+:)*[^:]+)?::(([^:]+:)*[^:]+)?)(%.+)?', pcre='^((([^\\:]+:){{6}}(([^\\:]+:[^\\:]+)|(.*\\..*)))|((([^\\:]+:)*[^\\:]+)?::(([^\\:]+:)*[^\\:]+)?)(%.+)?)$', invert=False), YangPattern(yang_regex='[0-9a-fA-F:\\.]*', pcre='^([0-9a-fA-F:\\.]*)$', invert=False)])),
-        DLeaf(module='ietf-ip', namespace='urn:ietf:params:xml:ns:yang:ietf-ip', prefix='ip', name='prefix-length', config=True, description='The length of the subnet prefix.', mandatory=True, type_=DTypeIntegerUnsigned(name='uint8', description=None, reference=None, exts=[], builtin_type='uint8', default=None, ranges=Ranges([(0, 128)])))
+SRC_DNODE_CHILD_39 = DLeaf(module='ietf-ip', namespace='urn:ietf:params:xml:ns:yang:ietf-ip', prefix='ip', name='enabled', config=True, description='Controls whether IPv6 is enabled or disabled on this\ninterface.  When IPv6 is enabled, this interface is\nconnected to an IPv6 stack, and the interface can send\nand receive IPv6 packets.', default='true', mandatory=False, type_=DTypeBoolean(name='boolean', description=None, reference=None, exts=[], builtin_type='boolean', default=None))
+
+SRC_DNODE_CHILD_40 = DLeaf(module='ietf-ip', namespace='urn:ietf:params:xml:ns:yang:ietf-ip', prefix='ip', name='forwarding', config=True, description='Controls IPv6 packet forwarding of datagrams received by,\nbut not addressed to, this interface.  IPv6 routers\nforward datagrams.  IPv6 hosts do not (except those\nsource-routed via the host).', default='false', mandatory=False, reference='RFC 4861: Neighbor Discovery for IP version 6 (IPv6)\n          Section 6.2.1, IsRouter', type_=DTypeBoolean(name='boolean', description=None, reference=None, exts=[], builtin_type='boolean', default=None))
+
+SRC_DNODE_CHILD_41 = DLeaf(module='ietf-ip', namespace='urn:ietf:params:xml:ns:yang:ietf-ip', prefix='ip', name='mtu', config=True, description="The size, in octets, of the largest IPv6 packet that the\ninterface will send and receive.\n\nThe server may restrict the allowed values for this leaf,\ndepending on the interface's type.\n\nIf this leaf is not configured, the operationally used MTU\ndepends on the interface's type.", mandatory=False, reference='RFC 8200: Internet Protocol, Version 6 (IPv6)\n          Specification\n          Section 5', type_=DTypeIntegerUnsigned(name='uint32', description=None, reference=None, exts=[], builtin_type='uint32', default=None, ranges=Ranges([(1280, 4294967295)])), units='octets')
+
+SRC_DNODE_CHILD_42 = DList(module='ietf-ip', namespace='urn:ietf:params:xml:ns:yang:ietf-ip', prefix='ip', name='address', key=['ip'], config=True, description='The list of IPv6 addresses on the interface.', min_elements=0, ordered_by='system', children=[
+    DLeaf(module='ietf-ip', namespace='urn:ietf:params:xml:ns:yang:ietf-ip', prefix='ip', name='ip', config=True, description='The IPv6 address on the interface.', mandatory=False, type_=DTypeString(name='inet:ipv6-address-no-zone', description='An IPv6 address without a zone index.  This type, derived from\nipv6-address, may be used in situations where the zone is\nknown from the context and hence no zone index is needed.', reference='RFC 4291: IP Version 6 Addressing Architecture\nRFC 4007: IPv6 Scoped Address Architecture\nRFC 5952: A Recommendation for IPv6 Address Text\n          Representation', exts=[], builtin_type='string', default=None, length=None, patterns=[YangPattern(yang_regex='((:|[0-9a-fA-F]{{0,4}}):)([0-9a-fA-F]{{0,4}}:){{0,5}}((([0-9a-fA-F]{{0,4}}:)?(:|[0-9a-fA-F]{{0,4}}))|(((25[0-5]|2[0-4][0-9]|[01]?[0-9]?[0-9])\\.){{3}}(25[0-5]|2[0-4][0-9]|[01]?[0-9]?[0-9])))(%[\\p{{N}}\\p{{L}}]+)?', pcre='^(((:|[0-9a-fA-F]{{0,4}}):)([0-9a-fA-F]{{0,4}}:){{0,5}}((([0-9a-fA-F]{{0,4}}:)?(:|[0-9a-fA-F]{{0,4}}))|(((25[0-5]|2[0-4][0-9]|[01]?[0-9]?[0-9])\\.){{3}}(25[0-5]|2[0-4][0-9]|[01]?[0-9]?[0-9])))(%[\\p{{N}}\\p{{L}}]+)?)$', invert=False), YangPattern(yang_regex='(([^:]+:){{6}}(([^:]+:[^:]+)|(.*\\..*)))|((([^:]+:)*[^:]+)?::(([^:]+:)*[^:]+)?)(%.+)?', pcre='^((([^\\:]+:){{6}}(([^\\:]+:[^\\:]+)|(.*\\..*)))|((([^\\:]+:)*[^\\:]+)?::(([^\\:]+:)*[^\\:]+)?)(%.+)?)$', invert=False), YangPattern(yang_regex='[0-9a-fA-F:\\.]*', pcre='^([0-9a-fA-F:\\.]*)$', invert=False)])),
+    DLeaf(module='ietf-ip', namespace='urn:ietf:params:xml:ns:yang:ietf-ip', prefix='ip', name='prefix-length', config=True, description='The length of the subnet prefix.', mandatory=True, type_=DTypeIntegerUnsigned(name='uint8', description=None, reference=None, exts=[], builtin_type='uint8', default=None, ranges=Ranges([(0, 128)]))),
+    DLeaf(module='ietf-ip', namespace='urn:ietf:params:xml:ns:yang:ietf-ip', prefix='ip', name='origin', config=False, description='The origin of this address.', mandatory=False, type_=DTypeEnum(name='ip-address-origin', description='The origin of an address.', reference=None, exts=[], builtin_type='enumeration', default=None, name_to_val={'other':0, 'static':1, 'dhcp':2, 'link-layer':3, 'random':4})),
+    DLeaf(module='ietf-ip', namespace='urn:ietf:params:xml:ns:yang:ietf-ip', prefix='ip', name='status', config=False, description='The status of an address.  Most of the states correspond\nto states from the IPv6 Stateless Address\nAutoconfiguration protocol.', mandatory=False, reference='RFC 4293: Management Information Base for the\n          Internet Protocol (IP)\n          - IpAddressStatusTC\nRFC 4862: IPv6 Stateless Address Autoconfiguration', type_=DTypeEnum(name='enumeration', description=None, reference=None, exts=[], builtin_type='enumeration', default=None, name_to_val={'preferred':0, 'deprecated':1, 'invalid':2, 'inaccessible':3, 'unknown':4, 'tentative':5, 'duplicate':6, 'optimistic':7}))
+])
+
+SRC_DNODE_CHILD_43 = DList(module='ietf-ip', namespace='urn:ietf:params:xml:ns:yang:ietf-ip', prefix='ip', name='neighbor', key=['ip'], config=True, description='A list of mappings from IPv6 addresses to\nlink-layer addresses.\n\nEntries in this list in the intended configuration are\nused as static entries in the Neighbor Cache.\n\nIn the operational state, this list represents the\nNeighbor Cache.', min_elements=0, ordered_by='system', reference='RFC 4861: Neighbor Discovery for IP version 6 (IPv6)', children=[
+    DLeaf(module='ietf-ip', namespace='urn:ietf:params:xml:ns:yang:ietf-ip', prefix='ip', name='ip', config=True, description='The IPv6 address of the neighbor node.', mandatory=False, type_=DTypeString(name='inet:ipv6-address-no-zone', description='An IPv6 address without a zone index.  This type, derived from\nipv6-address, may be used in situations where the zone is\nknown from the context and hence no zone index is needed.', reference='RFC 4291: IP Version 6 Addressing Architecture\nRFC 4007: IPv6 Scoped Address Architecture\nRFC 5952: A Recommendation for IPv6 Address Text\n          Representation', exts=[], builtin_type='string', default=None, length=None, patterns=[YangPattern(yang_regex='((:|[0-9a-fA-F]{{0,4}}):)([0-9a-fA-F]{{0,4}}:){{0,5}}((([0-9a-fA-F]{{0,4}}:)?(:|[0-9a-fA-F]{{0,4}}))|(((25[0-5]|2[0-4][0-9]|[01]?[0-9]?[0-9])\\.){{3}}(25[0-5]|2[0-4][0-9]|[01]?[0-9]?[0-9])))(%[\\p{{N}}\\p{{L}}]+)?', pcre='^(((:|[0-9a-fA-F]{{0,4}}):)([0-9a-fA-F]{{0,4}}:){{0,5}}((([0-9a-fA-F]{{0,4}}:)?(:|[0-9a-fA-F]{{0,4}}))|(((25[0-5]|2[0-4][0-9]|[01]?[0-9]?[0-9])\\.){{3}}(25[0-5]|2[0-4][0-9]|[01]?[0-9]?[0-9])))(%[\\p{{N}}\\p{{L}}]+)?)$', invert=False), YangPattern(yang_regex='(([^:]+:){{6}}(([^:]+:[^:]+)|(.*\\..*)))|((([^:]+:)*[^:]+)?::(([^:]+:)*[^:]+)?)(%.+)?', pcre='^((([^\\:]+:){{6}}(([^\\:]+:[^\\:]+)|(.*\\..*)))|((([^\\:]+:)*[^\\:]+)?::(([^\\:]+:)*[^\\:]+)?)(%.+)?)$', invert=False), YangPattern(yang_regex='[0-9a-fA-F:\\.]*', pcre='^([0-9a-fA-F:\\.]*)$', invert=False)])),
+    DLeaf(module='ietf-ip', namespace='urn:ietf:params:xml:ns:yang:ietf-ip', prefix='ip', name='link-layer-address', config=True, description="The link-layer address of the neighbor node.\n\nIn the operational state, if the neighbor's 'state' leaf\nis 'incomplete', this leaf is not instantiated.", mandatory=True, type_=DTypeString(name='yang:phys-address', description='Represents media- or physical-level addresses represented\nas a sequence octets, each octet represented by two hexadecimal\nnumbers.  Octets are separated by colons.  The canonical\nrepresentation uses lowercase characters.\n\nIn the value set and its semantics, this type is equivalent\nto the PhysAddress textual convention of the SMIv2.', reference='RFC 2579: Textual Conventions for SMIv2', exts=[], builtin_type='string', default=None, length=None, patterns=[YangPattern(yang_regex='([0-9a-fA-F]{{2}}(:[0-9a-fA-F]{{2}})*)?', pcre='^(([0-9a-fA-F]{{2}}(:[0-9a-fA-F]{{2}})*)?)$', invert=False)])),
+    DLeaf(module='ietf-ip', namespace='urn:ietf:params:xml:ns:yang:ietf-ip', prefix='ip', name='origin', config=False, description='The origin of this neighbor entry.', mandatory=False, type_=DTypeEnum(name='neighbor-origin', description='The origin of a neighbor entry.', reference=None, exts=[], builtin_type='enumeration', default=None, name_to_val={'other':0, 'static':1, 'dynamic':2})),
+    DLeaf(module='ietf-ip', namespace='urn:ietf:params:xml:ns:yang:ietf-ip', prefix='ip', name='is-router', config=False, description='Indicates that the neighbor node acts as a router.', mandatory=False, type_=DTypeEmpty(name='empty', description=None, reference=None, exts=[], builtin_type='empty', default=None)),
+    DLeaf(module='ietf-ip', namespace='urn:ietf:params:xml:ns:yang:ietf-ip', prefix='ip', name='state', config=False, description='The Neighbor Unreachability Detection state of this\nentry.', mandatory=False, reference='RFC 4861: Neighbor Discovery for IP version 6 (IPv6)\n          Section 7.3.2', type_=DTypeEnum(name='enumeration', description=None, reference=None, exts=[], builtin_type='enumeration', default=None, name_to_val={'incomplete':0, 'reachable':1, 'stale':2, 'delay':3, 'probe':4}))
+])
+
+SRC_DNODE_CHILD_44 = DLeaf(module='ietf-ip', namespace='urn:ietf:params:xml:ns:yang:ietf-ip', prefix='ip', name='dup-addr-detect-transmits', config=True, description='The number of consecutive Neighbor Solicitation messages\nsent while performing Duplicate Address Detection on a\ntentative address.  A value of zero indicates that\nDuplicate Address Detection is not performed on\ntentative addresses.  A value of one indicates a single\ntransmission with no follow-up retransmissions.', default='1', mandatory=False, reference='RFC 4862: IPv6 Stateless Address Autoconfiguration', type_=DTypeIntegerUnsigned(name='uint32', description=None, reference=None, exts=[], builtin_type='uint32', default=None, ranges=Ranges([(0, 4294967295)])))
+
+SRC_DNODE_CHILD_45 = DContainer(module='ietf-ip', namespace='urn:ietf:params:xml:ns:yang:ietf-ip', prefix='ip', name='autoconf', config=True, description='Parameters to control the autoconfiguration of IPv6\naddresses, as described in RFC 4862.', presence=False, reference='RFC 4862: IPv6 Stateless Address Autoconfiguration', children=[
+    DLeaf(module='ietf-ip', namespace='urn:ietf:params:xml:ns:yang:ietf-ip', prefix='ip', name='create-global-addresses', config=True, description='If enabled, the host creates global addresses as\ndescribed in RFC 4862.', default='true', mandatory=False, reference='RFC 4862: IPv6 Stateless Address Autoconfiguration\n          Section 5.5', type_=DTypeBoolean(name='boolean', description=None, reference=None, exts=[], builtin_type='boolean', default=None)),
+    DLeaf(module='ietf-ip', namespace='urn:ietf:params:xml:ns:yang:ietf-ip', prefix='ip', name='create-temporary-addresses', config=True, description='If enabled, the host creates temporary addresses as\ndescribed in RFC 4941.', default='false', if_feature=[
+'ipv6-privacy-autoconf'
+        ], mandatory=False, reference='RFC 4941: Privacy Extensions for Stateless Address\n          Autoconfiguration in IPv6', type_=DTypeBoolean(name='boolean', description=None, reference=None, exts=[], builtin_type='boolean', default=None)),
+    DLeaf(module='ietf-ip', namespace='urn:ietf:params:xml:ns:yang:ietf-ip', prefix='ip', name='temporary-valid-lifetime', config=True, description='The time period during which the temporary address\nis valid.', default='604800', if_feature=[
+'ipv6-privacy-autoconf'
+        ], mandatory=False, reference='RFC 4941: Privacy Extensions for Stateless Address\n          Autoconfiguration in IPv6\n          - TEMP_VALID_LIFETIME', type_=DTypeIntegerUnsigned(name='uint32', description=None, reference=None, exts=[], builtin_type='uint32', default=None, ranges=Ranges([(0, 4294967295)])), units='seconds'),
+    DLeaf(module='ietf-ip', namespace='urn:ietf:params:xml:ns:yang:ietf-ip', prefix='ip', name='temporary-preferred-lifetime', config=True, description='The time period during which the temporary address is\npreferred.', default='86400', if_feature=[
+'ipv6-privacy-autoconf'
+        ], mandatory=False, reference='RFC 4941: Privacy Extensions for Stateless Address\n          Autoconfiguration in IPv6\n          - TEMP_PREFERRED_LIFETIME', type_=DTypeIntegerUnsigned(name='uint32', description=None, reference=None, exts=[], builtin_type='uint32', default=None, ranges=Ranges([(0, 4294967295)])), units='seconds')
+])
+
+SRC_DNODE_CHILD_38 = DContainer(module='ietf-ip', namespace='urn:ietf:params:xml:ns:yang:ietf-ip', prefix='ip', name='ipv6', config=True, description='Parameters for the IPv6 address family.', presence=True, children=[SRC_DNODE_CHILD_39, SRC_DNODE_CHILD_40, SRC_DNODE_CHILD_41, SRC_DNODE_CHILD_42, SRC_DNODE_CHILD_43, SRC_DNODE_CHILD_44, SRC_DNODE_CHILD_45])
+
+SRC_DNODE_CHILD_22 = DList(module='ietf-interfaces', namespace='urn:ietf:params:xml:ns:yang:ietf-interfaces', prefix='if', name='interface', key=['name'], config=True, description='The list of interfaces on the device.\n\nThe status of an interface is available in this list in the\noperational state.  If the configuration of a\nsystem-controlled interface cannot be used by the system\n(e.g., the interface hardware present does not match the\ninterface type), then the configuration is not applied to\nthe system-controlled interface shown in the operational\nstate.  If the configuration of a user-controlled interface\ncannot be used by the system, the configured interface is\nnot instantiated in the operational state.\n\nSystem-controlled interfaces created by the system are\nalways present in this list in the operational state,\nwhether or not they are configured.', min_elements=0, ordered_by='system', children=[SRC_DNODE_CHILD_23, SRC_DNODE_CHILD_24, SRC_DNODE_CHILD_25, SRC_DNODE_CHILD_26, SRC_DNODE_CHILD_27, SRC_DNODE_CHILD_28, SRC_DNODE_CHILD_29, SRC_DNODE_CHILD_30, SRC_DNODE_CHILD_31, SRC_DNODE_CHILD_32, SRC_DNODE_CHILD_33, SRC_DNODE_CHILD_34, SRC_DNODE_CHILD_35, SRC_DNODE_CHILD_36, SRC_DNODE_CHILD_37, SRC_DNODE_CHILD_38])
+
+SRC_DNODE_CHILD_21 = DContainer(module='ietf-interfaces', namespace='urn:ietf:params:xml:ns:yang:ietf-interfaces', prefix='if', name='interfaces', config=True, description='Interface parameters.', presence=False, children=[SRC_DNODE_CHILD_22])
+
+SRC_DNODE_CHILD_48 = DLeaf(module='ietf-interfaces', namespace='urn:ietf:params:xml:ns:yang:ietf-interfaces', prefix='if', name='name', config=False, description='The name of the interface.\n\nA server implementation MAY map this leaf to the ifName\nMIB object.  Such an implementation needs to use some\nmechanism to handle the differences in size and characters\nallowed between this leaf and ifName.  The definition of\nsuch a mechanism is outside the scope of this document.', mandatory=False, reference='RFC 2863: The Interfaces Group MIB - ifName', status='deprecated', type_=DTypeString(name='string', description=None, reference=None, exts=[], builtin_type='string', default=None, length=None, patterns=[]))
+
+SRC_DNODE_CHILD_49 = DLeaf(module='ietf-interfaces', namespace='urn:ietf:params:xml:ns:yang:ietf-interfaces', prefix='if', name='type', config=False, description='The type of the interface.', mandatory=True, reference='RFC 2863: The Interfaces Group MIB - ifType', status='deprecated', type_=DTypeIdentityref(name='identityref', description=None, reference=None, exts=[], builtin_type='identityref', default=None, identity_bases=[_base_ietf_interfaces_interface_type], identities=_identities))
+
+SRC_DNODE_CHILD_50 = DLeaf(module='ietf-interfaces', namespace='urn:ietf:params:xml:ns:yang:ietf-interfaces', prefix='if', name='admin-status', config=False, description='The desired state of the interface.\n\nThis leaf has the same read semantics as ifAdminStatus.', if_feature=['if-mib'], mandatory=True, reference='RFC 2863: The Interfaces Group MIB - ifAdminStatus', status='deprecated', type_=DTypeEnum(name='enumeration', description=None, reference=None, exts=[], builtin_type='enumeration', default=None, name_to_val={'up':1, 'down':2, 'testing':3}))
+
+SRC_DNODE_CHILD_51 = DLeaf(module='ietf-interfaces', namespace='urn:ietf:params:xml:ns:yang:ietf-interfaces', prefix='if', name='oper-status', config=False, description='The current operational state of the interface.\n\nThis leaf has the same semantics as ifOperStatus.', mandatory=True, reference='RFC 2863: The Interfaces Group MIB - ifOperStatus', status='deprecated', type_=DTypeEnum(name='enumeration', description=None, reference=None, exts=[], builtin_type='enumeration', default=None, name_to_val={'up':1, 'down':2, 'testing':3, 'unknown':4, 'dormant':5, 'not-present':6, 'lower-layer-down':7}))
+
+SRC_DNODE_CHILD_52 = DLeaf(module='ietf-interfaces', namespace='urn:ietf:params:xml:ns:yang:ietf-interfaces', prefix='if', name='last-change', config=False, description='The time the interface entered its current operational\nstate.  If the current state was entered prior to the\nlast re-initialization of the local network management\nsubsystem, then this node is not present.', mandatory=False, reference='RFC 2863: The Interfaces Group MIB - ifLastChange', status='deprecated', type_=DTypeString(name='yang:date-and-time', description="The date-and-time type is a profile of the ISO 8601\nstandard for representation of dates and times using the\nGregorian calendar.  The profile is defined by the\ndate-time production in Section 5.6 of RFC 3339.\n\nThe date-and-time type is compatible with the dateTime XML\nschema type with the following notable exceptions:\n\n(a) The date-and-time type does not allow negative years.\n\n(b) The date-and-time time-offset -00:00 indicates an unknown\n    time zone (see RFC 3339) while -00:00 and +00:00 and Z\n    all represent the same time zone in dateTime.\n\n(c) The canonical format (see below) of data-and-time values\n    differs from the canonical format used by the dateTime XML\n    schema type, which requires all times to be in UTC using\n    the time-offset 'Z'.\n\nThis type is not equivalent to the DateAndTime textual\nconvention of the SMIv2 since RFC 3339 uses a different\nseparator between full-date and full-time and provides\nhigher resolution of time-secfrac.\n\nThe canonical format for date-and-time values with a known time\nzone uses a numeric time zone offset that is calculated using\nthe device's configured known offset to UTC time.  A change of\nthe device's offset to UTC time will cause date-and-time values\nto change accordingly.  Such changes might happen periodically\nin case a server follows automatically daylight saving time\n(DST) time zone offset changes.  The canonical format for\ndate-and-time values with an unknown time zone (usually\nreferring to the notion of local time) uses the time-offset\n-00:00.", reference='RFC 3339: Date and Time on the Internet: Timestamps\nRFC 2579: Textual Conventions for SMIv2\nXSD-TYPES: XML Schema Part 2: Datatypes Second Edition', exts=[], builtin_type='string', default=None, length=None, patterns=[YangPattern(yang_regex='\\d{{4}}-\\d{{2}}-\\d{{2}}T\\d{{2}}:\\d{{2}}:\\d{{2}}(\\.\\d+)?(Z|[\\+\\-]\\d{{2}}:\\d{{2}})', pcre='^(\\p{{Nd}}{{4}}-\\p{{Nd}}{{2}}-\\p{{Nd}}{{2}}T\\p{{Nd}}{{2}}:\\p{{Nd}}{{2}}:\\p{{Nd}}{{2}}(\\.\\p{{Nd}}+)?(Z|[\\+\\-]\\p{{Nd}}{{2}}:\\p{{Nd}}{{2}}))$', invert=False)]))
+
+SRC_DNODE_CHILD_53 = DLeaf(module='ietf-interfaces', namespace='urn:ietf:params:xml:ns:yang:ietf-interfaces', prefix='if', name='if-index', config=False, description='The ifIndex value for the ifEntry represented by this\ninterface.', if_feature=['if-mib'], mandatory=True, reference='RFC 2863: The Interfaces Group MIB - ifIndex', status='deprecated', type_=DTypeIntegerSigned(name='int32', description=None, reference=None, exts=[], builtin_type='int32', default=None, ranges=Ranges([(1, 2147483647)])))
+
+SRC_DNODE_CHILD_54 = DLeaf(module='ietf-interfaces', namespace='urn:ietf:params:xml:ns:yang:ietf-interfaces', prefix='if', name='phys-address', config=False, description="The interface's address at its protocol sub-layer.  For\nexample, for an 802.x interface, this object normally\ncontains a Media Access Control (MAC) address.  The\ninterface's media-specific modules must define the bit\nand byte ordering and the format of the value of this\nobject.  For interfaces that do not have such an address\n(e.g., a serial line), this node is not present.", mandatory=False, reference='RFC 2863: The Interfaces Group MIB - ifPhysAddress', status='deprecated', type_=DTypeString(name='yang:phys-address', description='Represents media- or physical-level addresses represented\nas a sequence octets, each octet represented by two hexadecimal\nnumbers.  Octets are separated by colons.  The canonical\nrepresentation uses lowercase characters.\n\nIn the value set and its semantics, this type is equivalent\nto the PhysAddress textual convention of the SMIv2.', reference='RFC 2579: Textual Conventions for SMIv2', exts=[], builtin_type='string', default=None, length=None, patterns=[YangPattern(yang_regex='([0-9a-fA-F]{{2}}(:[0-9a-fA-F]{{2}})*)?', pcre='^(([0-9a-fA-F]{{2}}(:[0-9a-fA-F]{{2}})*)?)$', invert=False)]))
+
+SRC_DNODE_CHILD_55 = DLeafList(module='ietf-interfaces', namespace='urn:ietf:params:xml:ns:yang:ietf-interfaces', prefix='if', name='higher-layer-if', config=False, description='A list of references to interfaces layered on top of this\ninterface.', min_elements=0, ordered_by='system', reference='RFC 2863: The Interfaces Group MIB - ifStackTable', status='deprecated', type_=DTypeLeafref(name='interface-state-ref', description='This type is used by data models that need to reference\nthe operationally present interfaces.', reference=None, exts=[], builtin_type='leafref', default=None, path=yang.xpath.AbsoluteLocationPath([yang.xpath.NodeTestStep('if', 'interfaces-state', []), yang.xpath.NodeTestStep('if', 'interface', []), yang.xpath.NodeTestStep('if', 'name', [])]), require_instance=False, target_type=DTypeString(name='string', description=None, reference=None, exts=[], builtin_type='string', default=None, length=None, patterns=[])))
+
+SRC_DNODE_CHILD_56 = DLeafList(module='ietf-interfaces', namespace='urn:ietf:params:xml:ns:yang:ietf-interfaces', prefix='if', name='lower-layer-if', config=False, description='A list of references to interfaces layered underneath this\ninterface.', min_elements=0, ordered_by='system', reference='RFC 2863: The Interfaces Group MIB - ifStackTable', status='deprecated', type_=DTypeLeafref(name='interface-state-ref', description='This type is used by data models that need to reference\nthe operationally present interfaces.', reference=None, exts=[], builtin_type='leafref', default=None, path=yang.xpath.AbsoluteLocationPath([yang.xpath.NodeTestStep('if', 'interfaces-state', []), yang.xpath.NodeTestStep('if', 'interface', []), yang.xpath.NodeTestStep('if', 'name', [])]), require_instance=False, target_type=DTypeString(name='string', description=None, reference=None, exts=[], builtin_type='string', default=None, length=None, patterns=[])))
+
+SRC_DNODE_CHILD_57 = DLeaf(module='ietf-interfaces', namespace='urn:ietf:params:xml:ns:yang:ietf-interfaces', prefix='if', name='speed', config=False, description="An estimate of the interface's current bandwidth in bits\nper second.  For interfaces that do not vary in\nbandwidth or for those where no accurate estimation can\n\nbe made, this node should contain the nominal bandwidth.\nFor interfaces that have no concept of bandwidth, this\nnode is not present.", mandatory=False, reference='RFC 2863: The Interfaces Group MIB -\n          ifSpeed, ifHighSpeed', status='deprecated', type_=DTypeIntegerUnsigned(name='yang:gauge64', description='The gauge64 type represents a non-negative integer, which\nmay increase or decrease, but shall never exceed a maximum\nvalue, nor fall below a minimum value.  The maximum value\ncannot be greater than 2^64-1 (18446744073709551615), and\nthe minimum value cannot be smaller than 0.  The value of\na gauge64 has its maximum value whenever the information\nbeing modeled is greater than or equal to its maximum\nvalue, and has its minimum value whenever the information\nbeing modeled is smaller than or equal to its minimum value.\nIf the information being modeled subsequently decreases\nbelow (increases above) the maximum (minimum) value, the\ngauge64 also decreases (increases).\n\nIn the value set and its semantics, this type is equivalent\nto the CounterBasedGauge64 SMIv2 textual convention defined\nin RFC 2856', reference='RFC 2856: Textual Conventions for Additional High Capacity\n          Data Types', exts=[], builtin_type='uint64', default=None, ranges=Ranges([(0, 18446744073709551615)])), units='bits/second')
+
+SRC_DNODE_CHILD_58 = DContainer(module='ietf-interfaces', namespace='urn:ietf:params:xml:ns:yang:ietf-interfaces', prefix='if', name='statistics', config=False, description='A collection of interface-related statistics objects.', presence=False, status='deprecated', children=[
+    DLeaf(module='ietf-interfaces', namespace='urn:ietf:params:xml:ns:yang:ietf-interfaces', prefix='if', name='discontinuity-time', config=False, description="The time on the most recent occasion at which any one or\nmore of this interface's counters suffered a\ndiscontinuity.  If no such discontinuities have occurred\nsince the last re-initialization of the local management\nsubsystem, then this node contains the time the local\nmanagement subsystem re-initialized itself.", mandatory=True, status='deprecated', type_=DTypeString(name='yang:date-and-time', description="The date-and-time type is a profile of the ISO 8601\nstandard for representation of dates and times using the\nGregorian calendar.  The profile is defined by the\ndate-time production in Section 5.6 of RFC 3339.\n\nThe date-and-time type is compatible with the dateTime XML\nschema type with the following notable exceptions:\n\n(a) The date-and-time type does not allow negative years.\n\n(b) The date-and-time time-offset -00:00 indicates an unknown\n    time zone (see RFC 3339) while -00:00 and +00:00 and Z\n    all represent the same time zone in dateTime.\n\n(c) The canonical format (see below) of data-and-time values\n    differs from the canonical format used by the dateTime XML\n    schema type, which requires all times to be in UTC using\n    the time-offset 'Z'.\n\nThis type is not equivalent to the DateAndTime textual\nconvention of the SMIv2 since RFC 3339 uses a different\nseparator between full-date and full-time and provides\nhigher resolution of time-secfrac.\n\nThe canonical format for date-and-time values with a known time\nzone uses a numeric time zone offset that is calculated using\nthe device's configured known offset to UTC time.  A change of\nthe device's offset to UTC time will cause date-and-time values\nto change accordingly.  Such changes might happen periodically\nin case a server follows automatically daylight saving time\n(DST) time zone offset changes.  The canonical format for\ndate-and-time values with an unknown time zone (usually\nreferring to the notion of local time) uses the time-offset\n-00:00.", reference='RFC 3339: Date and Time on the Internet: Timestamps\nRFC 2579: Textual Conventions for SMIv2\nXSD-TYPES: XML Schema Part 2: Datatypes Second Edition', exts=[], builtin_type='string', default=None, length=None, patterns=[YangPattern(yang_regex='\\d{{4}}-\\d{{2}}-\\d{{2}}T\\d{{2}}:\\d{{2}}:\\d{{2}}(\\.\\d+)?(Z|[\\+\\-]\\d{{2}}:\\d{{2}})', pcre='^(\\p{{Nd}}{{4}}-\\p{{Nd}}{{2}}-\\p{{Nd}}{{2}}T\\p{{Nd}}{{2}}:\\p{{Nd}}{{2}}:\\p{{Nd}}{{2}}(\\.\\p{{Nd}}+)?(Z|[\\+\\-]\\p{{Nd}}{{2}}:\\p{{Nd}}{{2}}))$', invert=False)])),
+    DLeaf(module='ietf-interfaces', namespace='urn:ietf:params:xml:ns:yang:ietf-interfaces', prefix='if', name='in-octets', config=False, description="The total number of octets received on the interface,\nincluding framing characters.\n\nDiscontinuities in the value of this counter can occur\nat re-initialization of the management system and at\nother times as indicated by the value of\n'discontinuity-time'.", mandatory=False, reference='RFC 2863: The Interfaces Group MIB - ifHCInOctets', status='deprecated', type_=DTypeIntegerUnsigned(name='yang:counter64', description="The counter64 type represents a non-negative integer\nthat monotonically increases until it reaches a\nmaximum value of 2^64-1 (18446744073709551615 decimal),\nwhen it wraps around and starts increasing again from zero.\n\nCounters have no defined 'initial' value, and thus, a\nsingle value of a counter has (in general) no information\ncontent.  Discontinuities in the monotonically increasing\nvalue normally occur at re-initialization of the\nmanagement system, and at other times as specified in the\ndescription of a schema node using this type.  If such\nother times can occur, for example, the creation of\na schema node of type counter64 at times other than\nre-initialization, then a corresponding schema node\nshould be defined, with an appropriate type, to indicate\nthe last discontinuity.\n\nThe counter64 type should not be used for configuration\nschema nodes.  A default statement SHOULD NOT be used in\ncombination with the type counter64.\n\nIn the value set and its semantics, this type is equivalent\nto the Counter64 type of the SMIv2.", reference='RFC 2578: Structure of Management Information Version 2\n          (SMIv2)', exts=[], builtin_type='uint64', default=None, ranges=Ranges([(0, 18446744073709551615)]))),
+    DLeaf(module='ietf-interfaces', namespace='urn:ietf:params:xml:ns:yang:ietf-interfaces', prefix='if', name='in-unicast-pkts', config=False, description="The number of packets, delivered by this sub-layer to a\nhigher (sub-)layer, that were not addressed to a\nmulticast or broadcast address at this sub-layer.\nDiscontinuities in the value of this counter can occur\nat re-initialization of the management system and at\nother times as indicated by the value of\n'discontinuity-time'.", mandatory=False, reference='RFC 2863: The Interfaces Group MIB - ifHCInUcastPkts', status='deprecated', type_=DTypeIntegerUnsigned(name='yang:counter64', description="The counter64 type represents a non-negative integer\nthat monotonically increases until it reaches a\nmaximum value of 2^64-1 (18446744073709551615 decimal),\nwhen it wraps around and starts increasing again from zero.\n\nCounters have no defined 'initial' value, and thus, a\nsingle value of a counter has (in general) no information\ncontent.  Discontinuities in the monotonically increasing\nvalue normally occur at re-initialization of the\nmanagement system, and at other times as specified in the\ndescription of a schema node using this type.  If such\nother times can occur, for example, the creation of\na schema node of type counter64 at times other than\nre-initialization, then a corresponding schema node\nshould be defined, with an appropriate type, to indicate\nthe last discontinuity.\n\nThe counter64 type should not be used for configuration\nschema nodes.  A default statement SHOULD NOT be used in\ncombination with the type counter64.\n\nIn the value set and its semantics, this type is equivalent\nto the Counter64 type of the SMIv2.", reference='RFC 2578: Structure of Management Information Version 2\n          (SMIv2)', exts=[], builtin_type='uint64', default=None, ranges=Ranges([(0, 18446744073709551615)]))),
+    DLeaf(module='ietf-interfaces', namespace='urn:ietf:params:xml:ns:yang:ietf-interfaces', prefix='if', name='in-broadcast-pkts', config=False, description="The number of packets, delivered by this sub-layer to a\nhigher (sub-)layer, that were addressed to a broadcast\naddress at this sub-layer.\n\nDiscontinuities in the value of this counter can occur\nat re-initialization of the management system and at\nother times as indicated by the value of\n'discontinuity-time'.", mandatory=False, reference='RFC 2863: The Interfaces Group MIB -\n          ifHCInBroadcastPkts', status='deprecated', type_=DTypeIntegerUnsigned(name='yang:counter64', description="The counter64 type represents a non-negative integer\nthat monotonically increases until it reaches a\nmaximum value of 2^64-1 (18446744073709551615 decimal),\nwhen it wraps around and starts increasing again from zero.\n\nCounters have no defined 'initial' value, and thus, a\nsingle value of a counter has (in general) no information\ncontent.  Discontinuities in the monotonically increasing\nvalue normally occur at re-initialization of the\nmanagement system, and at other times as specified in the\ndescription of a schema node using this type.  If such\nother times can occur, for example, the creation of\na schema node of type counter64 at times other than\nre-initialization, then a corresponding schema node\nshould be defined, with an appropriate type, to indicate\nthe last discontinuity.\n\nThe counter64 type should not be used for configuration\nschema nodes.  A default statement SHOULD NOT be used in\ncombination with the type counter64.\n\nIn the value set and its semantics, this type is equivalent\nto the Counter64 type of the SMIv2.", reference='RFC 2578: Structure of Management Information Version 2\n          (SMIv2)', exts=[], builtin_type='uint64', default=None, ranges=Ranges([(0, 18446744073709551615)]))),
+    DLeaf(module='ietf-interfaces', namespace='urn:ietf:params:xml:ns:yang:ietf-interfaces', prefix='if', name='in-multicast-pkts', config=False, description="The number of packets, delivered by this sub-layer to a\nhigher (sub-)layer, that were addressed to a multicast\naddress at this sub-layer.  For a MAC-layer protocol,\nthis includes both Group and Functional addresses.\n\nDiscontinuities in the value of this counter can occur\nat re-initialization of the management system and at\nother times as indicated by the value of\n'discontinuity-time'.", mandatory=False, reference='RFC 2863: The Interfaces Group MIB -\n          ifHCInMulticastPkts', status='deprecated', type_=DTypeIntegerUnsigned(name='yang:counter64', description="The counter64 type represents a non-negative integer\nthat monotonically increases until it reaches a\nmaximum value of 2^64-1 (18446744073709551615 decimal),\nwhen it wraps around and starts increasing again from zero.\n\nCounters have no defined 'initial' value, and thus, a\nsingle value of a counter has (in general) no information\ncontent.  Discontinuities in the monotonically increasing\nvalue normally occur at re-initialization of the\nmanagement system, and at other times as specified in the\ndescription of a schema node using this type.  If such\nother times can occur, for example, the creation of\na schema node of type counter64 at times other than\nre-initialization, then a corresponding schema node\nshould be defined, with an appropriate type, to indicate\nthe last discontinuity.\n\nThe counter64 type should not be used for configuration\nschema nodes.  A default statement SHOULD NOT be used in\ncombination with the type counter64.\n\nIn the value set and its semantics, this type is equivalent\nto the Counter64 type of the SMIv2.", reference='RFC 2578: Structure of Management Information Version 2\n          (SMIv2)', exts=[], builtin_type='uint64', default=None, ranges=Ranges([(0, 18446744073709551615)]))),
+    DLeaf(module='ietf-interfaces', namespace='urn:ietf:params:xml:ns:yang:ietf-interfaces', prefix='if', name='in-discards', config=False, description="The number of inbound packets that were chosen to be\ndiscarded even though no errors had been detected to\nprevent their being deliverable to a higher-layer\nprotocol.  One possible reason for discarding such a\npacket could be to free up buffer space.\n\nDiscontinuities in the value of this counter can occur\nat re-initialization of the management system and at\nother times as indicated by the value of\n'discontinuity-time'.", mandatory=False, reference='RFC 2863: The Interfaces Group MIB - ifInDiscards', status='deprecated', type_=DTypeIntegerUnsigned(name='yang:counter32', description="The counter32 type represents a non-negative integer\nthat monotonically increases until it reaches a\nmaximum value of 2^32-1 (4294967295 decimal), when it\nwraps around and starts increasing again from zero.\n\nCounters have no defined 'initial' value, and thus, a\nsingle value of a counter has (in general) no information\ncontent.  Discontinuities in the monotonically increasing\nvalue normally occur at re-initialization of the\nmanagement system, and at other times as specified in the\ndescription of a schema node using this type.  If such\nother times can occur, for example, the creation of\na schema node of type counter32 at times other than\nre-initialization, then a corresponding schema node\nshould be defined, with an appropriate type, to indicate\nthe last discontinuity.\n\nThe counter32 type should not be used for configuration\nschema nodes.  A default statement SHOULD NOT be used in\ncombination with the type counter32.\n\nIn the value set and its semantics, this type is equivalent\nto the Counter32 type of the SMIv2.", reference='RFC 2578: Structure of Management Information Version 2\n          (SMIv2)', exts=[], builtin_type='uint32', default=None, ranges=Ranges([(0, 4294967295)]))),
+    DLeaf(module='ietf-interfaces', namespace='urn:ietf:params:xml:ns:yang:ietf-interfaces', prefix='if', name='in-errors', config=False, description="For packet-oriented interfaces, the number of inbound\npackets that contained errors preventing them from being\ndeliverable to a higher-layer protocol.  For character-\noriented or fixed-length interfaces, the number of\ninbound transmission units that contained errors\npreventing them from being deliverable to a higher-layer\nprotocol.\n\nDiscontinuities in the value of this counter can occur\nat re-initialization of the management system and at\nother times as indicated by the value of\n'discontinuity-time'.", mandatory=False, reference='RFC 2863: The Interfaces Group MIB - ifInErrors', status='deprecated', type_=DTypeIntegerUnsigned(name='yang:counter32', description="The counter32 type represents a non-negative integer\nthat monotonically increases until it reaches a\nmaximum value of 2^32-1 (4294967295 decimal), when it\nwraps around and starts increasing again from zero.\n\nCounters have no defined 'initial' value, and thus, a\nsingle value of a counter has (in general) no information\ncontent.  Discontinuities in the monotonically increasing\nvalue normally occur at re-initialization of the\nmanagement system, and at other times as specified in the\ndescription of a schema node using this type.  If such\nother times can occur, for example, the creation of\na schema node of type counter32 at times other than\nre-initialization, then a corresponding schema node\nshould be defined, with an appropriate type, to indicate\nthe last discontinuity.\n\nThe counter32 type should not be used for configuration\nschema nodes.  A default statement SHOULD NOT be used in\ncombination with the type counter32.\n\nIn the value set and its semantics, this type is equivalent\nto the Counter32 type of the SMIv2.", reference='RFC 2578: Structure of Management Information Version 2\n          (SMIv2)', exts=[], builtin_type='uint32', default=None, ranges=Ranges([(0, 4294967295)]))),
+    DLeaf(module='ietf-interfaces', namespace='urn:ietf:params:xml:ns:yang:ietf-interfaces', prefix='if', name='in-unknown-protos', config=False, description="For packet-oriented interfaces, the number of packets\nreceived via the interface that were discarded because\nof an unknown or unsupported protocol.  For\ncharacter-oriented or fixed-length interfaces that\nsupport protocol multiplexing, the number of\ntransmission units received via the interface that were\ndiscarded because of an unknown or unsupported protocol.\nFor any interface that does not support protocol\nmultiplexing, this counter is not present.\nDiscontinuities in the value of this counter can occur\nat re-initialization of the management system and at\nother times as indicated by the value of\n'discontinuity-time'.", mandatory=False, reference='RFC 2863: The Interfaces Group MIB - ifInUnknownProtos', status='deprecated', type_=DTypeIntegerUnsigned(name='yang:counter32', description="The counter32 type represents a non-negative integer\nthat monotonically increases until it reaches a\nmaximum value of 2^32-1 (4294967295 decimal), when it\nwraps around and starts increasing again from zero.\n\nCounters have no defined 'initial' value, and thus, a\nsingle value of a counter has (in general) no information\ncontent.  Discontinuities in the monotonically increasing\nvalue normally occur at re-initialization of the\nmanagement system, and at other times as specified in the\ndescription of a schema node using this type.  If such\nother times can occur, for example, the creation of\na schema node of type counter32 at times other than\nre-initialization, then a corresponding schema node\nshould be defined, with an appropriate type, to indicate\nthe last discontinuity.\n\nThe counter32 type should not be used for configuration\nschema nodes.  A default statement SHOULD NOT be used in\ncombination with the type counter32.\n\nIn the value set and its semantics, this type is equivalent\nto the Counter32 type of the SMIv2.", reference='RFC 2578: Structure of Management Information Version 2\n          (SMIv2)', exts=[], builtin_type='uint32', default=None, ranges=Ranges([(0, 4294967295)]))),
+    DLeaf(module='ietf-interfaces', namespace='urn:ietf:params:xml:ns:yang:ietf-interfaces', prefix='if', name='out-octets', config=False, description="The total number of octets transmitted out of the\ninterface, including framing characters.\n\nDiscontinuities in the value of this counter can occur\nat re-initialization of the management system and at\nother times as indicated by the value of\n'discontinuity-time'.", mandatory=False, reference='RFC 2863: The Interfaces Group MIB - ifHCOutOctets', status='deprecated', type_=DTypeIntegerUnsigned(name='yang:counter64', description="The counter64 type represents a non-negative integer\nthat monotonically increases until it reaches a\nmaximum value of 2^64-1 (18446744073709551615 decimal),\nwhen it wraps around and starts increasing again from zero.\n\nCounters have no defined 'initial' value, and thus, a\nsingle value of a counter has (in general) no information\ncontent.  Discontinuities in the monotonically increasing\nvalue normally occur at re-initialization of the\nmanagement system, and at other times as specified in the\ndescription of a schema node using this type.  If such\nother times can occur, for example, the creation of\na schema node of type counter64 at times other than\nre-initialization, then a corresponding schema node\nshould be defined, with an appropriate type, to indicate\nthe last discontinuity.\n\nThe counter64 type should not be used for configuration\nschema nodes.  A default statement SHOULD NOT be used in\ncombination with the type counter64.\n\nIn the value set and its semantics, this type is equivalent\nto the Counter64 type of the SMIv2.", reference='RFC 2578: Structure of Management Information Version 2\n          (SMIv2)', exts=[], builtin_type='uint64', default=None, ranges=Ranges([(0, 18446744073709551615)]))),
+    DLeaf(module='ietf-interfaces', namespace='urn:ietf:params:xml:ns:yang:ietf-interfaces', prefix='if', name='out-unicast-pkts', config=False, description="The total number of packets that higher-level protocols\nrequested be transmitted and that were not addressed\nto a multicast or broadcast address at this sub-layer,\nincluding those that were discarded or not sent.\n\nDiscontinuities in the value of this counter can occur\nat re-initialization of the management system and at\nother times as indicated by the value of\n'discontinuity-time'.", mandatory=False, reference='RFC 2863: The Interfaces Group MIB - ifHCOutUcastPkts', status='deprecated', type_=DTypeIntegerUnsigned(name='yang:counter64', description="The counter64 type represents a non-negative integer\nthat monotonically increases until it reaches a\nmaximum value of 2^64-1 (18446744073709551615 decimal),\nwhen it wraps around and starts increasing again from zero.\n\nCounters have no defined 'initial' value, and thus, a\nsingle value of a counter has (in general) no information\ncontent.  Discontinuities in the monotonically increasing\nvalue normally occur at re-initialization of the\nmanagement system, and at other times as specified in the\ndescription of a schema node using this type.  If such\nother times can occur, for example, the creation of\na schema node of type counter64 at times other than\nre-initialization, then a corresponding schema node\nshould be defined, with an appropriate type, to indicate\nthe last discontinuity.\n\nThe counter64 type should not be used for configuration\nschema nodes.  A default statement SHOULD NOT be used in\ncombination with the type counter64.\n\nIn the value set and its semantics, this type is equivalent\nto the Counter64 type of the SMIv2.", reference='RFC 2578: Structure of Management Information Version 2\n          (SMIv2)', exts=[], builtin_type='uint64', default=None, ranges=Ranges([(0, 18446744073709551615)]))),
+    DLeaf(module='ietf-interfaces', namespace='urn:ietf:params:xml:ns:yang:ietf-interfaces', prefix='if', name='out-broadcast-pkts', config=False, description="The total number of packets that higher-level protocols\nrequested be transmitted and that were addressed to a\nbroadcast address at this sub-layer, including those\nthat were discarded or not sent.\n\nDiscontinuities in the value of this counter can occur\nat re-initialization of the management system and at\nother times as indicated by the value of\n'discontinuity-time'.", mandatory=False, reference='RFC 2863: The Interfaces Group MIB -\n          ifHCOutBroadcastPkts', status='deprecated', type_=DTypeIntegerUnsigned(name='yang:counter64', description="The counter64 type represents a non-negative integer\nthat monotonically increases until it reaches a\nmaximum value of 2^64-1 (18446744073709551615 decimal),\nwhen it wraps around and starts increasing again from zero.\n\nCounters have no defined 'initial' value, and thus, a\nsingle value of a counter has (in general) no information\ncontent.  Discontinuities in the monotonically increasing\nvalue normally occur at re-initialization of the\nmanagement system, and at other times as specified in the\ndescription of a schema node using this type.  If such\nother times can occur, for example, the creation of\na schema node of type counter64 at times other than\nre-initialization, then a corresponding schema node\nshould be defined, with an appropriate type, to indicate\nthe last discontinuity.\n\nThe counter64 type should not be used for configuration\nschema nodes.  A default statement SHOULD NOT be used in\ncombination with the type counter64.\n\nIn the value set and its semantics, this type is equivalent\nto the Counter64 type of the SMIv2.", reference='RFC 2578: Structure of Management Information Version 2\n          (SMIv2)', exts=[], builtin_type='uint64', default=None, ranges=Ranges([(0, 18446744073709551615)]))),
+    DLeaf(module='ietf-interfaces', namespace='urn:ietf:params:xml:ns:yang:ietf-interfaces', prefix='if', name='out-multicast-pkts', config=False, description="The total number of packets that higher-level protocols\nrequested be transmitted and that were addressed to a\nmulticast address at this sub-layer, including those\nthat were discarded or not sent.  For a MAC-layer\nprotocol, this includes both Group and Functional\naddresses.\n\nDiscontinuities in the value of this counter can occur\nat re-initialization of the management system and at\nother times as indicated by the value of\n'discontinuity-time'.", mandatory=False, reference='RFC 2863: The Interfaces Group MIB -\n          ifHCOutMulticastPkts', status='deprecated', type_=DTypeIntegerUnsigned(name='yang:counter64', description="The counter64 type represents a non-negative integer\nthat monotonically increases until it reaches a\nmaximum value of 2^64-1 (18446744073709551615 decimal),\nwhen it wraps around and starts increasing again from zero.\n\nCounters have no defined 'initial' value, and thus, a\nsingle value of a counter has (in general) no information\ncontent.  Discontinuities in the monotonically increasing\nvalue normally occur at re-initialization of the\nmanagement system, and at other times as specified in the\ndescription of a schema node using this type.  If such\nother times can occur, for example, the creation of\na schema node of type counter64 at times other than\nre-initialization, then a corresponding schema node\nshould be defined, with an appropriate type, to indicate\nthe last discontinuity.\n\nThe counter64 type should not be used for configuration\nschema nodes.  A default statement SHOULD NOT be used in\ncombination with the type counter64.\n\nIn the value set and its semantics, this type is equivalent\nto the Counter64 type of the SMIv2.", reference='RFC 2578: Structure of Management Information Version 2\n          (SMIv2)', exts=[], builtin_type='uint64', default=None, ranges=Ranges([(0, 18446744073709551615)]))),
+    DLeaf(module='ietf-interfaces', namespace='urn:ietf:params:xml:ns:yang:ietf-interfaces', prefix='if', name='out-discards', config=False, description="The number of outbound packets that were chosen to be\ndiscarded even though no errors had been detected to\nprevent their being transmitted.  One possible reason\nfor discarding such a packet could be to free up buffer\nspace.\n\nDiscontinuities in the value of this counter can occur\nat re-initialization of the management system and at\nother times as indicated by the value of\n'discontinuity-time'.", mandatory=False, reference='RFC 2863: The Interfaces Group MIB - ifOutDiscards', status='deprecated', type_=DTypeIntegerUnsigned(name='yang:counter32', description="The counter32 type represents a non-negative integer\nthat monotonically increases until it reaches a\nmaximum value of 2^32-1 (4294967295 decimal), when it\nwraps around and starts increasing again from zero.\n\nCounters have no defined 'initial' value, and thus, a\nsingle value of a counter has (in general) no information\ncontent.  Discontinuities in the monotonically increasing\nvalue normally occur at re-initialization of the\nmanagement system, and at other times as specified in the\ndescription of a schema node using this type.  If such\nother times can occur, for example, the creation of\na schema node of type counter32 at times other than\nre-initialization, then a corresponding schema node\nshould be defined, with an appropriate type, to indicate\nthe last discontinuity.\n\nThe counter32 type should not be used for configuration\nschema nodes.  A default statement SHOULD NOT be used in\ncombination with the type counter32.\n\nIn the value set and its semantics, this type is equivalent\nto the Counter32 type of the SMIv2.", reference='RFC 2578: Structure of Management Information Version 2\n          (SMIv2)', exts=[], builtin_type='uint32', default=None, ranges=Ranges([(0, 4294967295)]))),
+    DLeaf(module='ietf-interfaces', namespace='urn:ietf:params:xml:ns:yang:ietf-interfaces', prefix='if', name='out-errors', config=False, description="For packet-oriented interfaces, the number of outbound\npackets that could not be transmitted because of errors.\nFor character-oriented or fixed-length interfaces, the\nnumber of outbound transmission units that could not be\ntransmitted because of errors.\n\nDiscontinuities in the value of this counter can occur\nat re-initialization of the management system and at\nother times as indicated by the value of\n'discontinuity-time'.", mandatory=False, reference='RFC 2863: The Interfaces Group MIB - ifOutErrors', status='deprecated', type_=DTypeIntegerUnsigned(name='yang:counter32', description="The counter32 type represents a non-negative integer\nthat monotonically increases until it reaches a\nmaximum value of 2^32-1 (4294967295 decimal), when it\nwraps around and starts increasing again from zero.\n\nCounters have no defined 'initial' value, and thus, a\nsingle value of a counter has (in general) no information\ncontent.  Discontinuities in the monotonically increasing\nvalue normally occur at re-initialization of the\nmanagement system, and at other times as specified in the\ndescription of a schema node using this type.  If such\nother times can occur, for example, the creation of\na schema node of type counter32 at times other than\nre-initialization, then a corresponding schema node\nshould be defined, with an appropriate type, to indicate\nthe last discontinuity.\n\nThe counter32 type should not be used for configuration\nschema nodes.  A default statement SHOULD NOT be used in\ncombination with the type counter32.\n\nIn the value set and its semantics, this type is equivalent\nto the Counter32 type of the SMIv2.", reference='RFC 2578: Structure of Management Information Version 2\n          (SMIv2)', exts=[], builtin_type='uint32', default=None, ranges=Ranges([(0, 4294967295)])))
+])
+
+SRC_DNODE_CHILD_59 = DContainer(module='ietf-ip', namespace='urn:ietf:params:xml:ns:yang:ietf-ip', prefix='ip', name='ipv4', config=False, description='Interface-specific parameters for the IPv4 address family.', presence=True, status='deprecated', children=[
+    DLeaf(module='ietf-ip', namespace='urn:ietf:params:xml:ns:yang:ietf-ip', prefix='ip', name='forwarding', config=False, description='Indicates whether IPv4 packet forwarding is enabled or\ndisabled on this interface.', mandatory=False, status='deprecated', type_=DTypeBoolean(name='boolean', description=None, reference=None, exts=[], builtin_type='boolean', default=None)),
+    DLeaf(module='ietf-ip', namespace='urn:ietf:params:xml:ns:yang:ietf-ip', prefix='ip', name='mtu', config=False, description='The size, in octets, of the largest IPv4 packet that the\ninterface will send and receive.', mandatory=False, reference='RFC 791: Internet Protocol', status='deprecated', type_=DTypeIntegerUnsigned(name='uint16', description=None, reference=None, exts=[], builtin_type='uint16', default=None, ranges=Ranges([(68, 65535)])), units='octets'),
+    DList(module='ietf-ip', namespace='urn:ietf:params:xml:ns:yang:ietf-ip', prefix='ip', name='address', key=['ip'], config=False, description='The list of IPv4 addresses on the interface.', min_elements=0, ordered_by='system', status='deprecated', children=[
+        DLeaf(module='ietf-ip', namespace='urn:ietf:params:xml:ns:yang:ietf-ip', prefix='ip', name='ip', config=False, description='The IPv4 address on the interface.', mandatory=False, status='deprecated', type_=DTypeString(name='inet:ipv4-address-no-zone', description='An IPv4 address without a zone index.  This type, derived from\nipv4-address, may be used in situations where the zone is\nknown from the context and hence no zone index is needed.', reference=None, exts=[], builtin_type='string', default=None, length=None, patterns=[YangPattern(yang_regex='(([0-9]|[1-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5])\\.){{3}}([0-9]|[1-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5])(%[\\p{{N}}\\p{{L}}]+)?', pcre='^((([0-9]|[1-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5])\\.){{3}}([0-9]|[1-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5])(%[\\p{{N}}\\p{{L}}]+)?)$', invert=False), YangPattern(yang_regex='[0-9\\.]*', pcre='^([0-9\\.]*)$', invert=False)])),
+        DLeaf(module='ietf-ip', namespace='urn:ietf:params:xml:ns:yang:ietf-ip', prefix='ip', name='prefix-length', config=False, description='The length of the subnet prefix.', mandatory=False, status='deprecated', type_=DTypeIntegerUnsigned(name='uint8', description=None, reference=None, exts=[], builtin_type='uint8', default=None, ranges=Ranges([(0, 32)]))),
+        DLeaf(module='ietf-ip', namespace='urn:ietf:params:xml:ns:yang:ietf-ip', prefix='ip', name='netmask', config=False, description='The subnet specified as a netmask.', if_feature=[
+'ipv4-non-contiguous-netmasks'
+            ], mandatory=False, status='deprecated', type_=DTypeString(name='yang:dotted-quad', description="An unsigned 32-bit number expressed in the dotted-quad\nnotation, i.e., four octets written as decimal numbers\nand separated with the '.' (full stop) character.", reference=None, exts=[], builtin_type='string', default=None, length=None, patterns=[YangPattern(yang_regex='(([0-9]|[1-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5])\\.){{3}}([0-9]|[1-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5])', pcre='^((([0-9]|[1-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5])\\.){{3}}([0-9]|[1-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5]))$', invert=False)])),
+        DLeaf(module='ietf-ip', namespace='urn:ietf:params:xml:ns:yang:ietf-ip', prefix='ip', name='origin', config=False, description='The origin of this address.', mandatory=False, status='deprecated', type_=DTypeEnum(name='ip-address-origin', description='The origin of an address.', reference=None, exts=[], builtin_type='enumeration', default=None, name_to_val={'other':0, 'static':1, 'dhcp':2, 'link-layer':3, 'random':4}))
     ]),
-    DList(module='ietf-ip', namespace='urn:ietf:params:xml:ns:yang:ietf-ip', prefix='ip', name='neighbor', key=['ip'], config=True, description='A list of mappings from IPv6 addresses to\nlink-layer addresses.\n\nEntries in this list in the intended configuration are\nused as static entries in the Neighbor Cache.\n\nIn the operational state, this list represents the\nNeighbor Cache.', min_elements=0, ordered_by='system', reference='RFC 4861: Neighbor Discovery for IP version 6 (IPv6)', children=[
-        DLeaf(module='ietf-ip', namespace='urn:ietf:params:xml:ns:yang:ietf-ip', prefix='ip', name='ip', config=True, description='The IPv6 address of the neighbor node.', mandatory=False, type_=DTypeString(name='inet:ipv6-address-no-zone', description='An IPv6 address without a zone index.  This type, derived from\nipv6-address, may be used in situations where the zone is\nknown from the context and hence no zone index is needed.', reference='RFC 4291: IP Version 6 Addressing Architecture\nRFC 4007: IPv6 Scoped Address Architecture\nRFC 5952: A Recommendation for IPv6 Address Text\n          Representation', exts=[], builtin_type='string', default=None, length=None, patterns=[YangPattern(yang_regex='((:|[0-9a-fA-F]{{0,4}}):)([0-9a-fA-F]{{0,4}}:){{0,5}}((([0-9a-fA-F]{{0,4}}:)?(:|[0-9a-fA-F]{{0,4}}))|(((25[0-5]|2[0-4][0-9]|[01]?[0-9]?[0-9])\\.){{3}}(25[0-5]|2[0-4][0-9]|[01]?[0-9]?[0-9])))(%[\\p{{N}}\\p{{L}}]+)?', pcre='^(((:|[0-9a-fA-F]{{0,4}}):)([0-9a-fA-F]{{0,4}}:){{0,5}}((([0-9a-fA-F]{{0,4}}:)?(:|[0-9a-fA-F]{{0,4}}))|(((25[0-5]|2[0-4][0-9]|[01]?[0-9]?[0-9])\\.){{3}}(25[0-5]|2[0-4][0-9]|[01]?[0-9]?[0-9])))(%[\\p{{N}}\\p{{L}}]+)?)$', invert=False), YangPattern(yang_regex='(([^:]+:){{6}}(([^:]+:[^:]+)|(.*\\..*)))|((([^:]+:)*[^:]+)?::(([^:]+:)*[^:]+)?)(%.+)?', pcre='^((([^\\:]+:){{6}}(([^\\:]+:[^\\:]+)|(.*\\..*)))|((([^\\:]+:)*[^\\:]+)?::(([^\\:]+:)*[^\\:]+)?)(%.+)?)$', invert=False), YangPattern(yang_regex='[0-9a-fA-F:\\.]*', pcre='^([0-9a-fA-F:\\.]*)$', invert=False)])),
-        DLeaf(module='ietf-ip', namespace='urn:ietf:params:xml:ns:yang:ietf-ip', prefix='ip', name='link-layer-address', config=True, description="The link-layer address of the neighbor node.\n\nIn the operational state, if the neighbor's 'state' leaf\nis 'incomplete', this leaf is not instantiated.", mandatory=True, type_=DTypeString(name='yang:phys-address', description='Represents media- or physical-level addresses represented\nas a sequence octets, each octet represented by two hexadecimal\nnumbers.  Octets are separated by colons.  The canonical\nrepresentation uses lowercase characters.\n\nIn the value set and its semantics, this type is equivalent\nto the PhysAddress textual convention of the SMIv2.', reference='RFC 2579: Textual Conventions for SMIv2', exts=[], builtin_type='string', default=None, length=None, patterns=[YangPattern(yang_regex='([0-9a-fA-F]{{2}}(:[0-9a-fA-F]{{2}})*)?', pcre='^(([0-9a-fA-F]{{2}}(:[0-9a-fA-F]{{2}})*)?)$', invert=False)]))
-    ]),
-    DLeaf(module='ietf-ip', namespace='urn:ietf:params:xml:ns:yang:ietf-ip', prefix='ip', name='dup-addr-detect-transmits', config=True, description='The number of consecutive Neighbor Solicitation messages\nsent while performing Duplicate Address Detection on a\ntentative address.  A value of zero indicates that\nDuplicate Address Detection is not performed on\ntentative addresses.  A value of one indicates a single\ntransmission with no follow-up retransmissions.', default='1', mandatory=False, reference='RFC 4862: IPv6 Stateless Address Autoconfiguration', type_=DTypeIntegerUnsigned(name='uint32', description=None, reference=None, exts=[], builtin_type='uint32', default=None, ranges=Ranges([(0, 4294967295)]))),
-    DContainer(module='ietf-ip', namespace='urn:ietf:params:xml:ns:yang:ietf-ip', prefix='ip', name='autoconf', config=True, description='Parameters to control the autoconfiguration of IPv6\naddresses, as described in RFC 4862.', presence=False, reference='RFC 4862: IPv6 Stateless Address Autoconfiguration', children=[
-        DLeaf(module='ietf-ip', namespace='urn:ietf:params:xml:ns:yang:ietf-ip', prefix='ip', name='create-global-addresses', config=True, description='If enabled, the host creates global addresses as\ndescribed in RFC 4862.', default='true', mandatory=False, reference='RFC 4862: IPv6 Stateless Address Autoconfiguration\n          Section 5.5', type_=DTypeBoolean(name='boolean', description=None, reference=None, exts=[], builtin_type='boolean', default=None)),
-        DLeaf(module='ietf-ip', namespace='urn:ietf:params:xml:ns:yang:ietf-ip', prefix='ip', name='create-temporary-addresses', config=True, description='If enabled, the host creates temporary addresses as\ndescribed in RFC 4941.', default='false', if_feature=[
-'ipv6-privacy-autoconf'
-            ], mandatory=False, reference='RFC 4941: Privacy Extensions for Stateless Address\n          Autoconfiguration in IPv6', type_=DTypeBoolean(name='boolean', description=None, reference=None, exts=[], builtin_type='boolean', default=None)),
-        DLeaf(module='ietf-ip', namespace='urn:ietf:params:xml:ns:yang:ietf-ip', prefix='ip', name='temporary-valid-lifetime', config=True, description='The time period during which the temporary address\nis valid.', default='604800', if_feature=[
-'ipv6-privacy-autoconf'
-            ], mandatory=False, reference='RFC 4941: Privacy Extensions for Stateless Address\n          Autoconfiguration in IPv6\n          - TEMP_VALID_LIFETIME', type_=DTypeIntegerUnsigned(name='uint32', description=None, reference=None, exts=[], builtin_type='uint32', default=None, ranges=Ranges([(0, 4294967295)])), units='seconds'),
-        DLeaf(module='ietf-ip', namespace='urn:ietf:params:xml:ns:yang:ietf-ip', prefix='ip', name='temporary-preferred-lifetime', config=True, description='The time period during which the temporary address is\npreferred.', default='86400', if_feature=[
-'ipv6-privacy-autoconf'
-            ], mandatory=False, reference='RFC 4941: Privacy Extensions for Stateless Address\n          Autoconfiguration in IPv6\n          - TEMP_PREFERRED_LIFETIME', type_=DTypeIntegerUnsigned(name='uint32', description=None, reference=None, exts=[], builtin_type='uint32', default=None, ranges=Ranges([(0, 4294967295)])), units='seconds')
+    DList(module='ietf-ip', namespace='urn:ietf:params:xml:ns:yang:ietf-ip', prefix='ip', name='neighbor', key=['ip'], config=False, description='A list of mappings from IPv4 addresses to\nlink-layer addresses.\n\nThis list represents the ARP Cache.', min_elements=0, ordered_by='system', reference='RFC 826: An Ethernet Address Resolution Protocol', status='deprecated', children=[
+        DLeaf(module='ietf-ip', namespace='urn:ietf:params:xml:ns:yang:ietf-ip', prefix='ip', name='ip', config=False, description='The IPv4 address of the neighbor node.', mandatory=False, status='deprecated', type_=DTypeString(name='inet:ipv4-address-no-zone', description='An IPv4 address without a zone index.  This type, derived from\nipv4-address, may be used in situations where the zone is\nknown from the context and hence no zone index is needed.', reference=None, exts=[], builtin_type='string', default=None, length=None, patterns=[YangPattern(yang_regex='(([0-9]|[1-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5])\\.){{3}}([0-9]|[1-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5])(%[\\p{{N}}\\p{{L}}]+)?', pcre='^((([0-9]|[1-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5])\\.){{3}}([0-9]|[1-9][0-9]|1[0-9][0-9]|2[0-4][0-9]|25[0-5])(%[\\p{{N}}\\p{{L}}]+)?)$', invert=False), YangPattern(yang_regex='[0-9\\.]*', pcre='^([0-9\\.]*)$', invert=False)])),
+        DLeaf(module='ietf-ip', namespace='urn:ietf:params:xml:ns:yang:ietf-ip', prefix='ip', name='link-layer-address', config=False, description='The link-layer address of the neighbor node.', mandatory=False, status='deprecated', type_=DTypeString(name='yang:phys-address', description='Represents media- or physical-level addresses represented\nas a sequence octets, each octet represented by two hexadecimal\nnumbers.  Octets are separated by colons.  The canonical\nrepresentation uses lowercase characters.\n\nIn the value set and its semantics, this type is equivalent\nto the PhysAddress textual convention of the SMIv2.', reference='RFC 2579: Textual Conventions for SMIv2', exts=[], builtin_type='string', default=None, length=None, patterns=[YangPattern(yang_regex='([0-9a-fA-F]{{2}}(:[0-9a-fA-F]{{2}})*)?', pcre='^(([0-9a-fA-F]{{2}}(:[0-9a-fA-F]{{2}})*)?)$', invert=False)])),
+        DLeaf(module='ietf-ip', namespace='urn:ietf:params:xml:ns:yang:ietf-ip', prefix='ip', name='origin', config=False, description='The origin of this neighbor entry.', mandatory=False, status='deprecated', type_=DTypeEnum(name='neighbor-origin', description='The origin of a neighbor entry.', reference=None, exts=[], builtin_type='enumeration', default=None, name_to_val={'other':0, 'static':1, 'dynamic':2}))
     ])
 ])
 
-SRC_DNODE_CHILD_18 = DList(module='ietf-interfaces', namespace='urn:ietf:params:xml:ns:yang:ietf-interfaces', prefix='if', name='interface', key=['name'], config=True, description='The list of interfaces on the device.\n\nThe status of an interface is available in this list in the\noperational state.  If the configuration of a\nsystem-controlled interface cannot be used by the system\n(e.g., the interface hardware present does not match the\ninterface type), then the configuration is not applied to\nthe system-controlled interface shown in the operational\nstate.  If the configuration of a user-controlled interface\ncannot be used by the system, the configured interface is\nnot instantiated in the operational state.\n\nSystem-controlled interfaces created by the system are\nalways present in this list in the operational state,\nwhether or not they are configured.', min_elements=0, ordered_by='system', children=[SRC_DNODE_CHILD_19, SRC_DNODE_CHILD_20, SRC_DNODE_CHILD_21, SRC_DNODE_CHILD_22, SRC_DNODE_CHILD_23, SRC_DNODE_CHILD_24, SRC_DNODE_CHILD_25])
+SRC_DNODE_CHILD_60 = DContainer(module='ietf-ip', namespace='urn:ietf:params:xml:ns:yang:ietf-ip', prefix='ip', name='ipv6', config=False, description='Parameters for the IPv6 address family.', presence=True, status='deprecated', children=[
+    DLeaf(module='ietf-ip', namespace='urn:ietf:params:xml:ns:yang:ietf-ip', prefix='ip', name='forwarding', config=False, description='Indicates whether IPv6 packet forwarding is enabled or\ndisabled on this interface.', default='false', mandatory=False, reference='RFC 4861: Neighbor Discovery for IP version 6 (IPv6)\n          Section 6.2.1, IsRouter', status='deprecated', type_=DTypeBoolean(name='boolean', description=None, reference=None, exts=[], builtin_type='boolean', default=None)),
+    DLeaf(module='ietf-ip', namespace='urn:ietf:params:xml:ns:yang:ietf-ip', prefix='ip', name='mtu', config=False, description='The size, in octets, of the largest IPv6 packet that the\ninterface will send and receive.', mandatory=False, reference='RFC 8200: Internet Protocol, Version 6 (IPv6)\n          Specification\n          Section 5', status='deprecated', type_=DTypeIntegerUnsigned(name='uint32', description=None, reference=None, exts=[], builtin_type='uint32', default=None, ranges=Ranges([(1280, 4294967295)])), units='octets'),
+    DList(module='ietf-ip', namespace='urn:ietf:params:xml:ns:yang:ietf-ip', prefix='ip', name='address', key=['ip'], config=False, description='The list of IPv6 addresses on the interface.', min_elements=0, ordered_by='system', status='deprecated', children=[
+        DLeaf(module='ietf-ip', namespace='urn:ietf:params:xml:ns:yang:ietf-ip', prefix='ip', name='ip', config=False, description='The IPv6 address on the interface.', mandatory=False, status='deprecated', type_=DTypeString(name='inet:ipv6-address-no-zone', description='An IPv6 address without a zone index.  This type, derived from\nipv6-address, may be used in situations where the zone is\nknown from the context and hence no zone index is needed.', reference='RFC 4291: IP Version 6 Addressing Architecture\nRFC 4007: IPv6 Scoped Address Architecture\nRFC 5952: A Recommendation for IPv6 Address Text\n          Representation', exts=[], builtin_type='string', default=None, length=None, patterns=[YangPattern(yang_regex='((:|[0-9a-fA-F]{{0,4}}):)([0-9a-fA-F]{{0,4}}:){{0,5}}((([0-9a-fA-F]{{0,4}}:)?(:|[0-9a-fA-F]{{0,4}}))|(((25[0-5]|2[0-4][0-9]|[01]?[0-9]?[0-9])\\.){{3}}(25[0-5]|2[0-4][0-9]|[01]?[0-9]?[0-9])))(%[\\p{{N}}\\p{{L}}]+)?', pcre='^(((:|[0-9a-fA-F]{{0,4}}):)([0-9a-fA-F]{{0,4}}:){{0,5}}((([0-9a-fA-F]{{0,4}}:)?(:|[0-9a-fA-F]{{0,4}}))|(((25[0-5]|2[0-4][0-9]|[01]?[0-9]?[0-9])\\.){{3}}(25[0-5]|2[0-4][0-9]|[01]?[0-9]?[0-9])))(%[\\p{{N}}\\p{{L}}]+)?)$', invert=False), YangPattern(yang_regex='(([^:]+:){{6}}(([^:]+:[^:]+)|(.*\\..*)))|((([^:]+:)*[^:]+)?::(([^:]+:)*[^:]+)?)(%.+)?', pcre='^((([^\\:]+:){{6}}(([^\\:]+:[^\\:]+)|(.*\\..*)))|((([^\\:]+:)*[^\\:]+)?::(([^\\:]+:)*[^\\:]+)?)(%.+)?)$', invert=False), YangPattern(yang_regex='[0-9a-fA-F:\\.]*', pcre='^([0-9a-fA-F:\\.]*)$', invert=False)])),
+        DLeaf(module='ietf-ip', namespace='urn:ietf:params:xml:ns:yang:ietf-ip', prefix='ip', name='prefix-length', config=False, description='The length of the subnet prefix.', mandatory=True, status='deprecated', type_=DTypeIntegerUnsigned(name='uint8', description=None, reference=None, exts=[], builtin_type='uint8', default=None, ranges=Ranges([(0, 128)]))),
+        DLeaf(module='ietf-ip', namespace='urn:ietf:params:xml:ns:yang:ietf-ip', prefix='ip', name='origin', config=False, description='The origin of this address.', mandatory=False, status='deprecated', type_=DTypeEnum(name='ip-address-origin', description='The origin of an address.', reference=None, exts=[], builtin_type='enumeration', default=None, name_to_val={'other':0, 'static':1, 'dhcp':2, 'link-layer':3, 'random':4})),
+        DLeaf(module='ietf-ip', namespace='urn:ietf:params:xml:ns:yang:ietf-ip', prefix='ip', name='status', config=False, description='The status of an address.  Most of the states correspond\nto states from the IPv6 Stateless Address\nAutoconfiguration protocol.', mandatory=False, reference='RFC 4293: Management Information Base for the\n          Internet Protocol (IP)\n          - IpAddressStatusTC\nRFC 4862: IPv6 Stateless Address Autoconfiguration', status='deprecated', type_=DTypeEnum(name='enumeration', description=None, reference=None, exts=[], builtin_type='enumeration', default=None, name_to_val={'preferred':0, 'deprecated':1, 'invalid':2, 'inaccessible':3, 'unknown':4, 'tentative':5, 'duplicate':6, 'optimistic':7}))
+    ]),
+    DList(module='ietf-ip', namespace='urn:ietf:params:xml:ns:yang:ietf-ip', prefix='ip', name='neighbor', key=['ip'], config=False, description='A list of mappings from IPv6 addresses to\nlink-layer addresses.\n\nThis list represents the Neighbor Cache.', min_elements=0, ordered_by='system', reference='RFC 4861: Neighbor Discovery for IP version 6 (IPv6)', status='deprecated', children=[
+        DLeaf(module='ietf-ip', namespace='urn:ietf:params:xml:ns:yang:ietf-ip', prefix='ip', name='ip', config=False, description='The IPv6 address of the neighbor node.', mandatory=False, status='deprecated', type_=DTypeString(name='inet:ipv6-address-no-zone', description='An IPv6 address without a zone index.  This type, derived from\nipv6-address, may be used in situations where the zone is\nknown from the context and hence no zone index is needed.', reference='RFC 4291: IP Version 6 Addressing Architecture\nRFC 4007: IPv6 Scoped Address Architecture\nRFC 5952: A Recommendation for IPv6 Address Text\n          Representation', exts=[], builtin_type='string', default=None, length=None, patterns=[YangPattern(yang_regex='((:|[0-9a-fA-F]{{0,4}}):)([0-9a-fA-F]{{0,4}}:){{0,5}}((([0-9a-fA-F]{{0,4}}:)?(:|[0-9a-fA-F]{{0,4}}))|(((25[0-5]|2[0-4][0-9]|[01]?[0-9]?[0-9])\\.){{3}}(25[0-5]|2[0-4][0-9]|[01]?[0-9]?[0-9])))(%[\\p{{N}}\\p{{L}}]+)?', pcre='^(((:|[0-9a-fA-F]{{0,4}}):)([0-9a-fA-F]{{0,4}}:){{0,5}}((([0-9a-fA-F]{{0,4}}:)?(:|[0-9a-fA-F]{{0,4}}))|(((25[0-5]|2[0-4][0-9]|[01]?[0-9]?[0-9])\\.){{3}}(25[0-5]|2[0-4][0-9]|[01]?[0-9]?[0-9])))(%[\\p{{N}}\\p{{L}}]+)?)$', invert=False), YangPattern(yang_regex='(([^:]+:){{6}}(([^:]+:[^:]+)|(.*\\..*)))|((([^:]+:)*[^:]+)?::(([^:]+:)*[^:]+)?)(%.+)?', pcre='^((([^\\:]+:){{6}}(([^\\:]+:[^\\:]+)|(.*\\..*)))|((([^\\:]+:)*[^\\:]+)?::(([^\\:]+:)*[^\\:]+)?)(%.+)?)$', invert=False), YangPattern(yang_regex='[0-9a-fA-F:\\.]*', pcre='^([0-9a-fA-F:\\.]*)$', invert=False)])),
+        DLeaf(module='ietf-ip', namespace='urn:ietf:params:xml:ns:yang:ietf-ip', prefix='ip', name='link-layer-address', config=False, description='The link-layer address of the neighbor node.', mandatory=False, status='deprecated', type_=DTypeString(name='yang:phys-address', description='Represents media- or physical-level addresses represented\nas a sequence octets, each octet represented by two hexadecimal\nnumbers.  Octets are separated by colons.  The canonical\nrepresentation uses lowercase characters.\n\nIn the value set and its semantics, this type is equivalent\nto the PhysAddress textual convention of the SMIv2.', reference='RFC 2579: Textual Conventions for SMIv2', exts=[], builtin_type='string', default=None, length=None, patterns=[YangPattern(yang_regex='([0-9a-fA-F]{{2}}(:[0-9a-fA-F]{{2}})*)?', pcre='^(([0-9a-fA-F]{{2}}(:[0-9a-fA-F]{{2}})*)?)$', invert=False)])),
+        DLeaf(module='ietf-ip', namespace='urn:ietf:params:xml:ns:yang:ietf-ip', prefix='ip', name='origin', config=False, description='The origin of this neighbor entry.', mandatory=False, status='deprecated', type_=DTypeEnum(name='neighbor-origin', description='The origin of a neighbor entry.', reference=None, exts=[], builtin_type='enumeration', default=None, name_to_val={'other':0, 'static':1, 'dynamic':2})),
+        DLeaf(module='ietf-ip', namespace='urn:ietf:params:xml:ns:yang:ietf-ip', prefix='ip', name='is-router', config=False, description='Indicates that the neighbor node acts as a router.', mandatory=False, status='deprecated', type_=DTypeEmpty(name='empty', description=None, reference=None, exts=[], builtin_type='empty', default=None)),
+        DLeaf(module='ietf-ip', namespace='urn:ietf:params:xml:ns:yang:ietf-ip', prefix='ip', name='state', config=False, description='The Neighbor Unreachability Detection state of this\nentry.', mandatory=False, reference='RFC 4861: Neighbor Discovery for IP version 6 (IPv6)\n          Section 7.3.2', status='deprecated', type_=DTypeEnum(name='enumeration', description=None, reference=None, exts=[], builtin_type='enumeration', default=None, name_to_val={'incomplete':0, 'reachable':1, 'stale':2, 'delay':3, 'probe':4}))
+    ])
+])
 
-SRC_DNODE_CHILD_17 = DContainer(module='ietf-interfaces', namespace='urn:ietf:params:xml:ns:yang:ietf-interfaces', prefix='if', name='interfaces', config=True, description='Interface parameters.', presence=False, children=[SRC_DNODE_CHILD_18])
+SRC_DNODE_CHILD_47 = DList(module='ietf-interfaces', namespace='urn:ietf:params:xml:ns:yang:ietf-interfaces', prefix='if', name='interface', key=['name'], config=False, description='The list of interfaces on the device.\n\nSystem-controlled interfaces created by the system are\nalways present in this list, whether or not they are\nconfigured.', min_elements=0, ordered_by='system', status='deprecated', children=[SRC_DNODE_CHILD_48, SRC_DNODE_CHILD_49, SRC_DNODE_CHILD_50, SRC_DNODE_CHILD_51, SRC_DNODE_CHILD_52, SRC_DNODE_CHILD_53, SRC_DNODE_CHILD_54, SRC_DNODE_CHILD_55, SRC_DNODE_CHILD_56, SRC_DNODE_CHILD_57, SRC_DNODE_CHILD_58, SRC_DNODE_CHILD_59, SRC_DNODE_CHILD_60])
+
+SRC_DNODE_CHILD_46 = DContainer(module='ietf-interfaces', namespace='urn:ietf:params:xml:ns:yang:ietf-interfaces', prefix='if', name='interfaces-state', config=False, description='Data nodes for the operational state of interfaces.', presence=False, status='deprecated', children=[SRC_DNODE_CHILD_47])
 
 SRC_DNODE_IDENTITY_0 = DIdentity(module='ietf-system', namespace='urn:ietf:params:xml:ns:yang:ietf-system', prefix='sys', name='authentication-method')
 
@@ -2711,7 +2854,7 @@ SRC_DNODE_RPC_2 = DRpc(module='ietf-system', namespace='urn:ietf:params:xml:ns:y
     ])
 
 SRC_DNODE = DRoot(
-    children=[SRC_DNODE_CHILD_0, SRC_DNODE_CHILD_8, SRC_DNODE_CHILD_17],
+    children=[SRC_DNODE_CHILD_0, SRC_DNODE_CHILD_11, SRC_DNODE_CHILD_20, SRC_DNODE_CHILD_21, SRC_DNODE_CHILD_46],
     identities=[SRC_DNODE_IDENTITY_0, SRC_DNODE_IDENTITY_1, SRC_DNODE_IDENTITY_2, SRC_DNODE_IDENTITY_3, SRC_DNODE_IDENTITY_4, SRC_DNODE_IDENTITY_5, SRC_DNODE_IDENTITY_6, SRC_DNODE_IDENTITY_7, SRC_DNODE_IDENTITY_8, SRC_DNODE_IDENTITY_9, SRC_DNODE_IDENTITY_10, SRC_DNODE_IDENTITY_11, SRC_DNODE_IDENTITY_12, SRC_DNODE_IDENTITY_13, SRC_DNODE_IDENTITY_14, SRC_DNODE_IDENTITY_15, SRC_DNODE_IDENTITY_16, SRC_DNODE_IDENTITY_17, SRC_DNODE_IDENTITY_18, SRC_DNODE_IDENTITY_19, SRC_DNODE_IDENTITY_20, SRC_DNODE_IDENTITY_21, SRC_DNODE_IDENTITY_22, SRC_DNODE_IDENTITY_23, SRC_DNODE_IDENTITY_24, SRC_DNODE_IDENTITY_25, SRC_DNODE_IDENTITY_26, SRC_DNODE_IDENTITY_27, SRC_DNODE_IDENTITY_28, SRC_DNODE_IDENTITY_29, SRC_DNODE_IDENTITY_30, SRC_DNODE_IDENTITY_31, SRC_DNODE_IDENTITY_32, SRC_DNODE_IDENTITY_33, SRC_DNODE_IDENTITY_34, SRC_DNODE_IDENTITY_35, SRC_DNODE_IDENTITY_36, SRC_DNODE_IDENTITY_37, SRC_DNODE_IDENTITY_38, SRC_DNODE_IDENTITY_39, SRC_DNODE_IDENTITY_40, SRC_DNODE_IDENTITY_41, SRC_DNODE_IDENTITY_42, SRC_DNODE_IDENTITY_43, SRC_DNODE_IDENTITY_44, SRC_DNODE_IDENTITY_45, SRC_DNODE_IDENTITY_46, SRC_DNODE_IDENTITY_47, SRC_DNODE_IDENTITY_48, SRC_DNODE_IDENTITY_49, SRC_DNODE_IDENTITY_50, SRC_DNODE_IDENTITY_51, SRC_DNODE_IDENTITY_52, SRC_DNODE_IDENTITY_53, SRC_DNODE_IDENTITY_54, SRC_DNODE_IDENTITY_55, SRC_DNODE_IDENTITY_56, SRC_DNODE_IDENTITY_57, SRC_DNODE_IDENTITY_58, SRC_DNODE_IDENTITY_59, SRC_DNODE_IDENTITY_60, SRC_DNODE_IDENTITY_61, SRC_DNODE_IDENTITY_62, SRC_DNODE_IDENTITY_63, SRC_DNODE_IDENTITY_64, SRC_DNODE_IDENTITY_65, SRC_DNODE_IDENTITY_66, SRC_DNODE_IDENTITY_67, SRC_DNODE_IDENTITY_68, SRC_DNODE_IDENTITY_69, SRC_DNODE_IDENTITY_70, SRC_DNODE_IDENTITY_71, SRC_DNODE_IDENTITY_72, SRC_DNODE_IDENTITY_73, SRC_DNODE_IDENTITY_74, SRC_DNODE_IDENTITY_75, SRC_DNODE_IDENTITY_76, SRC_DNODE_IDENTITY_77, SRC_DNODE_IDENTITY_78, SRC_DNODE_IDENTITY_79, SRC_DNODE_IDENTITY_80, SRC_DNODE_IDENTITY_81, SRC_DNODE_IDENTITY_82, SRC_DNODE_IDENTITY_83, SRC_DNODE_IDENTITY_84, SRC_DNODE_IDENTITY_85, SRC_DNODE_IDENTITY_86, SRC_DNODE_IDENTITY_87, SRC_DNODE_IDENTITY_88, SRC_DNODE_IDENTITY_89, SRC_DNODE_IDENTITY_90, SRC_DNODE_IDENTITY_91, SRC_DNODE_IDENTITY_92, SRC_DNODE_IDENTITY_93, SRC_DNODE_IDENTITY_94, SRC_DNODE_IDENTITY_95, SRC_DNODE_IDENTITY_96, SRC_DNODE_IDENTITY_97, SRC_DNODE_IDENTITY_98, SRC_DNODE_IDENTITY_99, SRC_DNODE_IDENTITY_100, SRC_DNODE_IDENTITY_101, SRC_DNODE_IDENTITY_102, SRC_DNODE_IDENTITY_103, SRC_DNODE_IDENTITY_104, SRC_DNODE_IDENTITY_105, SRC_DNODE_IDENTITY_106, SRC_DNODE_IDENTITY_107, SRC_DNODE_IDENTITY_108, SRC_DNODE_IDENTITY_109, SRC_DNODE_IDENTITY_110, SRC_DNODE_IDENTITY_111, SRC_DNODE_IDENTITY_112, SRC_DNODE_IDENTITY_113, SRC_DNODE_IDENTITY_114, SRC_DNODE_IDENTITY_115, SRC_DNODE_IDENTITY_116, SRC_DNODE_IDENTITY_117, SRC_DNODE_IDENTITY_118, SRC_DNODE_IDENTITY_119, SRC_DNODE_IDENTITY_120, SRC_DNODE_IDENTITY_121, SRC_DNODE_IDENTITY_122, SRC_DNODE_IDENTITY_123, SRC_DNODE_IDENTITY_124, SRC_DNODE_IDENTITY_125, SRC_DNODE_IDENTITY_126, SRC_DNODE_IDENTITY_127, SRC_DNODE_IDENTITY_128, SRC_DNODE_IDENTITY_129, SRC_DNODE_IDENTITY_130, SRC_DNODE_IDENTITY_131, SRC_DNODE_IDENTITY_132, SRC_DNODE_IDENTITY_133, SRC_DNODE_IDENTITY_134, SRC_DNODE_IDENTITY_135, SRC_DNODE_IDENTITY_136, SRC_DNODE_IDENTITY_137, SRC_DNODE_IDENTITY_138, SRC_DNODE_IDENTITY_139, SRC_DNODE_IDENTITY_140, SRC_DNODE_IDENTITY_141, SRC_DNODE_IDENTITY_142, SRC_DNODE_IDENTITY_143, SRC_DNODE_IDENTITY_144, SRC_DNODE_IDENTITY_145, SRC_DNODE_IDENTITY_146, SRC_DNODE_IDENTITY_147, SRC_DNODE_IDENTITY_148, SRC_DNODE_IDENTITY_149, SRC_DNODE_IDENTITY_150, SRC_DNODE_IDENTITY_151, SRC_DNODE_IDENTITY_152, SRC_DNODE_IDENTITY_153, SRC_DNODE_IDENTITY_154, SRC_DNODE_IDENTITY_155, SRC_DNODE_IDENTITY_156, SRC_DNODE_IDENTITY_157, SRC_DNODE_IDENTITY_158, SRC_DNODE_IDENTITY_159, SRC_DNODE_IDENTITY_160, SRC_DNODE_IDENTITY_161, SRC_DNODE_IDENTITY_162, SRC_DNODE_IDENTITY_163, SRC_DNODE_IDENTITY_164, SRC_DNODE_IDENTITY_165, SRC_DNODE_IDENTITY_166, SRC_DNODE_IDENTITY_167, SRC_DNODE_IDENTITY_168, SRC_DNODE_IDENTITY_169, SRC_DNODE_IDENTITY_170, SRC_DNODE_IDENTITY_171, SRC_DNODE_IDENTITY_172, SRC_DNODE_IDENTITY_173, SRC_DNODE_IDENTITY_174, SRC_DNODE_IDENTITY_175, SRC_DNODE_IDENTITY_176, SRC_DNODE_IDENTITY_177, SRC_DNODE_IDENTITY_178, SRC_DNODE_IDENTITY_179, SRC_DNODE_IDENTITY_180, SRC_DNODE_IDENTITY_181, SRC_DNODE_IDENTITY_182, SRC_DNODE_IDENTITY_183, SRC_DNODE_IDENTITY_184, SRC_DNODE_IDENTITY_185, SRC_DNODE_IDENTITY_186, SRC_DNODE_IDENTITY_187, SRC_DNODE_IDENTITY_188, SRC_DNODE_IDENTITY_189, SRC_DNODE_IDENTITY_190, SRC_DNODE_IDENTITY_191, SRC_DNODE_IDENTITY_192, SRC_DNODE_IDENTITY_193, SRC_DNODE_IDENTITY_194, SRC_DNODE_IDENTITY_195, SRC_DNODE_IDENTITY_196, SRC_DNODE_IDENTITY_197, SRC_DNODE_IDENTITY_198, SRC_DNODE_IDENTITY_199, SRC_DNODE_IDENTITY_200, SRC_DNODE_IDENTITY_201, SRC_DNODE_IDENTITY_202, SRC_DNODE_IDENTITY_203, SRC_DNODE_IDENTITY_204, SRC_DNODE_IDENTITY_205, SRC_DNODE_IDENTITY_206, SRC_DNODE_IDENTITY_207, SRC_DNODE_IDENTITY_208, SRC_DNODE_IDENTITY_209, SRC_DNODE_IDENTITY_210, SRC_DNODE_IDENTITY_211, SRC_DNODE_IDENTITY_212, SRC_DNODE_IDENTITY_213, SRC_DNODE_IDENTITY_214, SRC_DNODE_IDENTITY_215, SRC_DNODE_IDENTITY_216, SRC_DNODE_IDENTITY_217, SRC_DNODE_IDENTITY_218, SRC_DNODE_IDENTITY_219, SRC_DNODE_IDENTITY_220, SRC_DNODE_IDENTITY_221, SRC_DNODE_IDENTITY_222, SRC_DNODE_IDENTITY_223, SRC_DNODE_IDENTITY_224, SRC_DNODE_IDENTITY_225, SRC_DNODE_IDENTITY_226, SRC_DNODE_IDENTITY_227, SRC_DNODE_IDENTITY_228, SRC_DNODE_IDENTITY_229, SRC_DNODE_IDENTITY_230, SRC_DNODE_IDENTITY_231, SRC_DNODE_IDENTITY_232, SRC_DNODE_IDENTITY_233, SRC_DNODE_IDENTITY_234, SRC_DNODE_IDENTITY_235, SRC_DNODE_IDENTITY_236, SRC_DNODE_IDENTITY_237, SRC_DNODE_IDENTITY_238, SRC_DNODE_IDENTITY_239, SRC_DNODE_IDENTITY_240, SRC_DNODE_IDENTITY_241, SRC_DNODE_IDENTITY_242, SRC_DNODE_IDENTITY_243, SRC_DNODE_IDENTITY_244, SRC_DNODE_IDENTITY_245, SRC_DNODE_IDENTITY_246, SRC_DNODE_IDENTITY_247, SRC_DNODE_IDENTITY_248, SRC_DNODE_IDENTITY_249, SRC_DNODE_IDENTITY_250, SRC_DNODE_IDENTITY_251, SRC_DNODE_IDENTITY_252, SRC_DNODE_IDENTITY_253, SRC_DNODE_IDENTITY_254, SRC_DNODE_IDENTITY_255, SRC_DNODE_IDENTITY_256, SRC_DNODE_IDENTITY_257, SRC_DNODE_IDENTITY_258, SRC_DNODE_IDENTITY_259, SRC_DNODE_IDENTITY_260, SRC_DNODE_IDENTITY_261, SRC_DNODE_IDENTITY_262, SRC_DNODE_IDENTITY_263, SRC_DNODE_IDENTITY_264, SRC_DNODE_IDENTITY_265, SRC_DNODE_IDENTITY_266, SRC_DNODE_IDENTITY_267, SRC_DNODE_IDENTITY_268, SRC_DNODE_IDENTITY_269, SRC_DNODE_IDENTITY_270, SRC_DNODE_IDENTITY_271, SRC_DNODE_IDENTITY_272, SRC_DNODE_IDENTITY_273, SRC_DNODE_IDENTITY_274, SRC_DNODE_IDENTITY_275, SRC_DNODE_IDENTITY_276, SRC_DNODE_IDENTITY_277, SRC_DNODE_IDENTITY_278, SRC_DNODE_IDENTITY_279],
     rpcs=[SRC_DNODE_RPC_0, SRC_DNODE_RPC_1, SRC_DNODE_RPC_2],
     module_metadata={'urn:ietf:params:xml:ns:yang:ietf-yang-types':('ietf-yang-types', '2013-07-15'), 'urn:ietf:params:xml:ns:yang:iana-crypt-hash':('iana-crypt-hash', '2014-08-06'), 'urn:ietf:params:xml:ns:yang:ietf-netconf-acm':('ietf-netconf-acm', '2018-02-14'), 'urn:ietf:params:xml:ns:yang:ietf-inet-types':('ietf-inet-types', '2013-07-15'), 'urn:ietf:params:xml:ns:yang:ietf-system':('ietf-system', '2014-08-06'), 'urn:ietf:params:xml:ns:yang:ietf-interfaces':('ietf-interfaces', '2018-02-20'), 'urn:ietf:params:xml:ns:yang:ietf-ip':('ietf-ip', '2018-02-22'), 'urn:ietf:params:xml:ns:yang:iana-if-type':('iana-if-type', '2014-05-08')},
@@ -8857,16 +9000,22 @@ class ietf_netconf_acm__nacm(yang.adata.MNode):
     write_default: ?str
     exec_default: ?str
     enable_external_groups: ?bool
+    denied_operations: ?u64
+    denied_data_writes: ?u64
+    denied_notifications: ?u64
     groups: ietf_netconf_acm__nacm__groups
     rule_list: ietf_netconf_acm__nacm__rule_list
 
-    mut def __init__(self, enable_nacm: ?bool, read_default: ?str, write_default: ?str, exec_default: ?str, enable_external_groups: ?bool, groups: ?ietf_netconf_acm__nacm__groups=None, rule_list: list[ietf_netconf_acm__nacm__rule_list_entry]=[]):
+    mut def __init__(self, enable_nacm: ?bool, read_default: ?str, write_default: ?str, exec_default: ?str, enable_external_groups: ?bool, denied_operations: ?u64, denied_data_writes: ?u64, denied_notifications: ?u64, groups: ?ietf_netconf_acm__nacm__groups=None, rule_list: list[ietf_netconf_acm__nacm__rule_list_entry]=[]):
         self._ns = 'urn:ietf:params:xml:ns:yang:ietf-netconf-acm'
         self.enable_nacm = enable_nacm
         self.read_default = read_default
         self.write_default = write_default
         self.exec_default = exec_default
         self.enable_external_groups = enable_external_groups
+        self.denied_operations = denied_operations
+        self.denied_data_writes = denied_data_writes
+        self.denied_notifications = denied_notifications
         self.groups = groups if groups is not None else ietf_netconf_acm__nacm__groups()
         self.rule_list = ietf_netconf_acm__nacm__rule_list(elements=rule_list)
 
@@ -8881,6 +9030,12 @@ class ietf_netconf_acm__nacm(yang.adata.MNode):
             return self.exec_default
         if name == 'enable_external_groups':
             return self.enable_external_groups
+        if name == 'denied_operations':
+            return self.denied_operations
+        if name == 'denied_data_writes':
+            return self.denied_data_writes
+        if name == 'denied_notifications':
+            return self.denied_notifications
         if name == 'groups':
             return self.groups
         if name == 'rule_list':
@@ -8892,7 +9047,7 @@ class ietf_netconf_acm__nacm(yang.adata.MNode):
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> ietf_netconf_acm__nacm:
         if n is not None:
-            return ietf_netconf_acm__nacm(enable_nacm=n.get_opt_bool(yang.gdata.Id(NS_ietf_netconf_acm, 'enable-nacm')), read_default=n.get_opt_str(yang.gdata.Id(NS_ietf_netconf_acm, 'read-default')), write_default=n.get_opt_str(yang.gdata.Id(NS_ietf_netconf_acm, 'write-default')), exec_default=n.get_opt_str(yang.gdata.Id(NS_ietf_netconf_acm, 'exec-default')), enable_external_groups=n.get_opt_bool(yang.gdata.Id(NS_ietf_netconf_acm, 'enable-external-groups')), groups=ietf_netconf_acm__nacm__groups.from_gdata(n.get_opt_cnt(yang.gdata.Id(NS_ietf_netconf_acm, 'groups'))), rule_list=ietf_netconf_acm__nacm__rule_list.from_gdata(n.get_opt_list(yang.gdata.Id(NS_ietf_netconf_acm, 'rule-list'))))
+            return ietf_netconf_acm__nacm(enable_nacm=n.get_opt_bool(yang.gdata.Id(NS_ietf_netconf_acm, 'enable-nacm')), read_default=n.get_opt_str(yang.gdata.Id(NS_ietf_netconf_acm, 'read-default')), write_default=n.get_opt_str(yang.gdata.Id(NS_ietf_netconf_acm, 'write-default')), exec_default=n.get_opt_str(yang.gdata.Id(NS_ietf_netconf_acm, 'exec-default')), enable_external_groups=n.get_opt_bool(yang.gdata.Id(NS_ietf_netconf_acm, 'enable-external-groups')), denied_operations=n.get_opt_u64(yang.gdata.Id(NS_ietf_netconf_acm, 'denied-operations')), denied_data_writes=n.get_opt_u64(yang.gdata.Id(NS_ietf_netconf_acm, 'denied-data-writes')), denied_notifications=n.get_opt_u64(yang.gdata.Id(NS_ietf_netconf_acm, 'denied-notifications')), groups=ietf_netconf_acm__nacm__groups.from_gdata(n.get_opt_cnt(yang.gdata.Id(NS_ietf_netconf_acm, 'groups'))), rule_list=ietf_netconf_acm__nacm__rule_list.from_gdata(n.get_opt_list(yang.gdata.Id(NS_ietf_netconf_acm, 'rule-list'))))
         return ietf_netconf_acm__nacm()
 
     def copy(self):
@@ -9654,16 +9809,194 @@ class ietf_system__system(yang.adata.MNode):
 
 
 _breaker30 = None
+class ietf_system__system_state__platform(yang.adata.MNode):
+    os_name: ?str
+    os_release: ?str
+    os_version: ?str
+    machine: ?str
+
+    mut def __init__(self, os_name: ?str, os_release: ?str, os_version: ?str, machine: ?str):
+        self._ns = 'urn:ietf:params:xml:ns:yang:ietf-system'
+        self.os_name = os_name
+        self.os_release = os_release
+        self.os_version = os_version
+        self.machine = machine
+
+    def _get_attr(self, name: str) -> ?value:
+        if name == 'os_name':
+            return self.os_name
+        if name == 'os_release':
+            return self.os_release
+        if name == 'os_version':
+            return self.os_version
+        if name == 'machine':
+            return self.machine
+
+    mut def to_gdata(self) -> yang.gdata.Node:
+        return yang.adata.from_adata(SRC_DNODE, self, loose=True, root_path=['ietf-system:system-state', 'platform'])
+
+    @staticmethod
+    mut def from_gdata(n: ?yang.gdata.Node) -> ietf_system__system_state__platform:
+        if n is not None:
+            return ietf_system__system_state__platform(os_name=n.get_opt_str(yang.gdata.Id(NS_ietf_system, 'os-name')), os_release=n.get_opt_str(yang.gdata.Id(NS_ietf_system, 'os-release')), os_version=n.get_opt_str(yang.gdata.Id(NS_ietf_system, 'os-version')), machine=n.get_opt_str(yang.gdata.Id(NS_ietf_system, 'machine')))
+        return ietf_system__system_state__platform()
+
+    def copy(self):
+        """Create a deep copy of this adata object"""
+        return ietf_system__system_state__platform.from_gdata(self.to_gdata())
+
+
+_breaker31 = None
+class ietf_system__system_state__clock(yang.adata.MNode):
+    current_datetime: ?str
+    boot_datetime: ?str
+
+    mut def __init__(self, current_datetime: ?str, boot_datetime: ?str):
+        self._ns = 'urn:ietf:params:xml:ns:yang:ietf-system'
+        self.current_datetime = current_datetime
+        self.boot_datetime = boot_datetime
+
+    def _get_attr(self, name: str) -> ?value:
+        if name == 'current_datetime':
+            return self.current_datetime
+        if name == 'boot_datetime':
+            return self.boot_datetime
+
+    mut def to_gdata(self) -> yang.gdata.Node:
+        return yang.adata.from_adata(SRC_DNODE, self, loose=True, root_path=['ietf-system:system-state', 'clock'])
+
+    @staticmethod
+    mut def from_gdata(n: ?yang.gdata.Node) -> ietf_system__system_state__clock:
+        if n is not None:
+            return ietf_system__system_state__clock(current_datetime=n.get_opt_str(yang.gdata.Id(NS_ietf_system, 'current-datetime')), boot_datetime=n.get_opt_str(yang.gdata.Id(NS_ietf_system, 'boot-datetime')))
+        return ietf_system__system_state__clock()
+
+    def copy(self):
+        """Create a deep copy of this adata object"""
+        return ietf_system__system_state__clock.from_gdata(self.to_gdata())
+
+
+_breaker32 = None
+class ietf_system__system_state(yang.adata.MNode):
+    platform: ietf_system__system_state__platform
+    clock: ietf_system__system_state__clock
+
+    mut def __init__(self, platform: ?ietf_system__system_state__platform=None, clock: ?ietf_system__system_state__clock=None):
+        self._ns = 'urn:ietf:params:xml:ns:yang:ietf-system'
+        self.platform = platform if platform is not None else ietf_system__system_state__platform()
+        self.clock = clock if clock is not None else ietf_system__system_state__clock()
+
+    def _get_attr(self, name: str) -> ?value:
+        if name == 'platform':
+            return self.platform
+        if name == 'clock':
+            return self.clock
+
+    mut def to_gdata(self) -> yang.gdata.Node:
+        return yang.adata.from_adata(SRC_DNODE, self, loose=True, root_path=['ietf-system:system-state'])
+
+    @staticmethod
+    mut def from_gdata(n: ?yang.gdata.Node) -> ietf_system__system_state:
+        if n is not None:
+            return ietf_system__system_state(platform=ietf_system__system_state__platform.from_gdata(n.get_opt_cnt(yang.gdata.Id(NS_ietf_system, 'platform'))), clock=ietf_system__system_state__clock.from_gdata(n.get_opt_cnt(yang.gdata.Id(NS_ietf_system, 'clock'))))
+        return ietf_system__system_state()
+
+    def copy(self):
+        """Create a deep copy of this adata object"""
+        return ietf_system__system_state.from_gdata(self.to_gdata())
+
+
+_breaker33 = None
+class ietf_interfaces__interfaces__interface__statistics(yang.adata.MNode):
+    discontinuity_time: ?str
+    in_octets: ?u64
+    in_unicast_pkts: ?u64
+    in_broadcast_pkts: ?u64
+    in_multicast_pkts: ?u64
+    in_discards: ?u64
+    in_errors: ?u64
+    in_unknown_protos: ?u64
+    out_octets: ?u64
+    out_unicast_pkts: ?u64
+    out_broadcast_pkts: ?u64
+    out_multicast_pkts: ?u64
+    out_discards: ?u64
+    out_errors: ?u64
+
+    mut def __init__(self, discontinuity_time: ?str, in_octets: ?u64, in_unicast_pkts: ?u64, in_broadcast_pkts: ?u64, in_multicast_pkts: ?u64, in_discards: ?u64, in_errors: ?u64, in_unknown_protos: ?u64, out_octets: ?u64, out_unicast_pkts: ?u64, out_broadcast_pkts: ?u64, out_multicast_pkts: ?u64, out_discards: ?u64, out_errors: ?u64):
+        self._ns = 'urn:ietf:params:xml:ns:yang:ietf-interfaces'
+        self.discontinuity_time = discontinuity_time
+        self.in_octets = in_octets
+        self.in_unicast_pkts = in_unicast_pkts
+        self.in_broadcast_pkts = in_broadcast_pkts
+        self.in_multicast_pkts = in_multicast_pkts
+        self.in_discards = in_discards
+        self.in_errors = in_errors
+        self.in_unknown_protos = in_unknown_protos
+        self.out_octets = out_octets
+        self.out_unicast_pkts = out_unicast_pkts
+        self.out_broadcast_pkts = out_broadcast_pkts
+        self.out_multicast_pkts = out_multicast_pkts
+        self.out_discards = out_discards
+        self.out_errors = out_errors
+
+    def _get_attr(self, name: str) -> ?value:
+        if name == 'discontinuity_time':
+            return self.discontinuity_time
+        if name == 'in_octets':
+            return self.in_octets
+        if name == 'in_unicast_pkts':
+            return self.in_unicast_pkts
+        if name == 'in_broadcast_pkts':
+            return self.in_broadcast_pkts
+        if name == 'in_multicast_pkts':
+            return self.in_multicast_pkts
+        if name == 'in_discards':
+            return self.in_discards
+        if name == 'in_errors':
+            return self.in_errors
+        if name == 'in_unknown_protos':
+            return self.in_unknown_protos
+        if name == 'out_octets':
+            return self.out_octets
+        if name == 'out_unicast_pkts':
+            return self.out_unicast_pkts
+        if name == 'out_broadcast_pkts':
+            return self.out_broadcast_pkts
+        if name == 'out_multicast_pkts':
+            return self.out_multicast_pkts
+        if name == 'out_discards':
+            return self.out_discards
+        if name == 'out_errors':
+            return self.out_errors
+
+    mut def to_gdata(self) -> yang.gdata.Node:
+        return yang.adata.from_adata(SRC_DNODE, self, loose=True, root_path=['ietf-interfaces:interfaces', 'interface', 'statistics'])
+
+    @staticmethod
+    mut def from_gdata(n: ?yang.gdata.Node) -> ietf_interfaces__interfaces__interface__statistics:
+        if n is not None:
+            return ietf_interfaces__interfaces__interface__statistics(discontinuity_time=n.get_opt_str(yang.gdata.Id(NS_ietf_interfaces, 'discontinuity-time')), in_octets=n.get_opt_u64(yang.gdata.Id(NS_ietf_interfaces, 'in-octets')), in_unicast_pkts=n.get_opt_u64(yang.gdata.Id(NS_ietf_interfaces, 'in-unicast-pkts')), in_broadcast_pkts=n.get_opt_u64(yang.gdata.Id(NS_ietf_interfaces, 'in-broadcast-pkts')), in_multicast_pkts=n.get_opt_u64(yang.gdata.Id(NS_ietf_interfaces, 'in-multicast-pkts')), in_discards=n.get_opt_u64(yang.gdata.Id(NS_ietf_interfaces, 'in-discards')), in_errors=n.get_opt_u64(yang.gdata.Id(NS_ietf_interfaces, 'in-errors')), in_unknown_protos=n.get_opt_u64(yang.gdata.Id(NS_ietf_interfaces, 'in-unknown-protos')), out_octets=n.get_opt_u64(yang.gdata.Id(NS_ietf_interfaces, 'out-octets')), out_unicast_pkts=n.get_opt_u64(yang.gdata.Id(NS_ietf_interfaces, 'out-unicast-pkts')), out_broadcast_pkts=n.get_opt_u64(yang.gdata.Id(NS_ietf_interfaces, 'out-broadcast-pkts')), out_multicast_pkts=n.get_opt_u64(yang.gdata.Id(NS_ietf_interfaces, 'out-multicast-pkts')), out_discards=n.get_opt_u64(yang.gdata.Id(NS_ietf_interfaces, 'out-discards')), out_errors=n.get_opt_u64(yang.gdata.Id(NS_ietf_interfaces, 'out-errors')))
+        return ietf_interfaces__interfaces__interface__statistics()
+
+    def copy(self):
+        """Create a deep copy of this adata object"""
+        return ietf_interfaces__interfaces__interface__statistics.from_gdata(self.to_gdata())
+
+
+_breaker34 = None
 class ietf_interfaces__interfaces__interface__ipv4__address_entry(yang.adata.MNode):
     ip: str
     prefix_length: ?u64
     netmask: ?str
+    origin: ?str
 
-    mut def __init__(self, ip: str, prefix_length: ?u64, netmask: ?str):
+    mut def __init__(self, ip: str, prefix_length: ?u64, netmask: ?str, origin: ?str):
         self._ns = 'urn:ietf:params:xml:ns:yang:ietf-ip'
         self.ip = ip
         self.prefix_length = prefix_length
         self.netmask = netmask
+        self.origin = origin
 
     def _get_attr(self, name: str) -> ?value:
         if name == 'ip':
@@ -9672,19 +10005,21 @@ class ietf_interfaces__interfaces__interface__ipv4__address_entry(yang.adata.MNo
             return self.prefix_length
         if name == 'netmask':
             return self.netmask
+        if name == 'origin':
+            return self.origin
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=True, root_path=['ietf-interfaces:interfaces', 'interface', 'ietf-ip:ipv4', 'address'])
 
     @staticmethod
     mut def from_gdata(n: yang.gdata.Node) -> ietf_interfaces__interfaces__interface__ipv4__address_entry:
-        return ietf_interfaces__interfaces__interface__ipv4__address_entry(ip=n.get_str(yang.gdata.Id(NS_ietf_ip, 'ip')), prefix_length=n.get_opt_u64(yang.gdata.Id(NS_ietf_ip, 'prefix-length')), netmask=n.get_opt_str(yang.gdata.Id(NS_ietf_ip, 'netmask')))
+        return ietf_interfaces__interfaces__interface__ipv4__address_entry(ip=n.get_str(yang.gdata.Id(NS_ietf_ip, 'ip')), prefix_length=n.get_opt_u64(yang.gdata.Id(NS_ietf_ip, 'prefix-length')), netmask=n.get_opt_str(yang.gdata.Id(NS_ietf_ip, 'netmask')), origin=n.get_opt_str(yang.gdata.Id(NS_ietf_ip, 'origin')))
 
     def copy(self):
         """Create a deep copy of this adata object"""
         return ietf_interfaces__interfaces__interface__ipv4__address_entry.from_gdata(self.to_gdata())
 
-_breaker31 = None
+_breaker35 = None
 class ietf_interfaces__interfaces__interface__ipv4__address(yang.adata.MNode):
     elements: list[ietf_interfaces__interfaces__interface__ipv4__address_entry]
     mut def __init__(self, elements=[]):
@@ -9692,7 +10027,7 @@ class ietf_interfaces__interfaces__interface__ipv4__address(yang.adata.MNode):
         self._name = 'address'
         self.elements = elements
 
-    mut def create(self, ip, prefix_length=None, netmask=None):
+    mut def create(self, ip, prefix_length=None, netmask=None, origin=None):
         for e in self:
             match = True
             if e.ip != ip:
@@ -9703,9 +10038,11 @@ class ietf_interfaces__interfaces__interface__ipv4__address(yang.adata.MNode):
                     e.prefix_length = prefix_length
                 if netmask is not None:
                     e.netmask = netmask
+                if origin is not None:
+                    e.origin = origin
                 return e
 
-        res = ietf_interfaces__interfaces__interface__ipv4__address_entry(ip=ip, prefix_length=prefix_length, netmask=netmask)
+        res = ietf_interfaces__interfaces__interface__ipv4__address_entry(ip=ip, prefix_length=prefix_length, netmask=netmask, origin=origin)
         self.elements.append(res)
         return res
 
@@ -9729,34 +10066,38 @@ extension ietf_interfaces__interfaces__interface__ipv4__address(Iterable[ietf_in
     def __iter__(self) -> Iterator[ietf_interfaces__interfaces__interface__ipv4__address_entry]:
         return self.elements.__iter__()
 
-_breaker32 = None
+_breaker36 = None
 class ietf_interfaces__interfaces__interface__ipv4__neighbor_entry(yang.adata.MNode):
     ip: str
     link_layer_address: ?str
+    origin: ?str
 
-    mut def __init__(self, ip: str, link_layer_address: ?str):
+    mut def __init__(self, ip: str, link_layer_address: ?str, origin: ?str):
         self._ns = 'urn:ietf:params:xml:ns:yang:ietf-ip'
         self.ip = ip
         self.link_layer_address = link_layer_address
+        self.origin = origin
 
     def _get_attr(self, name: str) -> ?value:
         if name == 'ip':
             return self.ip
         if name == 'link_layer_address':
             return self.link_layer_address
+        if name == 'origin':
+            return self.origin
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=True, root_path=['ietf-interfaces:interfaces', 'interface', 'ietf-ip:ipv4', 'neighbor'])
 
     @staticmethod
     mut def from_gdata(n: yang.gdata.Node) -> ietf_interfaces__interfaces__interface__ipv4__neighbor_entry:
-        return ietf_interfaces__interfaces__interface__ipv4__neighbor_entry(ip=n.get_str(yang.gdata.Id(NS_ietf_ip, 'ip')), link_layer_address=n.get_opt_str(yang.gdata.Id(NS_ietf_ip, 'link-layer-address')))
+        return ietf_interfaces__interfaces__interface__ipv4__neighbor_entry(ip=n.get_str(yang.gdata.Id(NS_ietf_ip, 'ip')), link_layer_address=n.get_opt_str(yang.gdata.Id(NS_ietf_ip, 'link-layer-address')), origin=n.get_opt_str(yang.gdata.Id(NS_ietf_ip, 'origin')))
 
     def copy(self):
         """Create a deep copy of this adata object"""
         return ietf_interfaces__interfaces__interface__ipv4__neighbor_entry.from_gdata(self.to_gdata())
 
-_breaker33 = None
+_breaker37 = None
 class ietf_interfaces__interfaces__interface__ipv4__neighbor(yang.adata.MNode):
     elements: list[ietf_interfaces__interfaces__interface__ipv4__neighbor_entry]
     mut def __init__(self, elements=[]):
@@ -9764,7 +10105,7 @@ class ietf_interfaces__interfaces__interface__ipv4__neighbor(yang.adata.MNode):
         self._name = 'neighbor'
         self.elements = elements
 
-    mut def create(self, ip, link_layer_address=None):
+    mut def create(self, ip, link_layer_address=None, origin=None):
         for e in self:
             match = True
             if e.ip != ip:
@@ -9773,9 +10114,11 @@ class ietf_interfaces__interfaces__interface__ipv4__neighbor(yang.adata.MNode):
             if match:
                 if link_layer_address is not None:
                     e.link_layer_address = link_layer_address
+                if origin is not None:
+                    e.origin = origin
                 return e
 
-        res = ietf_interfaces__interfaces__interface__ipv4__neighbor_entry(ip=ip, link_layer_address=link_layer_address)
+        res = ietf_interfaces__interfaces__interface__ipv4__neighbor_entry(ip=ip, link_layer_address=link_layer_address, origin=origin)
         self.elements.append(res)
         return res
 
@@ -9799,7 +10142,7 @@ extension ietf_interfaces__interfaces__interface__ipv4__neighbor(Iterable[ietf_i
     def __iter__(self) -> Iterator[ietf_interfaces__interfaces__interface__ipv4__neighbor_entry]:
         return self.elements.__iter__()
 
-_breaker34 = None
+_breaker38 = None
 class ietf_interfaces__interfaces__interface__ipv4(yang.adata.MNode):
     enabled: ?bool
     forwarding: ?bool
@@ -9844,34 +10187,42 @@ class ietf_interfaces__interfaces__interface__ipv4(yang.adata.MNode):
         raise Exception('Unreachable in ietf_interfaces__interfaces__interface__ipv4.copy()')
 
 
-_breaker35 = None
+_breaker39 = None
 class ietf_interfaces__interfaces__interface__ipv6__address_entry(yang.adata.MNode):
     ip: str
     prefix_length: ?u64
+    origin: ?str
+    status: ?str
 
-    mut def __init__(self, ip: str, prefix_length: ?u64):
+    mut def __init__(self, ip: str, prefix_length: ?u64, origin: ?str, status: ?str):
         self._ns = 'urn:ietf:params:xml:ns:yang:ietf-ip'
         self.ip = ip
         self.prefix_length = prefix_length
+        self.origin = origin
+        self.status = status
 
     def _get_attr(self, name: str) -> ?value:
         if name == 'ip':
             return self.ip
         if name == 'prefix_length':
             return self.prefix_length
+        if name == 'origin':
+            return self.origin
+        if name == 'status':
+            return self.status
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=True, root_path=['ietf-interfaces:interfaces', 'interface', 'ietf-ip:ipv6', 'address'])
 
     @staticmethod
     mut def from_gdata(n: yang.gdata.Node) -> ietf_interfaces__interfaces__interface__ipv6__address_entry:
-        return ietf_interfaces__interfaces__interface__ipv6__address_entry(ip=n.get_str(yang.gdata.Id(NS_ietf_ip, 'ip')), prefix_length=n.get_opt_u64(yang.gdata.Id(NS_ietf_ip, 'prefix-length')))
+        return ietf_interfaces__interfaces__interface__ipv6__address_entry(ip=n.get_str(yang.gdata.Id(NS_ietf_ip, 'ip')), prefix_length=n.get_opt_u64(yang.gdata.Id(NS_ietf_ip, 'prefix-length')), origin=n.get_opt_str(yang.gdata.Id(NS_ietf_ip, 'origin')), status=n.get_opt_str(yang.gdata.Id(NS_ietf_ip, 'status')))
 
     def copy(self):
         """Create a deep copy of this adata object"""
         return ietf_interfaces__interfaces__interface__ipv6__address_entry.from_gdata(self.to_gdata())
 
-_breaker36 = None
+_breaker40 = None
 class ietf_interfaces__interfaces__interface__ipv6__address(yang.adata.MNode):
     elements: list[ietf_interfaces__interfaces__interface__ipv6__address_entry]
     mut def __init__(self, elements=[]):
@@ -9879,7 +10230,7 @@ class ietf_interfaces__interfaces__interface__ipv6__address(yang.adata.MNode):
         self._name = 'address'
         self.elements = elements
 
-    mut def create(self, ip, prefix_length=None):
+    mut def create(self, ip, prefix_length=None, origin=None, status=None):
         for e in self:
             match = True
             if e.ip != ip:
@@ -9888,9 +10239,13 @@ class ietf_interfaces__interfaces__interface__ipv6__address(yang.adata.MNode):
             if match:
                 if prefix_length is not None:
                     e.prefix_length = prefix_length
+                if origin is not None:
+                    e.origin = origin
+                if status is not None:
+                    e.status = status
                 return e
 
-        res = ietf_interfaces__interfaces__interface__ipv6__address_entry(ip=ip, prefix_length=prefix_length)
+        res = ietf_interfaces__interfaces__interface__ipv6__address_entry(ip=ip, prefix_length=prefix_length, origin=origin, status=status)
         self.elements.append(res)
         return res
 
@@ -9914,34 +10269,46 @@ extension ietf_interfaces__interfaces__interface__ipv6__address(Iterable[ietf_in
     def __iter__(self) -> Iterator[ietf_interfaces__interfaces__interface__ipv6__address_entry]:
         return self.elements.__iter__()
 
-_breaker37 = None
+_breaker41 = None
 class ietf_interfaces__interfaces__interface__ipv6__neighbor_entry(yang.adata.MNode):
     ip: str
     link_layer_address: ?str
+    origin: ?str
+    is_router: ?bool
+    state: ?str
 
-    mut def __init__(self, ip: str, link_layer_address: ?str):
+    mut def __init__(self, ip: str, link_layer_address: ?str, origin: ?str, is_router: ?bool, state: ?str):
         self._ns = 'urn:ietf:params:xml:ns:yang:ietf-ip'
         self.ip = ip
         self.link_layer_address = link_layer_address
+        self.origin = origin
+        self.is_router = is_router
+        self.state = state
 
     def _get_attr(self, name: str) -> ?value:
         if name == 'ip':
             return self.ip
         if name == 'link_layer_address':
             return self.link_layer_address
+        if name == 'origin':
+            return self.origin
+        if name == 'is_router':
+            return self.is_router
+        if name == 'state':
+            return self.state
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=True, root_path=['ietf-interfaces:interfaces', 'interface', 'ietf-ip:ipv6', 'neighbor'])
 
     @staticmethod
     mut def from_gdata(n: yang.gdata.Node) -> ietf_interfaces__interfaces__interface__ipv6__neighbor_entry:
-        return ietf_interfaces__interfaces__interface__ipv6__neighbor_entry(ip=n.get_str(yang.gdata.Id(NS_ietf_ip, 'ip')), link_layer_address=n.get_opt_str(yang.gdata.Id(NS_ietf_ip, 'link-layer-address')))
+        return ietf_interfaces__interfaces__interface__ipv6__neighbor_entry(ip=n.get_str(yang.gdata.Id(NS_ietf_ip, 'ip')), link_layer_address=n.get_opt_str(yang.gdata.Id(NS_ietf_ip, 'link-layer-address')), origin=n.get_opt_str(yang.gdata.Id(NS_ietf_ip, 'origin')), is_router=n.get_opt_empty(yang.gdata.Id(NS_ietf_ip, 'is-router')), state=n.get_opt_str(yang.gdata.Id(NS_ietf_ip, 'state')))
 
     def copy(self):
         """Create a deep copy of this adata object"""
         return ietf_interfaces__interfaces__interface__ipv6__neighbor_entry.from_gdata(self.to_gdata())
 
-_breaker38 = None
+_breaker42 = None
 class ietf_interfaces__interfaces__interface__ipv6__neighbor(yang.adata.MNode):
     elements: list[ietf_interfaces__interfaces__interface__ipv6__neighbor_entry]
     mut def __init__(self, elements=[]):
@@ -9949,7 +10316,7 @@ class ietf_interfaces__interfaces__interface__ipv6__neighbor(yang.adata.MNode):
         self._name = 'neighbor'
         self.elements = elements
 
-    mut def create(self, ip, link_layer_address=None):
+    mut def create(self, ip, link_layer_address=None, origin=None, is_router=None, state=None):
         for e in self:
             match = True
             if e.ip != ip:
@@ -9958,9 +10325,15 @@ class ietf_interfaces__interfaces__interface__ipv6__neighbor(yang.adata.MNode):
             if match:
                 if link_layer_address is not None:
                     e.link_layer_address = link_layer_address
+                if origin is not None:
+                    e.origin = origin
+                if is_router is not None:
+                    e.is_router = is_router
+                if state is not None:
+                    e.state = state
                 return e
 
-        res = ietf_interfaces__interfaces__interface__ipv6__neighbor_entry(ip=ip, link_layer_address=link_layer_address)
+        res = ietf_interfaces__interfaces__interface__ipv6__neighbor_entry(ip=ip, link_layer_address=link_layer_address, origin=origin, is_router=is_router, state=state)
         self.elements.append(res)
         return res
 
@@ -9984,7 +10357,7 @@ extension ietf_interfaces__interfaces__interface__ipv6__neighbor(Iterable[ietf_i
     def __iter__(self) -> Iterator[ietf_interfaces__interfaces__interface__ipv6__neighbor_entry]:
         return self.elements.__iter__()
 
-_breaker39 = None
+_breaker43 = None
 class ietf_interfaces__interfaces__interface__ipv6__autoconf(yang.adata.MNode):
     create_global_addresses: ?bool
     create_temporary_addresses: ?bool
@@ -10022,7 +10395,7 @@ class ietf_interfaces__interfaces__interface__ipv6__autoconf(yang.adata.MNode):
         return ietf_interfaces__interfaces__interface__ipv6__autoconf.from_gdata(self.to_gdata())
 
 
-_breaker40 = None
+_breaker44 = None
 class ietf_interfaces__interfaces__interface__ipv6(yang.adata.MNode):
     enabled: ?bool
     forwarding: ?bool
@@ -10075,23 +10448,41 @@ class ietf_interfaces__interfaces__interface__ipv6(yang.adata.MNode):
         raise Exception('Unreachable in ietf_interfaces__interfaces__interface__ipv6.copy()')
 
 
-_breaker41 = None
+_breaker45 = None
 class ietf_interfaces__interfaces__interface_entry(yang.adata.MNode):
     name: str
     description: ?str
     type: ?Identityref
     enabled: ?bool
     link_up_down_trap_enable: ?str
+    admin_status: ?str
+    oper_status: ?str
+    last_change: ?str
+    if_index: ?int
+    phys_address: ?str
+    higher_layer_if: list[str]
+    lower_layer_if: list[str]
+    speed: ?u64
+    statistics: ietf_interfaces__interfaces__interface__statistics
     ipv4: ?ietf_interfaces__interfaces__interface__ipv4
     ipv6: ?ietf_interfaces__interfaces__interface__ipv6
 
-    mut def __init__(self, name: str, description: ?str, type: ?Identityref, enabled: ?bool, link_up_down_trap_enable: ?str, ipv4: ?ietf_interfaces__interfaces__interface__ipv4=None, ipv6: ?ietf_interfaces__interfaces__interface__ipv6=None):
+    mut def __init__(self, name: str, description: ?str, type: ?Identityref, enabled: ?bool, link_up_down_trap_enable: ?str, admin_status: ?str, oper_status: ?str, last_change: ?str, if_index: ?int, phys_address: ?str, higher_layer_if: ?list[str]=None, lower_layer_if: ?list[str]=None, speed: ?u64, statistics: ?ietf_interfaces__interfaces__interface__statistics=None, ipv4: ?ietf_interfaces__interfaces__interface__ipv4=None, ipv6: ?ietf_interfaces__interfaces__interface__ipv6=None):
         self._ns = 'urn:ietf:params:xml:ns:yang:ietf-interfaces'
         self.name = name
         self.description = description
         self.type = type
         self.enabled = enabled
         self.link_up_down_trap_enable = link_up_down_trap_enable
+        self.admin_status = admin_status
+        self.oper_status = oper_status
+        self.last_change = last_change
+        self.if_index = if_index
+        self.phys_address = phys_address
+        self.higher_layer_if = higher_layer_if if higher_layer_if is not None else []
+        self.lower_layer_if = lower_layer_if if lower_layer_if is not None else []
+        self.speed = speed
+        self.statistics = statistics if statistics is not None else ietf_interfaces__interfaces__interface__statistics()
         self.ipv4 = ipv4
         self.ipv6 = ipv6
 
@@ -10136,6 +10527,24 @@ class ietf_interfaces__interfaces__interface_entry(yang.adata.MNode):
             return self.enabled
         if name == 'link_up_down_trap_enable':
             return self.link_up_down_trap_enable
+        if name == 'admin_status':
+            return self.admin_status
+        if name == 'oper_status':
+            return self.oper_status
+        if name == 'last_change':
+            return self.last_change
+        if name == 'if_index':
+            return self.if_index
+        if name == 'phys_address':
+            return self.phys_address
+        if name == 'higher_layer_if':
+            return self.higher_layer_if
+        if name == 'lower_layer_if':
+            return self.lower_layer_if
+        if name == 'speed':
+            return self.speed
+        if name == 'statistics':
+            return self.statistics
         if name == 'ipv4':
             return self.ipv4
         if name == 'ipv6':
@@ -10146,13 +10555,13 @@ class ietf_interfaces__interfaces__interface_entry(yang.adata.MNode):
 
     @staticmethod
     mut def from_gdata(n: yang.gdata.Node) -> ietf_interfaces__interfaces__interface_entry:
-        return ietf_interfaces__interfaces__interface_entry(name=n.get_str(yang.gdata.Id(NS_ietf_interfaces, 'name')), description=n.get_opt_str(yang.gdata.Id(NS_ietf_interfaces, 'description')), type=n.get_opt_Identityref(yang.gdata.Id(NS_ietf_interfaces, 'type')), enabled=n.get_opt_bool(yang.gdata.Id(NS_ietf_interfaces, 'enabled')), link_up_down_trap_enable=n.get_opt_str(yang.gdata.Id(NS_ietf_interfaces, 'link-up-down-trap-enable')), ipv4=ietf_interfaces__interfaces__interface__ipv4.from_gdata(n.get_opt_cnt(yang.gdata.Id(NS_ietf_ip, 'ipv4'))), ipv6=ietf_interfaces__interfaces__interface__ipv6.from_gdata(n.get_opt_cnt(yang.gdata.Id(NS_ietf_ip, 'ipv6'))))
+        return ietf_interfaces__interfaces__interface_entry(name=n.get_str(yang.gdata.Id(NS_ietf_interfaces, 'name')), description=n.get_opt_str(yang.gdata.Id(NS_ietf_interfaces, 'description')), type=n.get_opt_Identityref(yang.gdata.Id(NS_ietf_interfaces, 'type')), enabled=n.get_opt_bool(yang.gdata.Id(NS_ietf_interfaces, 'enabled')), link_up_down_trap_enable=n.get_opt_str(yang.gdata.Id(NS_ietf_interfaces, 'link-up-down-trap-enable')), admin_status=n.get_opt_str(yang.gdata.Id(NS_ietf_interfaces, 'admin-status')), oper_status=n.get_opt_str(yang.gdata.Id(NS_ietf_interfaces, 'oper-status')), last_change=n.get_opt_str(yang.gdata.Id(NS_ietf_interfaces, 'last-change')), if_index=n.get_opt_int(yang.gdata.Id(NS_ietf_interfaces, 'if-index')), phys_address=n.get_opt_str(yang.gdata.Id(NS_ietf_interfaces, 'phys-address')), higher_layer_if=n.get_opt_strs(yang.gdata.Id(NS_ietf_interfaces, 'higher-layer-if')), lower_layer_if=n.get_opt_strs(yang.gdata.Id(NS_ietf_interfaces, 'lower-layer-if')), speed=n.get_opt_u64(yang.gdata.Id(NS_ietf_interfaces, 'speed')), statistics=ietf_interfaces__interfaces__interface__statistics.from_gdata(n.get_opt_cnt(yang.gdata.Id(NS_ietf_interfaces, 'statistics'))), ipv4=ietf_interfaces__interfaces__interface__ipv4.from_gdata(n.get_opt_cnt(yang.gdata.Id(NS_ietf_ip, 'ipv4'))), ipv6=ietf_interfaces__interfaces__interface__ipv6.from_gdata(n.get_opt_cnt(yang.gdata.Id(NS_ietf_ip, 'ipv6'))))
 
     def copy(self):
         """Create a deep copy of this adata object"""
         return ietf_interfaces__interfaces__interface_entry.from_gdata(self.to_gdata())
 
-_breaker42 = None
+_breaker46 = None
 class ietf_interfaces__interfaces__interface(yang.adata.MNode):
     elements: list[ietf_interfaces__interfaces__interface_entry]
     mut def __init__(self, elements=[]):
@@ -10160,7 +10569,7 @@ class ietf_interfaces__interfaces__interface(yang.adata.MNode):
         self._name = 'interface'
         self.elements = elements
 
-    mut def create(self, name, description=None, type=None, enabled=None, link_up_down_trap_enable=None):
+    mut def create(self, name, description=None, type=None, enabled=None, link_up_down_trap_enable=None, admin_status=None, oper_status=None, last_change=None, if_index=None, phys_address=None, speed=None):
         for e in self:
             match = True
             if e.name != name:
@@ -10175,9 +10584,21 @@ class ietf_interfaces__interfaces__interface(yang.adata.MNode):
                     e.enabled = enabled
                 if link_up_down_trap_enable is not None:
                     e.link_up_down_trap_enable = link_up_down_trap_enable
+                if admin_status is not None:
+                    e.admin_status = admin_status
+                if oper_status is not None:
+                    e.oper_status = oper_status
+                if last_change is not None:
+                    e.last_change = last_change
+                if if_index is not None:
+                    e.if_index = if_index
+                if phys_address is not None:
+                    e.phys_address = phys_address
+                if speed is not None:
+                    e.speed = speed
                 return e
 
-        res = ietf_interfaces__interfaces__interface_entry(name=name, description=description, type=type, enabled=enabled, link_up_down_trap_enable=link_up_down_trap_enable)
+        res = ietf_interfaces__interfaces__interface_entry(name=name, description=description, type=type, enabled=enabled, link_up_down_trap_enable=link_up_down_trap_enable, admin_status=admin_status, oper_status=oper_status, last_change=last_change, if_index=if_index, phys_address=phys_address, speed=speed)
         self.elements.append(res)
         return res
 
@@ -10201,7 +10622,7 @@ extension ietf_interfaces__interfaces__interface(Iterable[ietf_interfaces__inter
     def __iter__(self) -> Iterator[ietf_interfaces__interfaces__interface_entry]:
         return self.elements.__iter__()
 
-_breaker43 = None
+_breaker47 = None
 class ietf_interfaces__interfaces(yang.adata.MNode):
     interface: ietf_interfaces__interfaces__interface
 
@@ -10227,25 +10648,697 @@ class ietf_interfaces__interfaces(yang.adata.MNode):
         return ietf_interfaces__interfaces.from_gdata(self.to_gdata())
 
 
-_breaker44 = None
+_breaker48 = None
+class ietf_interfaces__interfaces_state__interface__statistics(yang.adata.MNode):
+    discontinuity_time: ?str
+    in_octets: ?u64
+    in_unicast_pkts: ?u64
+    in_broadcast_pkts: ?u64
+    in_multicast_pkts: ?u64
+    in_discards: ?u64
+    in_errors: ?u64
+    in_unknown_protos: ?u64
+    out_octets: ?u64
+    out_unicast_pkts: ?u64
+    out_broadcast_pkts: ?u64
+    out_multicast_pkts: ?u64
+    out_discards: ?u64
+    out_errors: ?u64
+
+    mut def __init__(self, discontinuity_time: ?str, in_octets: ?u64, in_unicast_pkts: ?u64, in_broadcast_pkts: ?u64, in_multicast_pkts: ?u64, in_discards: ?u64, in_errors: ?u64, in_unknown_protos: ?u64, out_octets: ?u64, out_unicast_pkts: ?u64, out_broadcast_pkts: ?u64, out_multicast_pkts: ?u64, out_discards: ?u64, out_errors: ?u64):
+        self._ns = 'urn:ietf:params:xml:ns:yang:ietf-interfaces'
+        self.discontinuity_time = discontinuity_time
+        self.in_octets = in_octets
+        self.in_unicast_pkts = in_unicast_pkts
+        self.in_broadcast_pkts = in_broadcast_pkts
+        self.in_multicast_pkts = in_multicast_pkts
+        self.in_discards = in_discards
+        self.in_errors = in_errors
+        self.in_unknown_protos = in_unknown_protos
+        self.out_octets = out_octets
+        self.out_unicast_pkts = out_unicast_pkts
+        self.out_broadcast_pkts = out_broadcast_pkts
+        self.out_multicast_pkts = out_multicast_pkts
+        self.out_discards = out_discards
+        self.out_errors = out_errors
+
+    def _get_attr(self, name: str) -> ?value:
+        if name == 'discontinuity_time':
+            return self.discontinuity_time
+        if name == 'in_octets':
+            return self.in_octets
+        if name == 'in_unicast_pkts':
+            return self.in_unicast_pkts
+        if name == 'in_broadcast_pkts':
+            return self.in_broadcast_pkts
+        if name == 'in_multicast_pkts':
+            return self.in_multicast_pkts
+        if name == 'in_discards':
+            return self.in_discards
+        if name == 'in_errors':
+            return self.in_errors
+        if name == 'in_unknown_protos':
+            return self.in_unknown_protos
+        if name == 'out_octets':
+            return self.out_octets
+        if name == 'out_unicast_pkts':
+            return self.out_unicast_pkts
+        if name == 'out_broadcast_pkts':
+            return self.out_broadcast_pkts
+        if name == 'out_multicast_pkts':
+            return self.out_multicast_pkts
+        if name == 'out_discards':
+            return self.out_discards
+        if name == 'out_errors':
+            return self.out_errors
+
+    mut def to_gdata(self) -> yang.gdata.Node:
+        return yang.adata.from_adata(SRC_DNODE, self, loose=True, root_path=['ietf-interfaces:interfaces-state', 'interface', 'statistics'])
+
+    @staticmethod
+    mut def from_gdata(n: ?yang.gdata.Node) -> ietf_interfaces__interfaces_state__interface__statistics:
+        if n is not None:
+            return ietf_interfaces__interfaces_state__interface__statistics(discontinuity_time=n.get_opt_str(yang.gdata.Id(NS_ietf_interfaces, 'discontinuity-time')), in_octets=n.get_opt_u64(yang.gdata.Id(NS_ietf_interfaces, 'in-octets')), in_unicast_pkts=n.get_opt_u64(yang.gdata.Id(NS_ietf_interfaces, 'in-unicast-pkts')), in_broadcast_pkts=n.get_opt_u64(yang.gdata.Id(NS_ietf_interfaces, 'in-broadcast-pkts')), in_multicast_pkts=n.get_opt_u64(yang.gdata.Id(NS_ietf_interfaces, 'in-multicast-pkts')), in_discards=n.get_opt_u64(yang.gdata.Id(NS_ietf_interfaces, 'in-discards')), in_errors=n.get_opt_u64(yang.gdata.Id(NS_ietf_interfaces, 'in-errors')), in_unknown_protos=n.get_opt_u64(yang.gdata.Id(NS_ietf_interfaces, 'in-unknown-protos')), out_octets=n.get_opt_u64(yang.gdata.Id(NS_ietf_interfaces, 'out-octets')), out_unicast_pkts=n.get_opt_u64(yang.gdata.Id(NS_ietf_interfaces, 'out-unicast-pkts')), out_broadcast_pkts=n.get_opt_u64(yang.gdata.Id(NS_ietf_interfaces, 'out-broadcast-pkts')), out_multicast_pkts=n.get_opt_u64(yang.gdata.Id(NS_ietf_interfaces, 'out-multicast-pkts')), out_discards=n.get_opt_u64(yang.gdata.Id(NS_ietf_interfaces, 'out-discards')), out_errors=n.get_opt_u64(yang.gdata.Id(NS_ietf_interfaces, 'out-errors')))
+        return ietf_interfaces__interfaces_state__interface__statistics()
+
+    def copy(self):
+        """Create a deep copy of this adata object"""
+        return ietf_interfaces__interfaces_state__interface__statistics.from_gdata(self.to_gdata())
+
+
+_breaker49 = None
+class ietf_interfaces__interfaces_state__interface__ipv4__address_entry(yang.adata.MNode):
+    ip: str
+    prefix_length: ?u64
+    netmask: ?str
+    origin: ?str
+
+    mut def __init__(self, ip: str, prefix_length: ?u64, netmask: ?str, origin: ?str):
+        self._ns = 'urn:ietf:params:xml:ns:yang:ietf-ip'
+        self.ip = ip
+        self.prefix_length = prefix_length
+        self.netmask = netmask
+        self.origin = origin
+
+    def _get_attr(self, name: str) -> ?value:
+        if name == 'ip':
+            return self.ip
+        if name == 'prefix_length':
+            return self.prefix_length
+        if name == 'netmask':
+            return self.netmask
+        if name == 'origin':
+            return self.origin
+
+    mut def to_gdata(self) -> yang.gdata.Node:
+        return yang.adata.from_adata(SRC_DNODE, self, loose=True, root_path=['ietf-interfaces:interfaces-state', 'interface', 'ietf-ip:ipv4', 'address'])
+
+    @staticmethod
+    mut def from_gdata(n: yang.gdata.Node) -> ietf_interfaces__interfaces_state__interface__ipv4__address_entry:
+        return ietf_interfaces__interfaces_state__interface__ipv4__address_entry(ip=n.get_str(yang.gdata.Id(NS_ietf_ip, 'ip')), prefix_length=n.get_opt_u64(yang.gdata.Id(NS_ietf_ip, 'prefix-length')), netmask=n.get_opt_str(yang.gdata.Id(NS_ietf_ip, 'netmask')), origin=n.get_opt_str(yang.gdata.Id(NS_ietf_ip, 'origin')))
+
+    def copy(self):
+        """Create a deep copy of this adata object"""
+        return ietf_interfaces__interfaces_state__interface__ipv4__address_entry.from_gdata(self.to_gdata())
+
+_breaker50 = None
+class ietf_interfaces__interfaces_state__interface__ipv4__address(yang.adata.MNode):
+    elements: list[ietf_interfaces__interfaces_state__interface__ipv4__address_entry]
+    mut def __init__(self, elements=[]):
+        self._ns = 'urn:ietf:params:xml:ns:yang:ietf-ip'
+        self._name = 'address'
+        self.elements = elements
+
+    mut def create(self, ip, prefix_length=None, netmask=None, origin=None):
+        for e in self:
+            match = True
+            if e.ip != ip:
+                match = False
+                continue
+            if match:
+                if prefix_length is not None:
+                    e.prefix_length = prefix_length
+                if netmask is not None:
+                    e.netmask = netmask
+                if origin is not None:
+                    e.origin = origin
+                return e
+
+        res = ietf_interfaces__interfaces_state__interface__ipv4__address_entry(ip=ip, prefix_length=prefix_length, netmask=netmask, origin=origin)
+        self.elements.append(res)
+        return res
+
+    @staticmethod
+    mut def from_gdata(n: ?yang.gdata.List) -> list[ietf_interfaces__interfaces_state__interface__ipv4__address_entry]:
+        if n is not None:
+            return [ietf_interfaces__interfaces_state__interface__ipv4__address_entry.from_gdata(e) for e in n.elements]
+        return []
+
+    def copy(self):
+        """Create a deep copy of this list object"""
+        # Copy each element in the list
+        copied_elements = []
+        for e in self:
+            ce = e.copy()
+            if ce is not None:
+                copied_elements.append(ce)
+        return ietf_interfaces__interfaces_state__interface__ipv4__address(elements=copied_elements)
+
+extension ietf_interfaces__interfaces_state__interface__ipv4__address(Iterable[ietf_interfaces__interfaces_state__interface__ipv4__address_entry]):
+    def __iter__(self) -> Iterator[ietf_interfaces__interfaces_state__interface__ipv4__address_entry]:
+        return self.elements.__iter__()
+
+_breaker51 = None
+class ietf_interfaces__interfaces_state__interface__ipv4__neighbor_entry(yang.adata.MNode):
+    ip: str
+    link_layer_address: ?str
+    origin: ?str
+
+    mut def __init__(self, ip: str, link_layer_address: ?str, origin: ?str):
+        self._ns = 'urn:ietf:params:xml:ns:yang:ietf-ip'
+        self.ip = ip
+        self.link_layer_address = link_layer_address
+        self.origin = origin
+
+    def _get_attr(self, name: str) -> ?value:
+        if name == 'ip':
+            return self.ip
+        if name == 'link_layer_address':
+            return self.link_layer_address
+        if name == 'origin':
+            return self.origin
+
+    mut def to_gdata(self) -> yang.gdata.Node:
+        return yang.adata.from_adata(SRC_DNODE, self, loose=True, root_path=['ietf-interfaces:interfaces-state', 'interface', 'ietf-ip:ipv4', 'neighbor'])
+
+    @staticmethod
+    mut def from_gdata(n: yang.gdata.Node) -> ietf_interfaces__interfaces_state__interface__ipv4__neighbor_entry:
+        return ietf_interfaces__interfaces_state__interface__ipv4__neighbor_entry(ip=n.get_str(yang.gdata.Id(NS_ietf_ip, 'ip')), link_layer_address=n.get_opt_str(yang.gdata.Id(NS_ietf_ip, 'link-layer-address')), origin=n.get_opt_str(yang.gdata.Id(NS_ietf_ip, 'origin')))
+
+    def copy(self):
+        """Create a deep copy of this adata object"""
+        return ietf_interfaces__interfaces_state__interface__ipv4__neighbor_entry.from_gdata(self.to_gdata())
+
+_breaker52 = None
+class ietf_interfaces__interfaces_state__interface__ipv4__neighbor(yang.adata.MNode):
+    elements: list[ietf_interfaces__interfaces_state__interface__ipv4__neighbor_entry]
+    mut def __init__(self, elements=[]):
+        self._ns = 'urn:ietf:params:xml:ns:yang:ietf-ip'
+        self._name = 'neighbor'
+        self.elements = elements
+
+    mut def create(self, ip, link_layer_address=None, origin=None):
+        for e in self:
+            match = True
+            if e.ip != ip:
+                match = False
+                continue
+            if match:
+                if link_layer_address is not None:
+                    e.link_layer_address = link_layer_address
+                if origin is not None:
+                    e.origin = origin
+                return e
+
+        res = ietf_interfaces__interfaces_state__interface__ipv4__neighbor_entry(ip=ip, link_layer_address=link_layer_address, origin=origin)
+        self.elements.append(res)
+        return res
+
+    @staticmethod
+    mut def from_gdata(n: ?yang.gdata.List) -> list[ietf_interfaces__interfaces_state__interface__ipv4__neighbor_entry]:
+        if n is not None:
+            return [ietf_interfaces__interfaces_state__interface__ipv4__neighbor_entry.from_gdata(e) for e in n.elements]
+        return []
+
+    def copy(self):
+        """Create a deep copy of this list object"""
+        # Copy each element in the list
+        copied_elements = []
+        for e in self:
+            ce = e.copy()
+            if ce is not None:
+                copied_elements.append(ce)
+        return ietf_interfaces__interfaces_state__interface__ipv4__neighbor(elements=copied_elements)
+
+extension ietf_interfaces__interfaces_state__interface__ipv4__neighbor(Iterable[ietf_interfaces__interfaces_state__interface__ipv4__neighbor_entry]):
+    def __iter__(self) -> Iterator[ietf_interfaces__interfaces_state__interface__ipv4__neighbor_entry]:
+        return self.elements.__iter__()
+
+_breaker53 = None
+class ietf_interfaces__interfaces_state__interface__ipv4(yang.adata.MNode):
+    forwarding: ?bool
+    mtu: ?u64
+    address: ietf_interfaces__interfaces_state__interface__ipv4__address
+    neighbor: ietf_interfaces__interfaces_state__interface__ipv4__neighbor
+
+    mut def __init__(self, forwarding: ?bool, mtu: ?u64, address: list[ietf_interfaces__interfaces_state__interface__ipv4__address_entry]=[], neighbor: list[ietf_interfaces__interfaces_state__interface__ipv4__neighbor_entry]=[]):
+        self._ns = 'urn:ietf:params:xml:ns:yang:ietf-ip'
+        self.forwarding = forwarding
+        self.mtu = mtu
+        self.address = ietf_interfaces__interfaces_state__interface__ipv4__address(elements=address)
+        self.neighbor = ietf_interfaces__interfaces_state__interface__ipv4__neighbor(elements=neighbor)
+
+    def _get_attr(self, name: str) -> ?value:
+        if name == 'forwarding':
+            return self.forwarding
+        if name == 'mtu':
+            return self.mtu
+        if name == 'address':
+            return iter(self.address)
+        if name == 'neighbor':
+            return iter(self.neighbor)
+
+    mut def to_gdata(self) -> yang.gdata.Node:
+        return yang.adata.from_adata(SRC_DNODE, self, loose=True, root_path=['ietf-interfaces:interfaces-state', 'interface', 'ietf-ip:ipv4'])
+
+    @staticmethod
+    mut def from_gdata(n: ?yang.gdata.Node) -> ?ietf_interfaces__interfaces_state__interface__ipv4:
+        if n is not None:
+            return ietf_interfaces__interfaces_state__interface__ipv4(forwarding=n.get_opt_bool(yang.gdata.Id(NS_ietf_ip, 'forwarding')), mtu=n.get_opt_u64(yang.gdata.Id(NS_ietf_ip, 'mtu')), address=ietf_interfaces__interfaces_state__interface__ipv4__address.from_gdata(n.get_opt_list(yang.gdata.Id(NS_ietf_ip, 'address'))), neighbor=ietf_interfaces__interfaces_state__interface__ipv4__neighbor.from_gdata(n.get_opt_list(yang.gdata.Id(NS_ietf_ip, 'neighbor'))))
+        return None
+
+    def copy(self):
+        """Create a deep copy of this adata object"""
+        ad = ietf_interfaces__interfaces_state__interface__ipv4.from_gdata(self.to_gdata())
+        if ad is not None:
+            return ad
+        raise Exception('Unreachable in ietf_interfaces__interfaces_state__interface__ipv4.copy()')
+
+
+_breaker54 = None
+class ietf_interfaces__interfaces_state__interface__ipv6__address_entry(yang.adata.MNode):
+    ip: str
+    prefix_length: ?u64
+    origin: ?str
+    status: ?str
+
+    mut def __init__(self, ip: str, prefix_length: ?u64, origin: ?str, status: ?str):
+        self._ns = 'urn:ietf:params:xml:ns:yang:ietf-ip'
+        self.ip = ip
+        self.prefix_length = prefix_length
+        self.origin = origin
+        self.status = status
+
+    def _get_attr(self, name: str) -> ?value:
+        if name == 'ip':
+            return self.ip
+        if name == 'prefix_length':
+            return self.prefix_length
+        if name == 'origin':
+            return self.origin
+        if name == 'status':
+            return self.status
+
+    mut def to_gdata(self) -> yang.gdata.Node:
+        return yang.adata.from_adata(SRC_DNODE, self, loose=True, root_path=['ietf-interfaces:interfaces-state', 'interface', 'ietf-ip:ipv6', 'address'])
+
+    @staticmethod
+    mut def from_gdata(n: yang.gdata.Node) -> ietf_interfaces__interfaces_state__interface__ipv6__address_entry:
+        return ietf_interfaces__interfaces_state__interface__ipv6__address_entry(ip=n.get_str(yang.gdata.Id(NS_ietf_ip, 'ip')), prefix_length=n.get_opt_u64(yang.gdata.Id(NS_ietf_ip, 'prefix-length')), origin=n.get_opt_str(yang.gdata.Id(NS_ietf_ip, 'origin')), status=n.get_opt_str(yang.gdata.Id(NS_ietf_ip, 'status')))
+
+    def copy(self):
+        """Create a deep copy of this adata object"""
+        return ietf_interfaces__interfaces_state__interface__ipv6__address_entry.from_gdata(self.to_gdata())
+
+_breaker55 = None
+class ietf_interfaces__interfaces_state__interface__ipv6__address(yang.adata.MNode):
+    elements: list[ietf_interfaces__interfaces_state__interface__ipv6__address_entry]
+    mut def __init__(self, elements=[]):
+        self._ns = 'urn:ietf:params:xml:ns:yang:ietf-ip'
+        self._name = 'address'
+        self.elements = elements
+
+    mut def create(self, ip, prefix_length=None, origin=None, status=None):
+        for e in self:
+            match = True
+            if e.ip != ip:
+                match = False
+                continue
+            if match:
+                if prefix_length is not None:
+                    e.prefix_length = prefix_length
+                if origin is not None:
+                    e.origin = origin
+                if status is not None:
+                    e.status = status
+                return e
+
+        res = ietf_interfaces__interfaces_state__interface__ipv6__address_entry(ip=ip, prefix_length=prefix_length, origin=origin, status=status)
+        self.elements.append(res)
+        return res
+
+    @staticmethod
+    mut def from_gdata(n: ?yang.gdata.List) -> list[ietf_interfaces__interfaces_state__interface__ipv6__address_entry]:
+        if n is not None:
+            return [ietf_interfaces__interfaces_state__interface__ipv6__address_entry.from_gdata(e) for e in n.elements]
+        return []
+
+    def copy(self):
+        """Create a deep copy of this list object"""
+        # Copy each element in the list
+        copied_elements = []
+        for e in self:
+            ce = e.copy()
+            if ce is not None:
+                copied_elements.append(ce)
+        return ietf_interfaces__interfaces_state__interface__ipv6__address(elements=copied_elements)
+
+extension ietf_interfaces__interfaces_state__interface__ipv6__address(Iterable[ietf_interfaces__interfaces_state__interface__ipv6__address_entry]):
+    def __iter__(self) -> Iterator[ietf_interfaces__interfaces_state__interface__ipv6__address_entry]:
+        return self.elements.__iter__()
+
+_breaker56 = None
+class ietf_interfaces__interfaces_state__interface__ipv6__neighbor_entry(yang.adata.MNode):
+    ip: str
+    link_layer_address: ?str
+    origin: ?str
+    is_router: ?bool
+    state: ?str
+
+    mut def __init__(self, ip: str, link_layer_address: ?str, origin: ?str, is_router: ?bool, state: ?str):
+        self._ns = 'urn:ietf:params:xml:ns:yang:ietf-ip'
+        self.ip = ip
+        self.link_layer_address = link_layer_address
+        self.origin = origin
+        self.is_router = is_router
+        self.state = state
+
+    def _get_attr(self, name: str) -> ?value:
+        if name == 'ip':
+            return self.ip
+        if name == 'link_layer_address':
+            return self.link_layer_address
+        if name == 'origin':
+            return self.origin
+        if name == 'is_router':
+            return self.is_router
+        if name == 'state':
+            return self.state
+
+    mut def to_gdata(self) -> yang.gdata.Node:
+        return yang.adata.from_adata(SRC_DNODE, self, loose=True, root_path=['ietf-interfaces:interfaces-state', 'interface', 'ietf-ip:ipv6', 'neighbor'])
+
+    @staticmethod
+    mut def from_gdata(n: yang.gdata.Node) -> ietf_interfaces__interfaces_state__interface__ipv6__neighbor_entry:
+        return ietf_interfaces__interfaces_state__interface__ipv6__neighbor_entry(ip=n.get_str(yang.gdata.Id(NS_ietf_ip, 'ip')), link_layer_address=n.get_opt_str(yang.gdata.Id(NS_ietf_ip, 'link-layer-address')), origin=n.get_opt_str(yang.gdata.Id(NS_ietf_ip, 'origin')), is_router=n.get_opt_empty(yang.gdata.Id(NS_ietf_ip, 'is-router')), state=n.get_opt_str(yang.gdata.Id(NS_ietf_ip, 'state')))
+
+    def copy(self):
+        """Create a deep copy of this adata object"""
+        return ietf_interfaces__interfaces_state__interface__ipv6__neighbor_entry.from_gdata(self.to_gdata())
+
+_breaker57 = None
+class ietf_interfaces__interfaces_state__interface__ipv6__neighbor(yang.adata.MNode):
+    elements: list[ietf_interfaces__interfaces_state__interface__ipv6__neighbor_entry]
+    mut def __init__(self, elements=[]):
+        self._ns = 'urn:ietf:params:xml:ns:yang:ietf-ip'
+        self._name = 'neighbor'
+        self.elements = elements
+
+    mut def create(self, ip, link_layer_address=None, origin=None, is_router=None, state=None):
+        for e in self:
+            match = True
+            if e.ip != ip:
+                match = False
+                continue
+            if match:
+                if link_layer_address is not None:
+                    e.link_layer_address = link_layer_address
+                if origin is not None:
+                    e.origin = origin
+                if is_router is not None:
+                    e.is_router = is_router
+                if state is not None:
+                    e.state = state
+                return e
+
+        res = ietf_interfaces__interfaces_state__interface__ipv6__neighbor_entry(ip=ip, link_layer_address=link_layer_address, origin=origin, is_router=is_router, state=state)
+        self.elements.append(res)
+        return res
+
+    @staticmethod
+    mut def from_gdata(n: ?yang.gdata.List) -> list[ietf_interfaces__interfaces_state__interface__ipv6__neighbor_entry]:
+        if n is not None:
+            return [ietf_interfaces__interfaces_state__interface__ipv6__neighbor_entry.from_gdata(e) for e in n.elements]
+        return []
+
+    def copy(self):
+        """Create a deep copy of this list object"""
+        # Copy each element in the list
+        copied_elements = []
+        for e in self:
+            ce = e.copy()
+            if ce is not None:
+                copied_elements.append(ce)
+        return ietf_interfaces__interfaces_state__interface__ipv6__neighbor(elements=copied_elements)
+
+extension ietf_interfaces__interfaces_state__interface__ipv6__neighbor(Iterable[ietf_interfaces__interfaces_state__interface__ipv6__neighbor_entry]):
+    def __iter__(self) -> Iterator[ietf_interfaces__interfaces_state__interface__ipv6__neighbor_entry]:
+        return self.elements.__iter__()
+
+_breaker58 = None
+class ietf_interfaces__interfaces_state__interface__ipv6(yang.adata.MNode):
+    forwarding: ?bool
+    mtu: ?u64
+    address: ietf_interfaces__interfaces_state__interface__ipv6__address
+    neighbor: ietf_interfaces__interfaces_state__interface__ipv6__neighbor
+
+    mut def __init__(self, forwarding: ?bool, mtu: ?u64, address: list[ietf_interfaces__interfaces_state__interface__ipv6__address_entry]=[], neighbor: list[ietf_interfaces__interfaces_state__interface__ipv6__neighbor_entry]=[]):
+        self._ns = 'urn:ietf:params:xml:ns:yang:ietf-ip'
+        self.forwarding = forwarding
+        self.mtu = mtu
+        self.address = ietf_interfaces__interfaces_state__interface__ipv6__address(elements=address)
+        self.neighbor = ietf_interfaces__interfaces_state__interface__ipv6__neighbor(elements=neighbor)
+
+    def _get_attr(self, name: str) -> ?value:
+        if name == 'forwarding':
+            return self.forwarding
+        if name == 'mtu':
+            return self.mtu
+        if name == 'address':
+            return iter(self.address)
+        if name == 'neighbor':
+            return iter(self.neighbor)
+
+    mut def to_gdata(self) -> yang.gdata.Node:
+        return yang.adata.from_adata(SRC_DNODE, self, loose=True, root_path=['ietf-interfaces:interfaces-state', 'interface', 'ietf-ip:ipv6'])
+
+    @staticmethod
+    mut def from_gdata(n: ?yang.gdata.Node) -> ?ietf_interfaces__interfaces_state__interface__ipv6:
+        if n is not None:
+            return ietf_interfaces__interfaces_state__interface__ipv6(forwarding=n.get_opt_bool(yang.gdata.Id(NS_ietf_ip, 'forwarding')), mtu=n.get_opt_u64(yang.gdata.Id(NS_ietf_ip, 'mtu')), address=ietf_interfaces__interfaces_state__interface__ipv6__address.from_gdata(n.get_opt_list(yang.gdata.Id(NS_ietf_ip, 'address'))), neighbor=ietf_interfaces__interfaces_state__interface__ipv6__neighbor.from_gdata(n.get_opt_list(yang.gdata.Id(NS_ietf_ip, 'neighbor'))))
+        return None
+
+    def copy(self):
+        """Create a deep copy of this adata object"""
+        ad = ietf_interfaces__interfaces_state__interface__ipv6.from_gdata(self.to_gdata())
+        if ad is not None:
+            return ad
+        raise Exception('Unreachable in ietf_interfaces__interfaces_state__interface__ipv6.copy()')
+
+
+_breaker59 = None
+class ietf_interfaces__interfaces_state__interface_entry(yang.adata.MNode):
+    name: str
+    type: ?Identityref
+    admin_status: ?str
+    oper_status: ?str
+    last_change: ?str
+    if_index: ?int
+    phys_address: ?str
+    higher_layer_if: list[str]
+    lower_layer_if: list[str]
+    speed: ?u64
+    statistics: ietf_interfaces__interfaces_state__interface__statistics
+    ipv4: ?ietf_interfaces__interfaces_state__interface__ipv4
+    ipv6: ?ietf_interfaces__interfaces_state__interface__ipv6
+
+    mut def __init__(self, name: str, type: ?Identityref, admin_status: ?str, oper_status: ?str, last_change: ?str, if_index: ?int, phys_address: ?str, higher_layer_if: ?list[str]=None, lower_layer_if: ?list[str]=None, speed: ?u64, statistics: ?ietf_interfaces__interfaces_state__interface__statistics=None, ipv4: ?ietf_interfaces__interfaces_state__interface__ipv4=None, ipv6: ?ietf_interfaces__interfaces_state__interface__ipv6=None):
+        self._ns = 'urn:ietf:params:xml:ns:yang:ietf-interfaces'
+        self.name = name
+        self.type = type
+        self.admin_status = admin_status
+        self.oper_status = oper_status
+        self.last_change = last_change
+        self.if_index = if_index
+        self.phys_address = phys_address
+        self.higher_layer_if = higher_layer_if if higher_layer_if is not None else []
+        self.lower_layer_if = lower_layer_if if lower_layer_if is not None else []
+        self.speed = speed
+        self.statistics = statistics if statistics is not None else ietf_interfaces__interfaces_state__interface__statistics()
+        self.ipv4 = ipv4
+        self.ipv6 = ipv6
+
+    mut def create_ipv4(self, forwarding=None, mtu=None):
+        existing = self.ipv4
+        if existing is not None:
+            if forwarding is not None:
+                existing.forwarding = forwarding
+            if mtu is not None:
+                existing.mtu = mtu
+            return existing
+        res = ietf_interfaces__interfaces_state__interface__ipv4(forwarding=forwarding, mtu=mtu)
+        self.ipv4 = res
+        return res
+
+    mut def create_ipv6(self, forwarding=None, mtu=None):
+        existing = self.ipv6
+        if existing is not None:
+            if forwarding is not None:
+                existing.forwarding = forwarding
+            if mtu is not None:
+                existing.mtu = mtu
+            return existing
+        res = ietf_interfaces__interfaces_state__interface__ipv6(forwarding=forwarding, mtu=mtu)
+        self.ipv6 = res
+        return res
+
+    def _get_attr(self, name: str) -> ?value:
+        if name == 'name':
+            return self.name
+        if name == 'type':
+            return self.type
+        if name == 'admin_status':
+            return self.admin_status
+        if name == 'oper_status':
+            return self.oper_status
+        if name == 'last_change':
+            return self.last_change
+        if name == 'if_index':
+            return self.if_index
+        if name == 'phys_address':
+            return self.phys_address
+        if name == 'higher_layer_if':
+            return self.higher_layer_if
+        if name == 'lower_layer_if':
+            return self.lower_layer_if
+        if name == 'speed':
+            return self.speed
+        if name == 'statistics':
+            return self.statistics
+        if name == 'ipv4':
+            return self.ipv4
+        if name == 'ipv6':
+            return self.ipv6
+
+    mut def to_gdata(self) -> yang.gdata.Node:
+        return yang.adata.from_adata(SRC_DNODE, self, loose=True, root_path=['ietf-interfaces:interfaces-state', 'interface'])
+
+    @staticmethod
+    mut def from_gdata(n: yang.gdata.Node) -> ietf_interfaces__interfaces_state__interface_entry:
+        return ietf_interfaces__interfaces_state__interface_entry(name=n.get_str(yang.gdata.Id(NS_ietf_interfaces, 'name')), type=n.get_opt_Identityref(yang.gdata.Id(NS_ietf_interfaces, 'type')), admin_status=n.get_opt_str(yang.gdata.Id(NS_ietf_interfaces, 'admin-status')), oper_status=n.get_opt_str(yang.gdata.Id(NS_ietf_interfaces, 'oper-status')), last_change=n.get_opt_str(yang.gdata.Id(NS_ietf_interfaces, 'last-change')), if_index=n.get_opt_int(yang.gdata.Id(NS_ietf_interfaces, 'if-index')), phys_address=n.get_opt_str(yang.gdata.Id(NS_ietf_interfaces, 'phys-address')), higher_layer_if=n.get_opt_strs(yang.gdata.Id(NS_ietf_interfaces, 'higher-layer-if')), lower_layer_if=n.get_opt_strs(yang.gdata.Id(NS_ietf_interfaces, 'lower-layer-if')), speed=n.get_opt_u64(yang.gdata.Id(NS_ietf_interfaces, 'speed')), statistics=ietf_interfaces__interfaces_state__interface__statistics.from_gdata(n.get_opt_cnt(yang.gdata.Id(NS_ietf_interfaces, 'statistics'))), ipv4=ietf_interfaces__interfaces_state__interface__ipv4.from_gdata(n.get_opt_cnt(yang.gdata.Id(NS_ietf_ip, 'ipv4'))), ipv6=ietf_interfaces__interfaces_state__interface__ipv6.from_gdata(n.get_opt_cnt(yang.gdata.Id(NS_ietf_ip, 'ipv6'))))
+
+    def copy(self):
+        """Create a deep copy of this adata object"""
+        return ietf_interfaces__interfaces_state__interface_entry.from_gdata(self.to_gdata())
+
+_breaker60 = None
+class ietf_interfaces__interfaces_state__interface(yang.adata.MNode):
+    elements: list[ietf_interfaces__interfaces_state__interface_entry]
+    mut def __init__(self, elements=[]):
+        self._ns = 'urn:ietf:params:xml:ns:yang:ietf-interfaces'
+        self._name = 'interface'
+        self.elements = elements
+
+    mut def create(self, name, type=None, admin_status=None, oper_status=None, last_change=None, if_index=None, phys_address=None, speed=None):
+        for e in self:
+            match = True
+            if e.name != name:
+                match = False
+                continue
+            if match:
+                if type is not None:
+                    e.type = type
+                if admin_status is not None:
+                    e.admin_status = admin_status
+                if oper_status is not None:
+                    e.oper_status = oper_status
+                if last_change is not None:
+                    e.last_change = last_change
+                if if_index is not None:
+                    e.if_index = if_index
+                if phys_address is not None:
+                    e.phys_address = phys_address
+                if speed is not None:
+                    e.speed = speed
+                return e
+
+        res = ietf_interfaces__interfaces_state__interface_entry(name=name, type=type, admin_status=admin_status, oper_status=oper_status, last_change=last_change, if_index=if_index, phys_address=phys_address, speed=speed)
+        self.elements.append(res)
+        return res
+
+    @staticmethod
+    mut def from_gdata(n: ?yang.gdata.List) -> list[ietf_interfaces__interfaces_state__interface_entry]:
+        if n is not None:
+            return [ietf_interfaces__interfaces_state__interface_entry.from_gdata(e) for e in n.elements]
+        return []
+
+    def copy(self):
+        """Create a deep copy of this list object"""
+        # Copy each element in the list
+        copied_elements = []
+        for e in self:
+            ce = e.copy()
+            if ce is not None:
+                copied_elements.append(ce)
+        return ietf_interfaces__interfaces_state__interface(elements=copied_elements)
+
+extension ietf_interfaces__interfaces_state__interface(Iterable[ietf_interfaces__interfaces_state__interface_entry]):
+    def __iter__(self) -> Iterator[ietf_interfaces__interfaces_state__interface_entry]:
+        return self.elements.__iter__()
+
+_breaker61 = None
+class ietf_interfaces__interfaces_state(yang.adata.MNode):
+    interface: ietf_interfaces__interfaces_state__interface
+
+    mut def __init__(self, interface: list[ietf_interfaces__interfaces_state__interface_entry]=[]):
+        self._ns = 'urn:ietf:params:xml:ns:yang:ietf-interfaces'
+        self.interface = ietf_interfaces__interfaces_state__interface(elements=interface)
+
+    def _get_attr(self, name: str) -> ?value:
+        if name == 'interface':
+            return iter(self.interface)
+
+    mut def to_gdata(self) -> yang.gdata.Node:
+        return yang.adata.from_adata(SRC_DNODE, self, loose=True, root_path=['ietf-interfaces:interfaces-state'])
+
+    @staticmethod
+    mut def from_gdata(n: ?yang.gdata.Node) -> ietf_interfaces__interfaces_state:
+        if n is not None:
+            return ietf_interfaces__interfaces_state(interface=ietf_interfaces__interfaces_state__interface.from_gdata(n.get_opt_list(yang.gdata.Id(NS_ietf_interfaces, 'interface'))))
+        return ietf_interfaces__interfaces_state()
+
+    def copy(self):
+        """Create a deep copy of this adata object"""
+        return ietf_interfaces__interfaces_state.from_gdata(self.to_gdata())
+
+
+_breaker62 = None
 class root(yang.adata.MNode):
     nacm: ietf_netconf_acm__nacm
     system: ietf_system__system
+    system_state: ietf_system__system_state
     interfaces: ietf_interfaces__interfaces
+    interfaces_state: ietf_interfaces__interfaces_state
 
-    mut def __init__(self, nacm: ?ietf_netconf_acm__nacm=None, system: ?ietf_system__system=None, interfaces: ?ietf_interfaces__interfaces=None):
+    mut def __init__(self, nacm: ?ietf_netconf_acm__nacm=None, system: ?ietf_system__system=None, system_state: ?ietf_system__system_state=None, interfaces: ?ietf_interfaces__interfaces=None, interfaces_state: ?ietf_interfaces__interfaces_state=None):
         self._ns = ''
         self.nacm = nacm if nacm is not None else ietf_netconf_acm__nacm()
         self.system = system if system is not None else ietf_system__system()
+        self.system_state = system_state if system_state is not None else ietf_system__system_state()
         self.interfaces = interfaces if interfaces is not None else ietf_interfaces__interfaces()
+        self.interfaces_state = interfaces_state if interfaces_state is not None else ietf_interfaces__interfaces_state()
 
     def _get_attr(self, name: str) -> ?value:
         if name == 'nacm':
             return self.nacm
         if name == 'system':
             return self.system
+        if name == 'system_state':
+            return self.system_state
         if name == 'interfaces':
             return self.interfaces
+        if name == 'interfaces_state':
+            return self.interfaces_state
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=True)
@@ -10253,7 +11346,7 @@ class root(yang.adata.MNode):
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> root:
         if n is not None:
-            return root(nacm=ietf_netconf_acm__nacm.from_gdata(n.get_opt_cnt(yang.gdata.Id(NS_ietf_netconf_acm, 'nacm'))), system=ietf_system__system.from_gdata(n.get_opt_cnt(yang.gdata.Id(NS_ietf_system, 'system'))), interfaces=ietf_interfaces__interfaces.from_gdata(n.get_opt_cnt(yang.gdata.Id(NS_ietf_interfaces, 'interfaces'))))
+            return root(nacm=ietf_netconf_acm__nacm.from_gdata(n.get_opt_cnt(yang.gdata.Id(NS_ietf_netconf_acm, 'nacm'))), system=ietf_system__system.from_gdata(n.get_opt_cnt(yang.gdata.Id(NS_ietf_system, 'system'))), system_state=ietf_system__system_state.from_gdata(n.get_opt_cnt(yang.gdata.Id(NS_ietf_system, 'system-state'))), interfaces=ietf_interfaces__interfaces.from_gdata(n.get_opt_cnt(yang.gdata.Id(NS_ietf_interfaces, 'interfaces'))), interfaces_state=ietf_interfaces__interfaces_state.from_gdata(n.get_opt_cnt(yang.gdata.Id(NS_ietf_interfaces, 'interfaces-state'))))
         return root()
 
     def copy(self):
@@ -10261,7 +11354,7 @@ class root(yang.adata.MNode):
         return root.from_gdata(self.to_gdata())
 
 
-_breaker45 = None
+_breaker63 = None
 class ietf_system__set_current_datetime__input(yang.adata.MNode):
     current_datetime: ?str
 
@@ -10304,3 +11397,1262 @@ actor rpc_root(tp: yang.gdata.TreeProvider):
         tp.rpc_xml(lambda _, err: cb(err), rpc_xml)
 
 
+
+
+class ietf_netconf_acm__nacm__groups__group_subs(SubscriptionNode):
+    name: SubscriptionNode
+    user_name: SubscriptionNode
+    def __init__(self, path: ?SubscriptionPath=None):
+        SubscriptionNode.__init__(self, path)
+        self.name = SubscriptionNode(SubscriptionPath(yang.gdata.Id(NS_ietf_netconf_acm, 'name'), parent=path))
+        self.user_name = SubscriptionNode(SubscriptionPath(yang.gdata.Id(NS_ietf_netconf_acm, 'user-name'), parent=path))
+
+    def entry(self, name: str) -> ietf_netconf_acm__nacm__groups__group_entry_subs:
+        predicates = [
+            yang.gdata.FNode(yang.gdata.Id(NS_ietf_netconf_acm, 'name'), value_match=name),
+        ]
+        base_path = self._path!.parent
+        return ietf_netconf_acm__nacm__groups__group_entry_subs(SubscriptionPath(yang.gdata.Id(NS_ietf_netconf_acm, 'group'), predicates=predicates, parent=base_path))
+
+    def _direct_children(self) -> list[SubscriptionNode]:
+        direct: list[SubscriptionNode] = [self.name, self.user_name]
+        return direct
+
+class ietf_netconf_acm__nacm__groups__group_entry_subs(SubscriptionNode):
+    name: SubscriptionNode
+    user_name: SubscriptionNode
+
+    def __init__(self, path: ?SubscriptionPath=None):
+        SubscriptionNode.__init__(self, path)
+        self.name = SubscriptionNode(SubscriptionPath(yang.gdata.Id(NS_ietf_netconf_acm, 'name'), parent=path))
+        self.user_name = SubscriptionNode(SubscriptionPath(yang.gdata.Id(NS_ietf_netconf_acm, 'user-name'), parent=path))
+
+    def _direct_children(self) -> list[SubscriptionNode]:
+        direct: list[SubscriptionNode] = [self.name, self.user_name]
+        return direct
+
+class ietf_netconf_acm__nacm__groups_subs(SubscriptionNode):
+    group: ietf_netconf_acm__nacm__groups__group_subs
+
+    def __init__(self, path: ?SubscriptionPath=None):
+        SubscriptionNode.__init__(self, path)
+        self.group = ietf_netconf_acm__nacm__groups__group_subs(SubscriptionPath(yang.gdata.Id(NS_ietf_netconf_acm, 'group'), parent=path))
+
+    def _direct_children(self) -> list[SubscriptionNode]:
+        direct: list[SubscriptionNode] = [self.group]
+        return direct
+
+class ietf_netconf_acm__nacm__rule_list__rule_subs(SubscriptionNode):
+    name: SubscriptionNode
+    module_name: SubscriptionNode
+    rpc_name: SubscriptionNode
+    notification_name: SubscriptionNode
+    path: SubscriptionNode
+    access_operations: SubscriptionNode
+    action_: SubscriptionNode
+    comment: SubscriptionNode
+    def __init__(self, path: ?SubscriptionPath=None):
+        SubscriptionNode.__init__(self, path)
+        self.name = SubscriptionNode(SubscriptionPath(yang.gdata.Id(NS_ietf_netconf_acm, 'name'), parent=path))
+        self.module_name = SubscriptionNode(SubscriptionPath(yang.gdata.Id(NS_ietf_netconf_acm, 'module-name'), parent=path))
+        self.rpc_name = SubscriptionNode(SubscriptionPath(yang.gdata.Id(NS_ietf_netconf_acm, 'rpc-name'), parent=path))
+        self.notification_name = SubscriptionNode(SubscriptionPath(yang.gdata.Id(NS_ietf_netconf_acm, 'notification-name'), parent=path))
+        self.path = SubscriptionNode(SubscriptionPath(yang.gdata.Id(NS_ietf_netconf_acm, 'path'), parent=path))
+        self.access_operations = SubscriptionNode(SubscriptionPath(yang.gdata.Id(NS_ietf_netconf_acm, 'access-operations'), parent=path))
+        self.action_ = SubscriptionNode(SubscriptionPath(yang.gdata.Id(NS_ietf_netconf_acm, 'action'), parent=path))
+        self.comment = SubscriptionNode(SubscriptionPath(yang.gdata.Id(NS_ietf_netconf_acm, 'comment'), parent=path))
+
+    def entry(self, name: str) -> ietf_netconf_acm__nacm__rule_list__rule_entry_subs:
+        predicates = [
+            yang.gdata.FNode(yang.gdata.Id(NS_ietf_netconf_acm, 'name'), value_match=name),
+        ]
+        base_path = self._path!.parent
+        return ietf_netconf_acm__nacm__rule_list__rule_entry_subs(SubscriptionPath(yang.gdata.Id(NS_ietf_netconf_acm, 'rule'), predicates=predicates, parent=base_path))
+
+    def _direct_children(self) -> list[SubscriptionNode]:
+        direct: list[SubscriptionNode] = [self.name, self.module_name, self.rpc_name, self.notification_name, self.path, self.access_operations, self.action_, self.comment]
+        return direct
+
+class ietf_netconf_acm__nacm__rule_list__rule_entry_subs(SubscriptionNode):
+    name: SubscriptionNode
+    module_name: SubscriptionNode
+    rpc_name: SubscriptionNode
+    notification_name: SubscriptionNode
+    path: SubscriptionNode
+    access_operations: SubscriptionNode
+    action_: SubscriptionNode
+    comment: SubscriptionNode
+
+    def __init__(self, path: ?SubscriptionPath=None):
+        SubscriptionNode.__init__(self, path)
+        self.name = SubscriptionNode(SubscriptionPath(yang.gdata.Id(NS_ietf_netconf_acm, 'name'), parent=path))
+        self.module_name = SubscriptionNode(SubscriptionPath(yang.gdata.Id(NS_ietf_netconf_acm, 'module-name'), parent=path))
+        self.rpc_name = SubscriptionNode(SubscriptionPath(yang.gdata.Id(NS_ietf_netconf_acm, 'rpc-name'), parent=path))
+        self.notification_name = SubscriptionNode(SubscriptionPath(yang.gdata.Id(NS_ietf_netconf_acm, 'notification-name'), parent=path))
+        self.path = SubscriptionNode(SubscriptionPath(yang.gdata.Id(NS_ietf_netconf_acm, 'path'), parent=path))
+        self.access_operations = SubscriptionNode(SubscriptionPath(yang.gdata.Id(NS_ietf_netconf_acm, 'access-operations'), parent=path))
+        self.action_ = SubscriptionNode(SubscriptionPath(yang.gdata.Id(NS_ietf_netconf_acm, 'action'), parent=path))
+        self.comment = SubscriptionNode(SubscriptionPath(yang.gdata.Id(NS_ietf_netconf_acm, 'comment'), parent=path))
+
+    def _direct_children(self) -> list[SubscriptionNode]:
+        direct: list[SubscriptionNode] = [self.name, self.module_name, self.rpc_name, self.notification_name, self.path, self.access_operations, self.action_, self.comment]
+        return direct
+
+class ietf_netconf_acm__nacm__rule_list_subs(SubscriptionNode):
+    name: SubscriptionNode
+    group: SubscriptionNode
+    rule: ietf_netconf_acm__nacm__rule_list__rule_subs
+    def __init__(self, path: ?SubscriptionPath=None):
+        SubscriptionNode.__init__(self, path)
+        self.name = SubscriptionNode(SubscriptionPath(yang.gdata.Id(NS_ietf_netconf_acm, 'name'), parent=path))
+        self.group = SubscriptionNode(SubscriptionPath(yang.gdata.Id(NS_ietf_netconf_acm, 'group'), parent=path))
+        self.rule = ietf_netconf_acm__nacm__rule_list__rule_subs(SubscriptionPath(yang.gdata.Id(NS_ietf_netconf_acm, 'rule'), parent=path))
+
+    def entry(self, name: str) -> ietf_netconf_acm__nacm__rule_list_entry_subs:
+        predicates = [
+            yang.gdata.FNode(yang.gdata.Id(NS_ietf_netconf_acm, 'name'), value_match=name),
+        ]
+        base_path = self._path!.parent
+        return ietf_netconf_acm__nacm__rule_list_entry_subs(SubscriptionPath(yang.gdata.Id(NS_ietf_netconf_acm, 'rule-list'), predicates=predicates, parent=base_path))
+
+    def _direct_children(self) -> list[SubscriptionNode]:
+        direct: list[SubscriptionNode] = [self.name, self.group, self.rule]
+        return direct
+
+class ietf_netconf_acm__nacm__rule_list_entry_subs(SubscriptionNode):
+    name: SubscriptionNode
+    group: SubscriptionNode
+    rule: ietf_netconf_acm__nacm__rule_list__rule_subs
+
+    def __init__(self, path: ?SubscriptionPath=None):
+        SubscriptionNode.__init__(self, path)
+        self.name = SubscriptionNode(SubscriptionPath(yang.gdata.Id(NS_ietf_netconf_acm, 'name'), parent=path))
+        self.group = SubscriptionNode(SubscriptionPath(yang.gdata.Id(NS_ietf_netconf_acm, 'group'), parent=path))
+        self.rule = ietf_netconf_acm__nacm__rule_list__rule_subs(SubscriptionPath(yang.gdata.Id(NS_ietf_netconf_acm, 'rule'), parent=path))
+
+    def _direct_children(self) -> list[SubscriptionNode]:
+        direct: list[SubscriptionNode] = [self.name, self.group, self.rule]
+        return direct
+
+class ietf_netconf_acm__nacm_subs(SubscriptionNode):
+    enable_nacm: SubscriptionNode
+    read_default: SubscriptionNode
+    write_default: SubscriptionNode
+    exec_default: SubscriptionNode
+    enable_external_groups: SubscriptionNode
+    denied_operations: SubscriptionNode
+    denied_data_writes: SubscriptionNode
+    denied_notifications: SubscriptionNode
+    groups: ietf_netconf_acm__nacm__groups_subs
+    rule_list: ietf_netconf_acm__nacm__rule_list_subs
+
+    def __init__(self, path: ?SubscriptionPath=None):
+        SubscriptionNode.__init__(self, path)
+        self.enable_nacm = SubscriptionNode(SubscriptionPath(yang.gdata.Id(NS_ietf_netconf_acm, 'enable-nacm'), parent=path))
+        self.read_default = SubscriptionNode(SubscriptionPath(yang.gdata.Id(NS_ietf_netconf_acm, 'read-default'), parent=path))
+        self.write_default = SubscriptionNode(SubscriptionPath(yang.gdata.Id(NS_ietf_netconf_acm, 'write-default'), parent=path))
+        self.exec_default = SubscriptionNode(SubscriptionPath(yang.gdata.Id(NS_ietf_netconf_acm, 'exec-default'), parent=path))
+        self.enable_external_groups = SubscriptionNode(SubscriptionPath(yang.gdata.Id(NS_ietf_netconf_acm, 'enable-external-groups'), parent=path))
+        self.denied_operations = SubscriptionNode(SubscriptionPath(yang.gdata.Id(NS_ietf_netconf_acm, 'denied-operations'), parent=path))
+        self.denied_data_writes = SubscriptionNode(SubscriptionPath(yang.gdata.Id(NS_ietf_netconf_acm, 'denied-data-writes'), parent=path))
+        self.denied_notifications = SubscriptionNode(SubscriptionPath(yang.gdata.Id(NS_ietf_netconf_acm, 'denied-notifications'), parent=path))
+        self.groups = ietf_netconf_acm__nacm__groups_subs(SubscriptionPath(yang.gdata.Id(NS_ietf_netconf_acm, 'groups'), parent=path))
+        self.rule_list = ietf_netconf_acm__nacm__rule_list_subs(SubscriptionPath(yang.gdata.Id(NS_ietf_netconf_acm, 'rule-list'), parent=path))
+
+    def _direct_children(self) -> list[SubscriptionNode]:
+        direct: list[SubscriptionNode] = [self.enable_nacm, self.read_default, self.write_default, self.exec_default, self.enable_external_groups, self.denied_operations, self.denied_data_writes, self.denied_notifications, self.groups, self.rule_list]
+        return direct
+
+class ietf_system__system__clock_subs(SubscriptionNode):
+    timezone_name: SubscriptionNode
+    timezone_utc_offset: SubscriptionNode
+
+    def __init__(self, path: ?SubscriptionPath=None):
+        SubscriptionNode.__init__(self, path)
+        self.timezone_name = SubscriptionNode(SubscriptionPath(yang.gdata.Id(NS_ietf_system, 'timezone-name'), parent=path))
+        self.timezone_utc_offset = SubscriptionNode(SubscriptionPath(yang.gdata.Id(NS_ietf_system, 'timezone-utc-offset'), parent=path))
+
+    def _direct_children(self) -> list[SubscriptionNode]:
+        direct: list[SubscriptionNode] = [self.timezone_name, self.timezone_utc_offset]
+        return direct
+
+class ietf_system__system__ntp__server__udp_subs(SubscriptionNode):
+    address: SubscriptionNode
+    port: SubscriptionNode
+
+    def __init__(self, path: ?SubscriptionPath=None):
+        SubscriptionNode.__init__(self, path)
+        self.address = SubscriptionNode(SubscriptionPath(yang.gdata.Id(NS_ietf_system, 'address'), parent=path))
+        self.port = SubscriptionNode(SubscriptionPath(yang.gdata.Id(NS_ietf_system, 'port'), parent=path))
+
+    def _direct_children(self) -> list[SubscriptionNode]:
+        direct: list[SubscriptionNode] = [self.address, self.port]
+        return direct
+
+class ietf_system__system__ntp__server_subs(SubscriptionNode):
+    name: SubscriptionNode
+    udp: ietf_system__system__ntp__server__udp_subs
+    association_type: SubscriptionNode
+    iburst: SubscriptionNode
+    prefer: SubscriptionNode
+    def __init__(self, path: ?SubscriptionPath=None):
+        SubscriptionNode.__init__(self, path)
+        self.name = SubscriptionNode(SubscriptionPath(yang.gdata.Id(NS_ietf_system, 'name'), parent=path))
+        self.udp = ietf_system__system__ntp__server__udp_subs(SubscriptionPath(yang.gdata.Id(NS_ietf_system, 'udp'), parent=path))
+        self.association_type = SubscriptionNode(SubscriptionPath(yang.gdata.Id(NS_ietf_system, 'association-type'), parent=path))
+        self.iburst = SubscriptionNode(SubscriptionPath(yang.gdata.Id(NS_ietf_system, 'iburst'), parent=path))
+        self.prefer = SubscriptionNode(SubscriptionPath(yang.gdata.Id(NS_ietf_system, 'prefer'), parent=path))
+
+    def entry(self, name: str) -> ietf_system__system__ntp__server_entry_subs:
+        predicates = [
+            yang.gdata.FNode(yang.gdata.Id(NS_ietf_system, 'name'), value_match=name),
+        ]
+        base_path = self._path!.parent
+        return ietf_system__system__ntp__server_entry_subs(SubscriptionPath(yang.gdata.Id(NS_ietf_system, 'server'), predicates=predicates, parent=base_path))
+
+    def _direct_children(self) -> list[SubscriptionNode]:
+        direct: list[SubscriptionNode] = [self.name, self.udp, self.association_type, self.iburst, self.prefer]
+        return direct
+
+class ietf_system__system__ntp__server_entry_subs(SubscriptionNode):
+    name: SubscriptionNode
+    udp: ietf_system__system__ntp__server__udp_subs
+    association_type: SubscriptionNode
+    iburst: SubscriptionNode
+    prefer: SubscriptionNode
+
+    def __init__(self, path: ?SubscriptionPath=None):
+        SubscriptionNode.__init__(self, path)
+        self.name = SubscriptionNode(SubscriptionPath(yang.gdata.Id(NS_ietf_system, 'name'), parent=path))
+        self.udp = ietf_system__system__ntp__server__udp_subs(SubscriptionPath(yang.gdata.Id(NS_ietf_system, 'udp'), parent=path))
+        self.association_type = SubscriptionNode(SubscriptionPath(yang.gdata.Id(NS_ietf_system, 'association-type'), parent=path))
+        self.iburst = SubscriptionNode(SubscriptionPath(yang.gdata.Id(NS_ietf_system, 'iburst'), parent=path))
+        self.prefer = SubscriptionNode(SubscriptionPath(yang.gdata.Id(NS_ietf_system, 'prefer'), parent=path))
+
+    def _direct_children(self) -> list[SubscriptionNode]:
+        direct: list[SubscriptionNode] = [self.name, self.udp, self.association_type, self.iburst, self.prefer]
+        return direct
+
+class ietf_system__system__ntp_subs(SubscriptionNode):
+    enabled: SubscriptionNode
+    server: ietf_system__system__ntp__server_subs
+
+    def __init__(self, path: ?SubscriptionPath=None):
+        SubscriptionNode.__init__(self, path)
+        self.enabled = SubscriptionNode(SubscriptionPath(yang.gdata.Id(NS_ietf_system, 'enabled'), parent=path))
+        self.server = ietf_system__system__ntp__server_subs(SubscriptionPath(yang.gdata.Id(NS_ietf_system, 'server'), parent=path))
+
+    def _direct_children(self) -> list[SubscriptionNode]:
+        direct: list[SubscriptionNode] = [self.enabled, self.server]
+        return direct
+
+class ietf_system__system__dns_resolver__server__udp_and_tcp_subs(SubscriptionNode):
+    address: SubscriptionNode
+    port: SubscriptionNode
+
+    def __init__(self, path: ?SubscriptionPath=None):
+        SubscriptionNode.__init__(self, path)
+        self.address = SubscriptionNode(SubscriptionPath(yang.gdata.Id(NS_ietf_system, 'address'), parent=path))
+        self.port = SubscriptionNode(SubscriptionPath(yang.gdata.Id(NS_ietf_system, 'port'), parent=path))
+
+    def _direct_children(self) -> list[SubscriptionNode]:
+        direct: list[SubscriptionNode] = [self.address, self.port]
+        return direct
+
+class ietf_system__system__dns_resolver__server_subs(SubscriptionNode):
+    name: SubscriptionNode
+    udp_and_tcp: ietf_system__system__dns_resolver__server__udp_and_tcp_subs
+    def __init__(self, path: ?SubscriptionPath=None):
+        SubscriptionNode.__init__(self, path)
+        self.name = SubscriptionNode(SubscriptionPath(yang.gdata.Id(NS_ietf_system, 'name'), parent=path))
+        self.udp_and_tcp = ietf_system__system__dns_resolver__server__udp_and_tcp_subs(SubscriptionPath(yang.gdata.Id(NS_ietf_system, 'udp-and-tcp'), parent=path))
+
+    def entry(self, name: str) -> ietf_system__system__dns_resolver__server_entry_subs:
+        predicates = [
+            yang.gdata.FNode(yang.gdata.Id(NS_ietf_system, 'name'), value_match=name),
+        ]
+        base_path = self._path!.parent
+        return ietf_system__system__dns_resolver__server_entry_subs(SubscriptionPath(yang.gdata.Id(NS_ietf_system, 'server'), predicates=predicates, parent=base_path))
+
+    def _direct_children(self) -> list[SubscriptionNode]:
+        direct: list[SubscriptionNode] = [self.name, self.udp_and_tcp]
+        return direct
+
+class ietf_system__system__dns_resolver__server_entry_subs(SubscriptionNode):
+    name: SubscriptionNode
+    udp_and_tcp: ietf_system__system__dns_resolver__server__udp_and_tcp_subs
+
+    def __init__(self, path: ?SubscriptionPath=None):
+        SubscriptionNode.__init__(self, path)
+        self.name = SubscriptionNode(SubscriptionPath(yang.gdata.Id(NS_ietf_system, 'name'), parent=path))
+        self.udp_and_tcp = ietf_system__system__dns_resolver__server__udp_and_tcp_subs(SubscriptionPath(yang.gdata.Id(NS_ietf_system, 'udp-and-tcp'), parent=path))
+
+    def _direct_children(self) -> list[SubscriptionNode]:
+        direct: list[SubscriptionNode] = [self.name, self.udp_and_tcp]
+        return direct
+
+class ietf_system__system__dns_resolver__options_subs(SubscriptionNode):
+    timeout: SubscriptionNode
+    attempts: SubscriptionNode
+
+    def __init__(self, path: ?SubscriptionPath=None):
+        SubscriptionNode.__init__(self, path)
+        self.timeout = SubscriptionNode(SubscriptionPath(yang.gdata.Id(NS_ietf_system, 'timeout'), parent=path))
+        self.attempts = SubscriptionNode(SubscriptionPath(yang.gdata.Id(NS_ietf_system, 'attempts'), parent=path))
+
+    def _direct_children(self) -> list[SubscriptionNode]:
+        direct: list[SubscriptionNode] = [self.timeout, self.attempts]
+        return direct
+
+class ietf_system__system__dns_resolver_subs(SubscriptionNode):
+    search: SubscriptionNode
+    server: ietf_system__system__dns_resolver__server_subs
+    options: ietf_system__system__dns_resolver__options_subs
+
+    def __init__(self, path: ?SubscriptionPath=None):
+        SubscriptionNode.__init__(self, path)
+        self.search = SubscriptionNode(SubscriptionPath(yang.gdata.Id(NS_ietf_system, 'search'), parent=path))
+        self.server = ietf_system__system__dns_resolver__server_subs(SubscriptionPath(yang.gdata.Id(NS_ietf_system, 'server'), parent=path))
+        self.options = ietf_system__system__dns_resolver__options_subs(SubscriptionPath(yang.gdata.Id(NS_ietf_system, 'options'), parent=path))
+
+    def _direct_children(self) -> list[SubscriptionNode]:
+        direct: list[SubscriptionNode] = [self.search, self.server, self.options]
+        return direct
+
+class ietf_system__system__radius__server__udp_subs(SubscriptionNode):
+    address: SubscriptionNode
+    authentication_port: SubscriptionNode
+    shared_secret: SubscriptionNode
+
+    def __init__(self, path: ?SubscriptionPath=None):
+        SubscriptionNode.__init__(self, path)
+        self.address = SubscriptionNode(SubscriptionPath(yang.gdata.Id(NS_ietf_system, 'address'), parent=path))
+        self.authentication_port = SubscriptionNode(SubscriptionPath(yang.gdata.Id(NS_ietf_system, 'authentication-port'), parent=path))
+        self.shared_secret = SubscriptionNode(SubscriptionPath(yang.gdata.Id(NS_ietf_system, 'shared-secret'), parent=path))
+
+    def _direct_children(self) -> list[SubscriptionNode]:
+        direct: list[SubscriptionNode] = [self.address, self.authentication_port, self.shared_secret]
+        return direct
+
+class ietf_system__system__radius__server_subs(SubscriptionNode):
+    name: SubscriptionNode
+    udp: ietf_system__system__radius__server__udp_subs
+    authentication_type: SubscriptionNode
+    def __init__(self, path: ?SubscriptionPath=None):
+        SubscriptionNode.__init__(self, path)
+        self.name = SubscriptionNode(SubscriptionPath(yang.gdata.Id(NS_ietf_system, 'name'), parent=path))
+        self.udp = ietf_system__system__radius__server__udp_subs(SubscriptionPath(yang.gdata.Id(NS_ietf_system, 'udp'), parent=path))
+        self.authentication_type = SubscriptionNode(SubscriptionPath(yang.gdata.Id(NS_ietf_system, 'authentication-type'), parent=path))
+
+    def entry(self, name: str) -> ietf_system__system__radius__server_entry_subs:
+        predicates = [
+            yang.gdata.FNode(yang.gdata.Id(NS_ietf_system, 'name'), value_match=name),
+        ]
+        base_path = self._path!.parent
+        return ietf_system__system__radius__server_entry_subs(SubscriptionPath(yang.gdata.Id(NS_ietf_system, 'server'), predicates=predicates, parent=base_path))
+
+    def _direct_children(self) -> list[SubscriptionNode]:
+        direct: list[SubscriptionNode] = [self.name, self.udp, self.authentication_type]
+        return direct
+
+class ietf_system__system__radius__server_entry_subs(SubscriptionNode):
+    name: SubscriptionNode
+    udp: ietf_system__system__radius__server__udp_subs
+    authentication_type: SubscriptionNode
+
+    def __init__(self, path: ?SubscriptionPath=None):
+        SubscriptionNode.__init__(self, path)
+        self.name = SubscriptionNode(SubscriptionPath(yang.gdata.Id(NS_ietf_system, 'name'), parent=path))
+        self.udp = ietf_system__system__radius__server__udp_subs(SubscriptionPath(yang.gdata.Id(NS_ietf_system, 'udp'), parent=path))
+        self.authentication_type = SubscriptionNode(SubscriptionPath(yang.gdata.Id(NS_ietf_system, 'authentication-type'), parent=path))
+
+    def _direct_children(self) -> list[SubscriptionNode]:
+        direct: list[SubscriptionNode] = [self.name, self.udp, self.authentication_type]
+        return direct
+
+class ietf_system__system__radius__options_subs(SubscriptionNode):
+    timeout: SubscriptionNode
+    attempts: SubscriptionNode
+
+    def __init__(self, path: ?SubscriptionPath=None):
+        SubscriptionNode.__init__(self, path)
+        self.timeout = SubscriptionNode(SubscriptionPath(yang.gdata.Id(NS_ietf_system, 'timeout'), parent=path))
+        self.attempts = SubscriptionNode(SubscriptionPath(yang.gdata.Id(NS_ietf_system, 'attempts'), parent=path))
+
+    def _direct_children(self) -> list[SubscriptionNode]:
+        direct: list[SubscriptionNode] = [self.timeout, self.attempts]
+        return direct
+
+class ietf_system__system__radius_subs(SubscriptionNode):
+    server: ietf_system__system__radius__server_subs
+    options: ietf_system__system__radius__options_subs
+
+    def __init__(self, path: ?SubscriptionPath=None):
+        SubscriptionNode.__init__(self, path)
+        self.server = ietf_system__system__radius__server_subs(SubscriptionPath(yang.gdata.Id(NS_ietf_system, 'server'), parent=path))
+        self.options = ietf_system__system__radius__options_subs(SubscriptionPath(yang.gdata.Id(NS_ietf_system, 'options'), parent=path))
+
+    def _direct_children(self) -> list[SubscriptionNode]:
+        direct: list[SubscriptionNode] = [self.server, self.options]
+        return direct
+
+class ietf_system__system__authentication__user__authorized_key_subs(SubscriptionNode):
+    name: SubscriptionNode
+    algorithm: SubscriptionNode
+    key_data: SubscriptionNode
+    def __init__(self, path: ?SubscriptionPath=None):
+        SubscriptionNode.__init__(self, path)
+        self.name = SubscriptionNode(SubscriptionPath(yang.gdata.Id(NS_ietf_system, 'name'), parent=path))
+        self.algorithm = SubscriptionNode(SubscriptionPath(yang.gdata.Id(NS_ietf_system, 'algorithm'), parent=path))
+        self.key_data = SubscriptionNode(SubscriptionPath(yang.gdata.Id(NS_ietf_system, 'key-data'), parent=path))
+
+    def entry(self, name: str) -> ietf_system__system__authentication__user__authorized_key_entry_subs:
+        predicates = [
+            yang.gdata.FNode(yang.gdata.Id(NS_ietf_system, 'name'), value_match=name),
+        ]
+        base_path = self._path!.parent
+        return ietf_system__system__authentication__user__authorized_key_entry_subs(SubscriptionPath(yang.gdata.Id(NS_ietf_system, 'authorized-key'), predicates=predicates, parent=base_path))
+
+    def _direct_children(self) -> list[SubscriptionNode]:
+        direct: list[SubscriptionNode] = [self.name, self.algorithm, self.key_data]
+        return direct
+
+class ietf_system__system__authentication__user__authorized_key_entry_subs(SubscriptionNode):
+    name: SubscriptionNode
+    algorithm: SubscriptionNode
+    key_data: SubscriptionNode
+
+    def __init__(self, path: ?SubscriptionPath=None):
+        SubscriptionNode.__init__(self, path)
+        self.name = SubscriptionNode(SubscriptionPath(yang.gdata.Id(NS_ietf_system, 'name'), parent=path))
+        self.algorithm = SubscriptionNode(SubscriptionPath(yang.gdata.Id(NS_ietf_system, 'algorithm'), parent=path))
+        self.key_data = SubscriptionNode(SubscriptionPath(yang.gdata.Id(NS_ietf_system, 'key-data'), parent=path))
+
+    def _direct_children(self) -> list[SubscriptionNode]:
+        direct: list[SubscriptionNode] = [self.name, self.algorithm, self.key_data]
+        return direct
+
+class ietf_system__system__authentication__user_subs(SubscriptionNode):
+    name: SubscriptionNode
+    password: SubscriptionNode
+    authorized_key: ietf_system__system__authentication__user__authorized_key_subs
+    def __init__(self, path: ?SubscriptionPath=None):
+        SubscriptionNode.__init__(self, path)
+        self.name = SubscriptionNode(SubscriptionPath(yang.gdata.Id(NS_ietf_system, 'name'), parent=path))
+        self.password = SubscriptionNode(SubscriptionPath(yang.gdata.Id(NS_ietf_system, 'password'), parent=path))
+        self.authorized_key = ietf_system__system__authentication__user__authorized_key_subs(SubscriptionPath(yang.gdata.Id(NS_ietf_system, 'authorized-key'), parent=path))
+
+    def entry(self, name: str) -> ietf_system__system__authentication__user_entry_subs:
+        predicates = [
+            yang.gdata.FNode(yang.gdata.Id(NS_ietf_system, 'name'), value_match=name),
+        ]
+        base_path = self._path!.parent
+        return ietf_system__system__authentication__user_entry_subs(SubscriptionPath(yang.gdata.Id(NS_ietf_system, 'user'), predicates=predicates, parent=base_path))
+
+    def _direct_children(self) -> list[SubscriptionNode]:
+        direct: list[SubscriptionNode] = [self.name, self.password, self.authorized_key]
+        return direct
+
+class ietf_system__system__authentication__user_entry_subs(SubscriptionNode):
+    name: SubscriptionNode
+    password: SubscriptionNode
+    authorized_key: ietf_system__system__authentication__user__authorized_key_subs
+
+    def __init__(self, path: ?SubscriptionPath=None):
+        SubscriptionNode.__init__(self, path)
+        self.name = SubscriptionNode(SubscriptionPath(yang.gdata.Id(NS_ietf_system, 'name'), parent=path))
+        self.password = SubscriptionNode(SubscriptionPath(yang.gdata.Id(NS_ietf_system, 'password'), parent=path))
+        self.authorized_key = ietf_system__system__authentication__user__authorized_key_subs(SubscriptionPath(yang.gdata.Id(NS_ietf_system, 'authorized-key'), parent=path))
+
+    def _direct_children(self) -> list[SubscriptionNode]:
+        direct: list[SubscriptionNode] = [self.name, self.password, self.authorized_key]
+        return direct
+
+class ietf_system__system__authentication_subs(SubscriptionNode):
+    user_authentication_order: SubscriptionNode
+    user: ietf_system__system__authentication__user_subs
+
+    def __init__(self, path: ?SubscriptionPath=None):
+        SubscriptionNode.__init__(self, path)
+        self.user_authentication_order = SubscriptionNode(SubscriptionPath(yang.gdata.Id(NS_ietf_system, 'user-authentication-order'), parent=path))
+        self.user = ietf_system__system__authentication__user_subs(SubscriptionPath(yang.gdata.Id(NS_ietf_system, 'user'), parent=path))
+
+    def _direct_children(self) -> list[SubscriptionNode]:
+        direct: list[SubscriptionNode] = [self.user_authentication_order, self.user]
+        return direct
+
+class ietf_system__system_subs(SubscriptionNode):
+    contact: SubscriptionNode
+    hostname: SubscriptionNode
+    location: SubscriptionNode
+    clock: ietf_system__system__clock_subs
+    ntp: ietf_system__system__ntp_subs
+    dns_resolver: ietf_system__system__dns_resolver_subs
+    radius: ietf_system__system__radius_subs
+    authentication: ietf_system__system__authentication_subs
+
+    def __init__(self, path: ?SubscriptionPath=None):
+        SubscriptionNode.__init__(self, path)
+        self.contact = SubscriptionNode(SubscriptionPath(yang.gdata.Id(NS_ietf_system, 'contact'), parent=path))
+        self.hostname = SubscriptionNode(SubscriptionPath(yang.gdata.Id(NS_ietf_system, 'hostname'), parent=path))
+        self.location = SubscriptionNode(SubscriptionPath(yang.gdata.Id(NS_ietf_system, 'location'), parent=path))
+        self.clock = ietf_system__system__clock_subs(SubscriptionPath(yang.gdata.Id(NS_ietf_system, 'clock'), parent=path))
+        self.ntp = ietf_system__system__ntp_subs(SubscriptionPath(yang.gdata.Id(NS_ietf_system, 'ntp'), parent=path))
+        self.dns_resolver = ietf_system__system__dns_resolver_subs(SubscriptionPath(yang.gdata.Id(NS_ietf_system, 'dns-resolver'), parent=path))
+        self.radius = ietf_system__system__radius_subs(SubscriptionPath(yang.gdata.Id(NS_ietf_system, 'radius'), parent=path))
+        self.authentication = ietf_system__system__authentication_subs(SubscriptionPath(yang.gdata.Id(NS_ietf_system, 'authentication'), parent=path))
+
+    def _direct_children(self) -> list[SubscriptionNode]:
+        direct: list[SubscriptionNode] = [self.contact, self.hostname, self.location, self.clock, self.ntp, self.dns_resolver, self.radius, self.authentication]
+        return direct
+
+class ietf_system__system_state__platform_subs(SubscriptionNode):
+    os_name: SubscriptionNode
+    os_release: SubscriptionNode
+    os_version: SubscriptionNode
+    machine: SubscriptionNode
+
+    def __init__(self, path: ?SubscriptionPath=None):
+        SubscriptionNode.__init__(self, path)
+        self.os_name = SubscriptionNode(SubscriptionPath(yang.gdata.Id(NS_ietf_system, 'os-name'), parent=path))
+        self.os_release = SubscriptionNode(SubscriptionPath(yang.gdata.Id(NS_ietf_system, 'os-release'), parent=path))
+        self.os_version = SubscriptionNode(SubscriptionPath(yang.gdata.Id(NS_ietf_system, 'os-version'), parent=path))
+        self.machine = SubscriptionNode(SubscriptionPath(yang.gdata.Id(NS_ietf_system, 'machine'), parent=path))
+
+    def _direct_children(self) -> list[SubscriptionNode]:
+        direct: list[SubscriptionNode] = [self.os_name, self.os_release, self.os_version, self.machine]
+        return direct
+
+class ietf_system__system_state__clock_subs(SubscriptionNode):
+    current_datetime: SubscriptionNode
+    boot_datetime: SubscriptionNode
+
+    def __init__(self, path: ?SubscriptionPath=None):
+        SubscriptionNode.__init__(self, path)
+        self.current_datetime = SubscriptionNode(SubscriptionPath(yang.gdata.Id(NS_ietf_system, 'current-datetime'), parent=path))
+        self.boot_datetime = SubscriptionNode(SubscriptionPath(yang.gdata.Id(NS_ietf_system, 'boot-datetime'), parent=path))
+
+    def _direct_children(self) -> list[SubscriptionNode]:
+        direct: list[SubscriptionNode] = [self.current_datetime, self.boot_datetime]
+        return direct
+
+class ietf_system__system_state_subs(SubscriptionNode):
+    platform: ietf_system__system_state__platform_subs
+    clock: ietf_system__system_state__clock_subs
+
+    def __init__(self, path: ?SubscriptionPath=None):
+        SubscriptionNode.__init__(self, path)
+        self.platform = ietf_system__system_state__platform_subs(SubscriptionPath(yang.gdata.Id(NS_ietf_system, 'platform'), parent=path))
+        self.clock = ietf_system__system_state__clock_subs(SubscriptionPath(yang.gdata.Id(NS_ietf_system, 'clock'), parent=path))
+
+    def _direct_children(self) -> list[SubscriptionNode]:
+        direct: list[SubscriptionNode] = [self.platform, self.clock]
+        return direct
+
+class ietf_interfaces__interfaces__interface__statistics_subs(SubscriptionNode):
+    discontinuity_time: SubscriptionNode
+    in_octets: SubscriptionNode
+    in_unicast_pkts: SubscriptionNode
+    in_broadcast_pkts: SubscriptionNode
+    in_multicast_pkts: SubscriptionNode
+    in_discards: SubscriptionNode
+    in_errors: SubscriptionNode
+    in_unknown_protos: SubscriptionNode
+    out_octets: SubscriptionNode
+    out_unicast_pkts: SubscriptionNode
+    out_broadcast_pkts: SubscriptionNode
+    out_multicast_pkts: SubscriptionNode
+    out_discards: SubscriptionNode
+    out_errors: SubscriptionNode
+
+    def __init__(self, path: ?SubscriptionPath=None):
+        SubscriptionNode.__init__(self, path)
+        self.discontinuity_time = SubscriptionNode(SubscriptionPath(yang.gdata.Id(NS_ietf_interfaces, 'discontinuity-time'), parent=path))
+        self.in_octets = SubscriptionNode(SubscriptionPath(yang.gdata.Id(NS_ietf_interfaces, 'in-octets'), parent=path))
+        self.in_unicast_pkts = SubscriptionNode(SubscriptionPath(yang.gdata.Id(NS_ietf_interfaces, 'in-unicast-pkts'), parent=path))
+        self.in_broadcast_pkts = SubscriptionNode(SubscriptionPath(yang.gdata.Id(NS_ietf_interfaces, 'in-broadcast-pkts'), parent=path))
+        self.in_multicast_pkts = SubscriptionNode(SubscriptionPath(yang.gdata.Id(NS_ietf_interfaces, 'in-multicast-pkts'), parent=path))
+        self.in_discards = SubscriptionNode(SubscriptionPath(yang.gdata.Id(NS_ietf_interfaces, 'in-discards'), parent=path))
+        self.in_errors = SubscriptionNode(SubscriptionPath(yang.gdata.Id(NS_ietf_interfaces, 'in-errors'), parent=path))
+        self.in_unknown_protos = SubscriptionNode(SubscriptionPath(yang.gdata.Id(NS_ietf_interfaces, 'in-unknown-protos'), parent=path))
+        self.out_octets = SubscriptionNode(SubscriptionPath(yang.gdata.Id(NS_ietf_interfaces, 'out-octets'), parent=path))
+        self.out_unicast_pkts = SubscriptionNode(SubscriptionPath(yang.gdata.Id(NS_ietf_interfaces, 'out-unicast-pkts'), parent=path))
+        self.out_broadcast_pkts = SubscriptionNode(SubscriptionPath(yang.gdata.Id(NS_ietf_interfaces, 'out-broadcast-pkts'), parent=path))
+        self.out_multicast_pkts = SubscriptionNode(SubscriptionPath(yang.gdata.Id(NS_ietf_interfaces, 'out-multicast-pkts'), parent=path))
+        self.out_discards = SubscriptionNode(SubscriptionPath(yang.gdata.Id(NS_ietf_interfaces, 'out-discards'), parent=path))
+        self.out_errors = SubscriptionNode(SubscriptionPath(yang.gdata.Id(NS_ietf_interfaces, 'out-errors'), parent=path))
+
+    def _direct_children(self) -> list[SubscriptionNode]:
+        direct: list[SubscriptionNode] = [self.discontinuity_time, self.in_octets, self.in_unicast_pkts, self.in_broadcast_pkts, self.in_multicast_pkts, self.in_discards, self.in_errors, self.in_unknown_protos, self.out_octets, self.out_unicast_pkts, self.out_broadcast_pkts, self.out_multicast_pkts, self.out_discards, self.out_errors]
+        return direct
+
+class ietf_interfaces__interfaces__interface__ipv4__address_subs(SubscriptionNode):
+    ip: SubscriptionNode
+    prefix_length: SubscriptionNode
+    netmask: SubscriptionNode
+    origin: SubscriptionNode
+    def __init__(self, path: ?SubscriptionPath=None):
+        SubscriptionNode.__init__(self, path)
+        self.ip = SubscriptionNode(SubscriptionPath(yang.gdata.Id(NS_ietf_ip, 'ip'), parent=path))
+        self.prefix_length = SubscriptionNode(SubscriptionPath(yang.gdata.Id(NS_ietf_ip, 'prefix-length'), parent=path))
+        self.netmask = SubscriptionNode(SubscriptionPath(yang.gdata.Id(NS_ietf_ip, 'netmask'), parent=path))
+        self.origin = SubscriptionNode(SubscriptionPath(yang.gdata.Id(NS_ietf_ip, 'origin'), parent=path))
+
+    def entry(self, ip: str) -> ietf_interfaces__interfaces__interface__ipv4__address_entry_subs:
+        predicates = [
+            yang.gdata.FNode(yang.gdata.Id(NS_ietf_ip, 'ip'), value_match=ip),
+        ]
+        base_path = self._path!.parent
+        return ietf_interfaces__interfaces__interface__ipv4__address_entry_subs(SubscriptionPath(yang.gdata.Id(NS_ietf_ip, 'address'), predicates=predicates, parent=base_path))
+
+    def _direct_children(self) -> list[SubscriptionNode]:
+        direct: list[SubscriptionNode] = [self.ip, self.prefix_length, self.netmask, self.origin]
+        return direct
+
+class ietf_interfaces__interfaces__interface__ipv4__address_entry_subs(SubscriptionNode):
+    ip: SubscriptionNode
+    prefix_length: SubscriptionNode
+    netmask: SubscriptionNode
+    origin: SubscriptionNode
+
+    def __init__(self, path: ?SubscriptionPath=None):
+        SubscriptionNode.__init__(self, path)
+        self.ip = SubscriptionNode(SubscriptionPath(yang.gdata.Id(NS_ietf_ip, 'ip'), parent=path))
+        self.prefix_length = SubscriptionNode(SubscriptionPath(yang.gdata.Id(NS_ietf_ip, 'prefix-length'), parent=path))
+        self.netmask = SubscriptionNode(SubscriptionPath(yang.gdata.Id(NS_ietf_ip, 'netmask'), parent=path))
+        self.origin = SubscriptionNode(SubscriptionPath(yang.gdata.Id(NS_ietf_ip, 'origin'), parent=path))
+
+    def _direct_children(self) -> list[SubscriptionNode]:
+        direct: list[SubscriptionNode] = [self.ip, self.prefix_length, self.netmask, self.origin]
+        return direct
+
+class ietf_interfaces__interfaces__interface__ipv4__neighbor_subs(SubscriptionNode):
+    ip: SubscriptionNode
+    link_layer_address: SubscriptionNode
+    origin: SubscriptionNode
+    def __init__(self, path: ?SubscriptionPath=None):
+        SubscriptionNode.__init__(self, path)
+        self.ip = SubscriptionNode(SubscriptionPath(yang.gdata.Id(NS_ietf_ip, 'ip'), parent=path))
+        self.link_layer_address = SubscriptionNode(SubscriptionPath(yang.gdata.Id(NS_ietf_ip, 'link-layer-address'), parent=path))
+        self.origin = SubscriptionNode(SubscriptionPath(yang.gdata.Id(NS_ietf_ip, 'origin'), parent=path))
+
+    def entry(self, ip: str) -> ietf_interfaces__interfaces__interface__ipv4__neighbor_entry_subs:
+        predicates = [
+            yang.gdata.FNode(yang.gdata.Id(NS_ietf_ip, 'ip'), value_match=ip),
+        ]
+        base_path = self._path!.parent
+        return ietf_interfaces__interfaces__interface__ipv4__neighbor_entry_subs(SubscriptionPath(yang.gdata.Id(NS_ietf_ip, 'neighbor'), predicates=predicates, parent=base_path))
+
+    def _direct_children(self) -> list[SubscriptionNode]:
+        direct: list[SubscriptionNode] = [self.ip, self.link_layer_address, self.origin]
+        return direct
+
+class ietf_interfaces__interfaces__interface__ipv4__neighbor_entry_subs(SubscriptionNode):
+    ip: SubscriptionNode
+    link_layer_address: SubscriptionNode
+    origin: SubscriptionNode
+
+    def __init__(self, path: ?SubscriptionPath=None):
+        SubscriptionNode.__init__(self, path)
+        self.ip = SubscriptionNode(SubscriptionPath(yang.gdata.Id(NS_ietf_ip, 'ip'), parent=path))
+        self.link_layer_address = SubscriptionNode(SubscriptionPath(yang.gdata.Id(NS_ietf_ip, 'link-layer-address'), parent=path))
+        self.origin = SubscriptionNode(SubscriptionPath(yang.gdata.Id(NS_ietf_ip, 'origin'), parent=path))
+
+    def _direct_children(self) -> list[SubscriptionNode]:
+        direct: list[SubscriptionNode] = [self.ip, self.link_layer_address, self.origin]
+        return direct
+
+class ietf_interfaces__interfaces__interface__ipv4_subs(SubscriptionNode):
+    enabled: SubscriptionNode
+    forwarding: SubscriptionNode
+    mtu: SubscriptionNode
+    address: ietf_interfaces__interfaces__interface__ipv4__address_subs
+    neighbor: ietf_interfaces__interfaces__interface__ipv4__neighbor_subs
+
+    def __init__(self, path: ?SubscriptionPath=None):
+        SubscriptionNode.__init__(self, path)
+        self.enabled = SubscriptionNode(SubscriptionPath(yang.gdata.Id(NS_ietf_ip, 'enabled'), parent=path))
+        self.forwarding = SubscriptionNode(SubscriptionPath(yang.gdata.Id(NS_ietf_ip, 'forwarding'), parent=path))
+        self.mtu = SubscriptionNode(SubscriptionPath(yang.gdata.Id(NS_ietf_ip, 'mtu'), parent=path))
+        self.address = ietf_interfaces__interfaces__interface__ipv4__address_subs(SubscriptionPath(yang.gdata.Id(NS_ietf_ip, 'address'), parent=path))
+        self.neighbor = ietf_interfaces__interfaces__interface__ipv4__neighbor_subs(SubscriptionPath(yang.gdata.Id(NS_ietf_ip, 'neighbor'), parent=path))
+
+    def _direct_children(self) -> list[SubscriptionNode]:
+        direct: list[SubscriptionNode] = [self.enabled, self.forwarding, self.mtu, self.address, self.neighbor]
+        return direct
+
+class ietf_interfaces__interfaces__interface__ipv6__address_subs(SubscriptionNode):
+    ip: SubscriptionNode
+    prefix_length: SubscriptionNode
+    origin: SubscriptionNode
+    status: SubscriptionNode
+    def __init__(self, path: ?SubscriptionPath=None):
+        SubscriptionNode.__init__(self, path)
+        self.ip = SubscriptionNode(SubscriptionPath(yang.gdata.Id(NS_ietf_ip, 'ip'), parent=path))
+        self.prefix_length = SubscriptionNode(SubscriptionPath(yang.gdata.Id(NS_ietf_ip, 'prefix-length'), parent=path))
+        self.origin = SubscriptionNode(SubscriptionPath(yang.gdata.Id(NS_ietf_ip, 'origin'), parent=path))
+        self.status = SubscriptionNode(SubscriptionPath(yang.gdata.Id(NS_ietf_ip, 'status'), parent=path))
+
+    def entry(self, ip: str) -> ietf_interfaces__interfaces__interface__ipv6__address_entry_subs:
+        predicates = [
+            yang.gdata.FNode(yang.gdata.Id(NS_ietf_ip, 'ip'), value_match=ip),
+        ]
+        base_path = self._path!.parent
+        return ietf_interfaces__interfaces__interface__ipv6__address_entry_subs(SubscriptionPath(yang.gdata.Id(NS_ietf_ip, 'address'), predicates=predicates, parent=base_path))
+
+    def _direct_children(self) -> list[SubscriptionNode]:
+        direct: list[SubscriptionNode] = [self.ip, self.prefix_length, self.origin, self.status]
+        return direct
+
+class ietf_interfaces__interfaces__interface__ipv6__address_entry_subs(SubscriptionNode):
+    ip: SubscriptionNode
+    prefix_length: SubscriptionNode
+    origin: SubscriptionNode
+    status: SubscriptionNode
+
+    def __init__(self, path: ?SubscriptionPath=None):
+        SubscriptionNode.__init__(self, path)
+        self.ip = SubscriptionNode(SubscriptionPath(yang.gdata.Id(NS_ietf_ip, 'ip'), parent=path))
+        self.prefix_length = SubscriptionNode(SubscriptionPath(yang.gdata.Id(NS_ietf_ip, 'prefix-length'), parent=path))
+        self.origin = SubscriptionNode(SubscriptionPath(yang.gdata.Id(NS_ietf_ip, 'origin'), parent=path))
+        self.status = SubscriptionNode(SubscriptionPath(yang.gdata.Id(NS_ietf_ip, 'status'), parent=path))
+
+    def _direct_children(self) -> list[SubscriptionNode]:
+        direct: list[SubscriptionNode] = [self.ip, self.prefix_length, self.origin, self.status]
+        return direct
+
+class ietf_interfaces__interfaces__interface__ipv6__neighbor_subs(SubscriptionNode):
+    ip: SubscriptionNode
+    link_layer_address: SubscriptionNode
+    origin: SubscriptionNode
+    is_router: SubscriptionNode
+    state: SubscriptionNode
+    def __init__(self, path: ?SubscriptionPath=None):
+        SubscriptionNode.__init__(self, path)
+        self.ip = SubscriptionNode(SubscriptionPath(yang.gdata.Id(NS_ietf_ip, 'ip'), parent=path))
+        self.link_layer_address = SubscriptionNode(SubscriptionPath(yang.gdata.Id(NS_ietf_ip, 'link-layer-address'), parent=path))
+        self.origin = SubscriptionNode(SubscriptionPath(yang.gdata.Id(NS_ietf_ip, 'origin'), parent=path))
+        self.is_router = SubscriptionNode(SubscriptionPath(yang.gdata.Id(NS_ietf_ip, 'is-router'), parent=path))
+        self.state = SubscriptionNode(SubscriptionPath(yang.gdata.Id(NS_ietf_ip, 'state'), parent=path))
+
+    def entry(self, ip: str) -> ietf_interfaces__interfaces__interface__ipv6__neighbor_entry_subs:
+        predicates = [
+            yang.gdata.FNode(yang.gdata.Id(NS_ietf_ip, 'ip'), value_match=ip),
+        ]
+        base_path = self._path!.parent
+        return ietf_interfaces__interfaces__interface__ipv6__neighbor_entry_subs(SubscriptionPath(yang.gdata.Id(NS_ietf_ip, 'neighbor'), predicates=predicates, parent=base_path))
+
+    def _direct_children(self) -> list[SubscriptionNode]:
+        direct: list[SubscriptionNode] = [self.ip, self.link_layer_address, self.origin, self.is_router, self.state]
+        return direct
+
+class ietf_interfaces__interfaces__interface__ipv6__neighbor_entry_subs(SubscriptionNode):
+    ip: SubscriptionNode
+    link_layer_address: SubscriptionNode
+    origin: SubscriptionNode
+    is_router: SubscriptionNode
+    state: SubscriptionNode
+
+    def __init__(self, path: ?SubscriptionPath=None):
+        SubscriptionNode.__init__(self, path)
+        self.ip = SubscriptionNode(SubscriptionPath(yang.gdata.Id(NS_ietf_ip, 'ip'), parent=path))
+        self.link_layer_address = SubscriptionNode(SubscriptionPath(yang.gdata.Id(NS_ietf_ip, 'link-layer-address'), parent=path))
+        self.origin = SubscriptionNode(SubscriptionPath(yang.gdata.Id(NS_ietf_ip, 'origin'), parent=path))
+        self.is_router = SubscriptionNode(SubscriptionPath(yang.gdata.Id(NS_ietf_ip, 'is-router'), parent=path))
+        self.state = SubscriptionNode(SubscriptionPath(yang.gdata.Id(NS_ietf_ip, 'state'), parent=path))
+
+    def _direct_children(self) -> list[SubscriptionNode]:
+        direct: list[SubscriptionNode] = [self.ip, self.link_layer_address, self.origin, self.is_router, self.state]
+        return direct
+
+class ietf_interfaces__interfaces__interface__ipv6__autoconf_subs(SubscriptionNode):
+    create_global_addresses: SubscriptionNode
+    create_temporary_addresses: SubscriptionNode
+    temporary_valid_lifetime: SubscriptionNode
+    temporary_preferred_lifetime: SubscriptionNode
+
+    def __init__(self, path: ?SubscriptionPath=None):
+        SubscriptionNode.__init__(self, path)
+        self.create_global_addresses = SubscriptionNode(SubscriptionPath(yang.gdata.Id(NS_ietf_ip, 'create-global-addresses'), parent=path))
+        self.create_temporary_addresses = SubscriptionNode(SubscriptionPath(yang.gdata.Id(NS_ietf_ip, 'create-temporary-addresses'), parent=path))
+        self.temporary_valid_lifetime = SubscriptionNode(SubscriptionPath(yang.gdata.Id(NS_ietf_ip, 'temporary-valid-lifetime'), parent=path))
+        self.temporary_preferred_lifetime = SubscriptionNode(SubscriptionPath(yang.gdata.Id(NS_ietf_ip, 'temporary-preferred-lifetime'), parent=path))
+
+    def _direct_children(self) -> list[SubscriptionNode]:
+        direct: list[SubscriptionNode] = [self.create_global_addresses, self.create_temporary_addresses, self.temporary_valid_lifetime, self.temporary_preferred_lifetime]
+        return direct
+
+class ietf_interfaces__interfaces__interface__ipv6_subs(SubscriptionNode):
+    enabled: SubscriptionNode
+    forwarding: SubscriptionNode
+    mtu: SubscriptionNode
+    address: ietf_interfaces__interfaces__interface__ipv6__address_subs
+    neighbor: ietf_interfaces__interfaces__interface__ipv6__neighbor_subs
+    dup_addr_detect_transmits: SubscriptionNode
+    autoconf: ietf_interfaces__interfaces__interface__ipv6__autoconf_subs
+
+    def __init__(self, path: ?SubscriptionPath=None):
+        SubscriptionNode.__init__(self, path)
+        self.enabled = SubscriptionNode(SubscriptionPath(yang.gdata.Id(NS_ietf_ip, 'enabled'), parent=path))
+        self.forwarding = SubscriptionNode(SubscriptionPath(yang.gdata.Id(NS_ietf_ip, 'forwarding'), parent=path))
+        self.mtu = SubscriptionNode(SubscriptionPath(yang.gdata.Id(NS_ietf_ip, 'mtu'), parent=path))
+        self.address = ietf_interfaces__interfaces__interface__ipv6__address_subs(SubscriptionPath(yang.gdata.Id(NS_ietf_ip, 'address'), parent=path))
+        self.neighbor = ietf_interfaces__interfaces__interface__ipv6__neighbor_subs(SubscriptionPath(yang.gdata.Id(NS_ietf_ip, 'neighbor'), parent=path))
+        self.dup_addr_detect_transmits = SubscriptionNode(SubscriptionPath(yang.gdata.Id(NS_ietf_ip, 'dup-addr-detect-transmits'), parent=path))
+        self.autoconf = ietf_interfaces__interfaces__interface__ipv6__autoconf_subs(SubscriptionPath(yang.gdata.Id(NS_ietf_ip, 'autoconf'), parent=path))
+
+    def _direct_children(self) -> list[SubscriptionNode]:
+        direct: list[SubscriptionNode] = [self.enabled, self.forwarding, self.mtu, self.address, self.neighbor, self.dup_addr_detect_transmits, self.autoconf]
+        return direct
+
+class ietf_interfaces__interfaces__interface_subs(SubscriptionNode):
+    name: SubscriptionNode
+    description: SubscriptionNode
+    type: SubscriptionNode
+    enabled: SubscriptionNode
+    link_up_down_trap_enable: SubscriptionNode
+    admin_status: SubscriptionNode
+    oper_status: SubscriptionNode
+    last_change: SubscriptionNode
+    if_index: SubscriptionNode
+    phys_address: SubscriptionNode
+    higher_layer_if: SubscriptionNode
+    lower_layer_if: SubscriptionNode
+    speed: SubscriptionNode
+    statistics: ietf_interfaces__interfaces__interface__statistics_subs
+    ipv4: ietf_interfaces__interfaces__interface__ipv4_subs
+    ipv6: ietf_interfaces__interfaces__interface__ipv6_subs
+    def __init__(self, path: ?SubscriptionPath=None):
+        SubscriptionNode.__init__(self, path)
+        self.name = SubscriptionNode(SubscriptionPath(yang.gdata.Id(NS_ietf_interfaces, 'name'), parent=path))
+        self.description = SubscriptionNode(SubscriptionPath(yang.gdata.Id(NS_ietf_interfaces, 'description'), parent=path))
+        self.type = SubscriptionNode(SubscriptionPath(yang.gdata.Id(NS_ietf_interfaces, 'type'), parent=path))
+        self.enabled = SubscriptionNode(SubscriptionPath(yang.gdata.Id(NS_ietf_interfaces, 'enabled'), parent=path))
+        self.link_up_down_trap_enable = SubscriptionNode(SubscriptionPath(yang.gdata.Id(NS_ietf_interfaces, 'link-up-down-trap-enable'), parent=path))
+        self.admin_status = SubscriptionNode(SubscriptionPath(yang.gdata.Id(NS_ietf_interfaces, 'admin-status'), parent=path))
+        self.oper_status = SubscriptionNode(SubscriptionPath(yang.gdata.Id(NS_ietf_interfaces, 'oper-status'), parent=path))
+        self.last_change = SubscriptionNode(SubscriptionPath(yang.gdata.Id(NS_ietf_interfaces, 'last-change'), parent=path))
+        self.if_index = SubscriptionNode(SubscriptionPath(yang.gdata.Id(NS_ietf_interfaces, 'if-index'), parent=path))
+        self.phys_address = SubscriptionNode(SubscriptionPath(yang.gdata.Id(NS_ietf_interfaces, 'phys-address'), parent=path))
+        self.higher_layer_if = SubscriptionNode(SubscriptionPath(yang.gdata.Id(NS_ietf_interfaces, 'higher-layer-if'), parent=path))
+        self.lower_layer_if = SubscriptionNode(SubscriptionPath(yang.gdata.Id(NS_ietf_interfaces, 'lower-layer-if'), parent=path))
+        self.speed = SubscriptionNode(SubscriptionPath(yang.gdata.Id(NS_ietf_interfaces, 'speed'), parent=path))
+        self.statistics = ietf_interfaces__interfaces__interface__statistics_subs(SubscriptionPath(yang.gdata.Id(NS_ietf_interfaces, 'statistics'), parent=path))
+        self.ipv4 = ietf_interfaces__interfaces__interface__ipv4_subs(SubscriptionPath(yang.gdata.Id(NS_ietf_ip, 'ipv4'), parent=path))
+        self.ipv6 = ietf_interfaces__interfaces__interface__ipv6_subs(SubscriptionPath(yang.gdata.Id(NS_ietf_ip, 'ipv6'), parent=path))
+
+    def entry(self, name: str) -> ietf_interfaces__interfaces__interface_entry_subs:
+        predicates = [
+            yang.gdata.FNode(yang.gdata.Id(NS_ietf_interfaces, 'name'), value_match=name),
+        ]
+        base_path = self._path!.parent
+        return ietf_interfaces__interfaces__interface_entry_subs(SubscriptionPath(yang.gdata.Id(NS_ietf_interfaces, 'interface'), predicates=predicates, parent=base_path))
+
+    def _direct_children(self) -> list[SubscriptionNode]:
+        direct: list[SubscriptionNode] = [self.name, self.description, self.type, self.enabled, self.link_up_down_trap_enable, self.admin_status, self.oper_status, self.last_change, self.if_index, self.phys_address, self.higher_layer_if, self.lower_layer_if, self.speed, self.statistics, self.ipv4, self.ipv6]
+        return direct
+
+class ietf_interfaces__interfaces__interface_entry_subs(SubscriptionNode):
+    name: SubscriptionNode
+    description: SubscriptionNode
+    type: SubscriptionNode
+    enabled: SubscriptionNode
+    link_up_down_trap_enable: SubscriptionNode
+    admin_status: SubscriptionNode
+    oper_status: SubscriptionNode
+    last_change: SubscriptionNode
+    if_index: SubscriptionNode
+    phys_address: SubscriptionNode
+    higher_layer_if: SubscriptionNode
+    lower_layer_if: SubscriptionNode
+    speed: SubscriptionNode
+    statistics: ietf_interfaces__interfaces__interface__statistics_subs
+    ipv4: ietf_interfaces__interfaces__interface__ipv4_subs
+    ipv6: ietf_interfaces__interfaces__interface__ipv6_subs
+
+    def __init__(self, path: ?SubscriptionPath=None):
+        SubscriptionNode.__init__(self, path)
+        self.name = SubscriptionNode(SubscriptionPath(yang.gdata.Id(NS_ietf_interfaces, 'name'), parent=path))
+        self.description = SubscriptionNode(SubscriptionPath(yang.gdata.Id(NS_ietf_interfaces, 'description'), parent=path))
+        self.type = SubscriptionNode(SubscriptionPath(yang.gdata.Id(NS_ietf_interfaces, 'type'), parent=path))
+        self.enabled = SubscriptionNode(SubscriptionPath(yang.gdata.Id(NS_ietf_interfaces, 'enabled'), parent=path))
+        self.link_up_down_trap_enable = SubscriptionNode(SubscriptionPath(yang.gdata.Id(NS_ietf_interfaces, 'link-up-down-trap-enable'), parent=path))
+        self.admin_status = SubscriptionNode(SubscriptionPath(yang.gdata.Id(NS_ietf_interfaces, 'admin-status'), parent=path))
+        self.oper_status = SubscriptionNode(SubscriptionPath(yang.gdata.Id(NS_ietf_interfaces, 'oper-status'), parent=path))
+        self.last_change = SubscriptionNode(SubscriptionPath(yang.gdata.Id(NS_ietf_interfaces, 'last-change'), parent=path))
+        self.if_index = SubscriptionNode(SubscriptionPath(yang.gdata.Id(NS_ietf_interfaces, 'if-index'), parent=path))
+        self.phys_address = SubscriptionNode(SubscriptionPath(yang.gdata.Id(NS_ietf_interfaces, 'phys-address'), parent=path))
+        self.higher_layer_if = SubscriptionNode(SubscriptionPath(yang.gdata.Id(NS_ietf_interfaces, 'higher-layer-if'), parent=path))
+        self.lower_layer_if = SubscriptionNode(SubscriptionPath(yang.gdata.Id(NS_ietf_interfaces, 'lower-layer-if'), parent=path))
+        self.speed = SubscriptionNode(SubscriptionPath(yang.gdata.Id(NS_ietf_interfaces, 'speed'), parent=path))
+        self.statistics = ietf_interfaces__interfaces__interface__statistics_subs(SubscriptionPath(yang.gdata.Id(NS_ietf_interfaces, 'statistics'), parent=path))
+        self.ipv4 = ietf_interfaces__interfaces__interface__ipv4_subs(SubscriptionPath(yang.gdata.Id(NS_ietf_ip, 'ipv4'), parent=path))
+        self.ipv6 = ietf_interfaces__interfaces__interface__ipv6_subs(SubscriptionPath(yang.gdata.Id(NS_ietf_ip, 'ipv6'), parent=path))
+
+    def _direct_children(self) -> list[SubscriptionNode]:
+        direct: list[SubscriptionNode] = [self.name, self.description, self.type, self.enabled, self.link_up_down_trap_enable, self.admin_status, self.oper_status, self.last_change, self.if_index, self.phys_address, self.higher_layer_if, self.lower_layer_if, self.speed, self.statistics, self.ipv4, self.ipv6]
+        return direct
+
+class ietf_interfaces__interfaces_subs(SubscriptionNode):
+    interface: ietf_interfaces__interfaces__interface_subs
+
+    def __init__(self, path: ?SubscriptionPath=None):
+        SubscriptionNode.__init__(self, path)
+        self.interface = ietf_interfaces__interfaces__interface_subs(SubscriptionPath(yang.gdata.Id(NS_ietf_interfaces, 'interface'), parent=path))
+
+    def _direct_children(self) -> list[SubscriptionNode]:
+        direct: list[SubscriptionNode] = [self.interface]
+        return direct
+
+class ietf_interfaces__interfaces_state__interface__statistics_subs(SubscriptionNode):
+    discontinuity_time: SubscriptionNode
+    in_octets: SubscriptionNode
+    in_unicast_pkts: SubscriptionNode
+    in_broadcast_pkts: SubscriptionNode
+    in_multicast_pkts: SubscriptionNode
+    in_discards: SubscriptionNode
+    in_errors: SubscriptionNode
+    in_unknown_protos: SubscriptionNode
+    out_octets: SubscriptionNode
+    out_unicast_pkts: SubscriptionNode
+    out_broadcast_pkts: SubscriptionNode
+    out_multicast_pkts: SubscriptionNode
+    out_discards: SubscriptionNode
+    out_errors: SubscriptionNode
+
+    def __init__(self, path: ?SubscriptionPath=None):
+        SubscriptionNode.__init__(self, path)
+        self.discontinuity_time = SubscriptionNode(SubscriptionPath(yang.gdata.Id(NS_ietf_interfaces, 'discontinuity-time'), parent=path))
+        self.in_octets = SubscriptionNode(SubscriptionPath(yang.gdata.Id(NS_ietf_interfaces, 'in-octets'), parent=path))
+        self.in_unicast_pkts = SubscriptionNode(SubscriptionPath(yang.gdata.Id(NS_ietf_interfaces, 'in-unicast-pkts'), parent=path))
+        self.in_broadcast_pkts = SubscriptionNode(SubscriptionPath(yang.gdata.Id(NS_ietf_interfaces, 'in-broadcast-pkts'), parent=path))
+        self.in_multicast_pkts = SubscriptionNode(SubscriptionPath(yang.gdata.Id(NS_ietf_interfaces, 'in-multicast-pkts'), parent=path))
+        self.in_discards = SubscriptionNode(SubscriptionPath(yang.gdata.Id(NS_ietf_interfaces, 'in-discards'), parent=path))
+        self.in_errors = SubscriptionNode(SubscriptionPath(yang.gdata.Id(NS_ietf_interfaces, 'in-errors'), parent=path))
+        self.in_unknown_protos = SubscriptionNode(SubscriptionPath(yang.gdata.Id(NS_ietf_interfaces, 'in-unknown-protos'), parent=path))
+        self.out_octets = SubscriptionNode(SubscriptionPath(yang.gdata.Id(NS_ietf_interfaces, 'out-octets'), parent=path))
+        self.out_unicast_pkts = SubscriptionNode(SubscriptionPath(yang.gdata.Id(NS_ietf_interfaces, 'out-unicast-pkts'), parent=path))
+        self.out_broadcast_pkts = SubscriptionNode(SubscriptionPath(yang.gdata.Id(NS_ietf_interfaces, 'out-broadcast-pkts'), parent=path))
+        self.out_multicast_pkts = SubscriptionNode(SubscriptionPath(yang.gdata.Id(NS_ietf_interfaces, 'out-multicast-pkts'), parent=path))
+        self.out_discards = SubscriptionNode(SubscriptionPath(yang.gdata.Id(NS_ietf_interfaces, 'out-discards'), parent=path))
+        self.out_errors = SubscriptionNode(SubscriptionPath(yang.gdata.Id(NS_ietf_interfaces, 'out-errors'), parent=path))
+
+    def _direct_children(self) -> list[SubscriptionNode]:
+        direct: list[SubscriptionNode] = [self.discontinuity_time, self.in_octets, self.in_unicast_pkts, self.in_broadcast_pkts, self.in_multicast_pkts, self.in_discards, self.in_errors, self.in_unknown_protos, self.out_octets, self.out_unicast_pkts, self.out_broadcast_pkts, self.out_multicast_pkts, self.out_discards, self.out_errors]
+        return direct
+
+class ietf_interfaces__interfaces_state__interface__ipv4__address_subs(SubscriptionNode):
+    ip: SubscriptionNode
+    prefix_length: SubscriptionNode
+    netmask: SubscriptionNode
+    origin: SubscriptionNode
+    def __init__(self, path: ?SubscriptionPath=None):
+        SubscriptionNode.__init__(self, path)
+        self.ip = SubscriptionNode(SubscriptionPath(yang.gdata.Id(NS_ietf_ip, 'ip'), parent=path))
+        self.prefix_length = SubscriptionNode(SubscriptionPath(yang.gdata.Id(NS_ietf_ip, 'prefix-length'), parent=path))
+        self.netmask = SubscriptionNode(SubscriptionPath(yang.gdata.Id(NS_ietf_ip, 'netmask'), parent=path))
+        self.origin = SubscriptionNode(SubscriptionPath(yang.gdata.Id(NS_ietf_ip, 'origin'), parent=path))
+
+    def entry(self, ip: str) -> ietf_interfaces__interfaces_state__interface__ipv4__address_entry_subs:
+        predicates = [
+            yang.gdata.FNode(yang.gdata.Id(NS_ietf_ip, 'ip'), value_match=ip),
+        ]
+        base_path = self._path!.parent
+        return ietf_interfaces__interfaces_state__interface__ipv4__address_entry_subs(SubscriptionPath(yang.gdata.Id(NS_ietf_ip, 'address'), predicates=predicates, parent=base_path))
+
+    def _direct_children(self) -> list[SubscriptionNode]:
+        direct: list[SubscriptionNode] = [self.ip, self.prefix_length, self.netmask, self.origin]
+        return direct
+
+class ietf_interfaces__interfaces_state__interface__ipv4__address_entry_subs(SubscriptionNode):
+    ip: SubscriptionNode
+    prefix_length: SubscriptionNode
+    netmask: SubscriptionNode
+    origin: SubscriptionNode
+
+    def __init__(self, path: ?SubscriptionPath=None):
+        SubscriptionNode.__init__(self, path)
+        self.ip = SubscriptionNode(SubscriptionPath(yang.gdata.Id(NS_ietf_ip, 'ip'), parent=path))
+        self.prefix_length = SubscriptionNode(SubscriptionPath(yang.gdata.Id(NS_ietf_ip, 'prefix-length'), parent=path))
+        self.netmask = SubscriptionNode(SubscriptionPath(yang.gdata.Id(NS_ietf_ip, 'netmask'), parent=path))
+        self.origin = SubscriptionNode(SubscriptionPath(yang.gdata.Id(NS_ietf_ip, 'origin'), parent=path))
+
+    def _direct_children(self) -> list[SubscriptionNode]:
+        direct: list[SubscriptionNode] = [self.ip, self.prefix_length, self.netmask, self.origin]
+        return direct
+
+class ietf_interfaces__interfaces_state__interface__ipv4__neighbor_subs(SubscriptionNode):
+    ip: SubscriptionNode
+    link_layer_address: SubscriptionNode
+    origin: SubscriptionNode
+    def __init__(self, path: ?SubscriptionPath=None):
+        SubscriptionNode.__init__(self, path)
+        self.ip = SubscriptionNode(SubscriptionPath(yang.gdata.Id(NS_ietf_ip, 'ip'), parent=path))
+        self.link_layer_address = SubscriptionNode(SubscriptionPath(yang.gdata.Id(NS_ietf_ip, 'link-layer-address'), parent=path))
+        self.origin = SubscriptionNode(SubscriptionPath(yang.gdata.Id(NS_ietf_ip, 'origin'), parent=path))
+
+    def entry(self, ip: str) -> ietf_interfaces__interfaces_state__interface__ipv4__neighbor_entry_subs:
+        predicates = [
+            yang.gdata.FNode(yang.gdata.Id(NS_ietf_ip, 'ip'), value_match=ip),
+        ]
+        base_path = self._path!.parent
+        return ietf_interfaces__interfaces_state__interface__ipv4__neighbor_entry_subs(SubscriptionPath(yang.gdata.Id(NS_ietf_ip, 'neighbor'), predicates=predicates, parent=base_path))
+
+    def _direct_children(self) -> list[SubscriptionNode]:
+        direct: list[SubscriptionNode] = [self.ip, self.link_layer_address, self.origin]
+        return direct
+
+class ietf_interfaces__interfaces_state__interface__ipv4__neighbor_entry_subs(SubscriptionNode):
+    ip: SubscriptionNode
+    link_layer_address: SubscriptionNode
+    origin: SubscriptionNode
+
+    def __init__(self, path: ?SubscriptionPath=None):
+        SubscriptionNode.__init__(self, path)
+        self.ip = SubscriptionNode(SubscriptionPath(yang.gdata.Id(NS_ietf_ip, 'ip'), parent=path))
+        self.link_layer_address = SubscriptionNode(SubscriptionPath(yang.gdata.Id(NS_ietf_ip, 'link-layer-address'), parent=path))
+        self.origin = SubscriptionNode(SubscriptionPath(yang.gdata.Id(NS_ietf_ip, 'origin'), parent=path))
+
+    def _direct_children(self) -> list[SubscriptionNode]:
+        direct: list[SubscriptionNode] = [self.ip, self.link_layer_address, self.origin]
+        return direct
+
+class ietf_interfaces__interfaces_state__interface__ipv4_subs(SubscriptionNode):
+    forwarding: SubscriptionNode
+    mtu: SubscriptionNode
+    address: ietf_interfaces__interfaces_state__interface__ipv4__address_subs
+    neighbor: ietf_interfaces__interfaces_state__interface__ipv4__neighbor_subs
+
+    def __init__(self, path: ?SubscriptionPath=None):
+        SubscriptionNode.__init__(self, path)
+        self.forwarding = SubscriptionNode(SubscriptionPath(yang.gdata.Id(NS_ietf_ip, 'forwarding'), parent=path))
+        self.mtu = SubscriptionNode(SubscriptionPath(yang.gdata.Id(NS_ietf_ip, 'mtu'), parent=path))
+        self.address = ietf_interfaces__interfaces_state__interface__ipv4__address_subs(SubscriptionPath(yang.gdata.Id(NS_ietf_ip, 'address'), parent=path))
+        self.neighbor = ietf_interfaces__interfaces_state__interface__ipv4__neighbor_subs(SubscriptionPath(yang.gdata.Id(NS_ietf_ip, 'neighbor'), parent=path))
+
+    def _direct_children(self) -> list[SubscriptionNode]:
+        direct: list[SubscriptionNode] = [self.forwarding, self.mtu, self.address, self.neighbor]
+        return direct
+
+class ietf_interfaces__interfaces_state__interface__ipv6__address_subs(SubscriptionNode):
+    ip: SubscriptionNode
+    prefix_length: SubscriptionNode
+    origin: SubscriptionNode
+    status: SubscriptionNode
+    def __init__(self, path: ?SubscriptionPath=None):
+        SubscriptionNode.__init__(self, path)
+        self.ip = SubscriptionNode(SubscriptionPath(yang.gdata.Id(NS_ietf_ip, 'ip'), parent=path))
+        self.prefix_length = SubscriptionNode(SubscriptionPath(yang.gdata.Id(NS_ietf_ip, 'prefix-length'), parent=path))
+        self.origin = SubscriptionNode(SubscriptionPath(yang.gdata.Id(NS_ietf_ip, 'origin'), parent=path))
+        self.status = SubscriptionNode(SubscriptionPath(yang.gdata.Id(NS_ietf_ip, 'status'), parent=path))
+
+    def entry(self, ip: str) -> ietf_interfaces__interfaces_state__interface__ipv6__address_entry_subs:
+        predicates = [
+            yang.gdata.FNode(yang.gdata.Id(NS_ietf_ip, 'ip'), value_match=ip),
+        ]
+        base_path = self._path!.parent
+        return ietf_interfaces__interfaces_state__interface__ipv6__address_entry_subs(SubscriptionPath(yang.gdata.Id(NS_ietf_ip, 'address'), predicates=predicates, parent=base_path))
+
+    def _direct_children(self) -> list[SubscriptionNode]:
+        direct: list[SubscriptionNode] = [self.ip, self.prefix_length, self.origin, self.status]
+        return direct
+
+class ietf_interfaces__interfaces_state__interface__ipv6__address_entry_subs(SubscriptionNode):
+    ip: SubscriptionNode
+    prefix_length: SubscriptionNode
+    origin: SubscriptionNode
+    status: SubscriptionNode
+
+    def __init__(self, path: ?SubscriptionPath=None):
+        SubscriptionNode.__init__(self, path)
+        self.ip = SubscriptionNode(SubscriptionPath(yang.gdata.Id(NS_ietf_ip, 'ip'), parent=path))
+        self.prefix_length = SubscriptionNode(SubscriptionPath(yang.gdata.Id(NS_ietf_ip, 'prefix-length'), parent=path))
+        self.origin = SubscriptionNode(SubscriptionPath(yang.gdata.Id(NS_ietf_ip, 'origin'), parent=path))
+        self.status = SubscriptionNode(SubscriptionPath(yang.gdata.Id(NS_ietf_ip, 'status'), parent=path))
+
+    def _direct_children(self) -> list[SubscriptionNode]:
+        direct: list[SubscriptionNode] = [self.ip, self.prefix_length, self.origin, self.status]
+        return direct
+
+class ietf_interfaces__interfaces_state__interface__ipv6__neighbor_subs(SubscriptionNode):
+    ip: SubscriptionNode
+    link_layer_address: SubscriptionNode
+    origin: SubscriptionNode
+    is_router: SubscriptionNode
+    state: SubscriptionNode
+    def __init__(self, path: ?SubscriptionPath=None):
+        SubscriptionNode.__init__(self, path)
+        self.ip = SubscriptionNode(SubscriptionPath(yang.gdata.Id(NS_ietf_ip, 'ip'), parent=path))
+        self.link_layer_address = SubscriptionNode(SubscriptionPath(yang.gdata.Id(NS_ietf_ip, 'link-layer-address'), parent=path))
+        self.origin = SubscriptionNode(SubscriptionPath(yang.gdata.Id(NS_ietf_ip, 'origin'), parent=path))
+        self.is_router = SubscriptionNode(SubscriptionPath(yang.gdata.Id(NS_ietf_ip, 'is-router'), parent=path))
+        self.state = SubscriptionNode(SubscriptionPath(yang.gdata.Id(NS_ietf_ip, 'state'), parent=path))
+
+    def entry(self, ip: str) -> ietf_interfaces__interfaces_state__interface__ipv6__neighbor_entry_subs:
+        predicates = [
+            yang.gdata.FNode(yang.gdata.Id(NS_ietf_ip, 'ip'), value_match=ip),
+        ]
+        base_path = self._path!.parent
+        return ietf_interfaces__interfaces_state__interface__ipv6__neighbor_entry_subs(SubscriptionPath(yang.gdata.Id(NS_ietf_ip, 'neighbor'), predicates=predicates, parent=base_path))
+
+    def _direct_children(self) -> list[SubscriptionNode]:
+        direct: list[SubscriptionNode] = [self.ip, self.link_layer_address, self.origin, self.is_router, self.state]
+        return direct
+
+class ietf_interfaces__interfaces_state__interface__ipv6__neighbor_entry_subs(SubscriptionNode):
+    ip: SubscriptionNode
+    link_layer_address: SubscriptionNode
+    origin: SubscriptionNode
+    is_router: SubscriptionNode
+    state: SubscriptionNode
+
+    def __init__(self, path: ?SubscriptionPath=None):
+        SubscriptionNode.__init__(self, path)
+        self.ip = SubscriptionNode(SubscriptionPath(yang.gdata.Id(NS_ietf_ip, 'ip'), parent=path))
+        self.link_layer_address = SubscriptionNode(SubscriptionPath(yang.gdata.Id(NS_ietf_ip, 'link-layer-address'), parent=path))
+        self.origin = SubscriptionNode(SubscriptionPath(yang.gdata.Id(NS_ietf_ip, 'origin'), parent=path))
+        self.is_router = SubscriptionNode(SubscriptionPath(yang.gdata.Id(NS_ietf_ip, 'is-router'), parent=path))
+        self.state = SubscriptionNode(SubscriptionPath(yang.gdata.Id(NS_ietf_ip, 'state'), parent=path))
+
+    def _direct_children(self) -> list[SubscriptionNode]:
+        direct: list[SubscriptionNode] = [self.ip, self.link_layer_address, self.origin, self.is_router, self.state]
+        return direct
+
+class ietf_interfaces__interfaces_state__interface__ipv6_subs(SubscriptionNode):
+    forwarding: SubscriptionNode
+    mtu: SubscriptionNode
+    address: ietf_interfaces__interfaces_state__interface__ipv6__address_subs
+    neighbor: ietf_interfaces__interfaces_state__interface__ipv6__neighbor_subs
+
+    def __init__(self, path: ?SubscriptionPath=None):
+        SubscriptionNode.__init__(self, path)
+        self.forwarding = SubscriptionNode(SubscriptionPath(yang.gdata.Id(NS_ietf_ip, 'forwarding'), parent=path))
+        self.mtu = SubscriptionNode(SubscriptionPath(yang.gdata.Id(NS_ietf_ip, 'mtu'), parent=path))
+        self.address = ietf_interfaces__interfaces_state__interface__ipv6__address_subs(SubscriptionPath(yang.gdata.Id(NS_ietf_ip, 'address'), parent=path))
+        self.neighbor = ietf_interfaces__interfaces_state__interface__ipv6__neighbor_subs(SubscriptionPath(yang.gdata.Id(NS_ietf_ip, 'neighbor'), parent=path))
+
+    def _direct_children(self) -> list[SubscriptionNode]:
+        direct: list[SubscriptionNode] = [self.forwarding, self.mtu, self.address, self.neighbor]
+        return direct
+
+class ietf_interfaces__interfaces_state__interface_subs(SubscriptionNode):
+    name: SubscriptionNode
+    type: SubscriptionNode
+    admin_status: SubscriptionNode
+    oper_status: SubscriptionNode
+    last_change: SubscriptionNode
+    if_index: SubscriptionNode
+    phys_address: SubscriptionNode
+    higher_layer_if: SubscriptionNode
+    lower_layer_if: SubscriptionNode
+    speed: SubscriptionNode
+    statistics: ietf_interfaces__interfaces_state__interface__statistics_subs
+    ipv4: ietf_interfaces__interfaces_state__interface__ipv4_subs
+    ipv6: ietf_interfaces__interfaces_state__interface__ipv6_subs
+    def __init__(self, path: ?SubscriptionPath=None):
+        SubscriptionNode.__init__(self, path)
+        self.name = SubscriptionNode(SubscriptionPath(yang.gdata.Id(NS_ietf_interfaces, 'name'), parent=path))
+        self.type = SubscriptionNode(SubscriptionPath(yang.gdata.Id(NS_ietf_interfaces, 'type'), parent=path))
+        self.admin_status = SubscriptionNode(SubscriptionPath(yang.gdata.Id(NS_ietf_interfaces, 'admin-status'), parent=path))
+        self.oper_status = SubscriptionNode(SubscriptionPath(yang.gdata.Id(NS_ietf_interfaces, 'oper-status'), parent=path))
+        self.last_change = SubscriptionNode(SubscriptionPath(yang.gdata.Id(NS_ietf_interfaces, 'last-change'), parent=path))
+        self.if_index = SubscriptionNode(SubscriptionPath(yang.gdata.Id(NS_ietf_interfaces, 'if-index'), parent=path))
+        self.phys_address = SubscriptionNode(SubscriptionPath(yang.gdata.Id(NS_ietf_interfaces, 'phys-address'), parent=path))
+        self.higher_layer_if = SubscriptionNode(SubscriptionPath(yang.gdata.Id(NS_ietf_interfaces, 'higher-layer-if'), parent=path))
+        self.lower_layer_if = SubscriptionNode(SubscriptionPath(yang.gdata.Id(NS_ietf_interfaces, 'lower-layer-if'), parent=path))
+        self.speed = SubscriptionNode(SubscriptionPath(yang.gdata.Id(NS_ietf_interfaces, 'speed'), parent=path))
+        self.statistics = ietf_interfaces__interfaces_state__interface__statistics_subs(SubscriptionPath(yang.gdata.Id(NS_ietf_interfaces, 'statistics'), parent=path))
+        self.ipv4 = ietf_interfaces__interfaces_state__interface__ipv4_subs(SubscriptionPath(yang.gdata.Id(NS_ietf_ip, 'ipv4'), parent=path))
+        self.ipv6 = ietf_interfaces__interfaces_state__interface__ipv6_subs(SubscriptionPath(yang.gdata.Id(NS_ietf_ip, 'ipv6'), parent=path))
+
+    def entry(self, name: str) -> ietf_interfaces__interfaces_state__interface_entry_subs:
+        predicates = [
+            yang.gdata.FNode(yang.gdata.Id(NS_ietf_interfaces, 'name'), value_match=name),
+        ]
+        base_path = self._path!.parent
+        return ietf_interfaces__interfaces_state__interface_entry_subs(SubscriptionPath(yang.gdata.Id(NS_ietf_interfaces, 'interface'), predicates=predicates, parent=base_path))
+
+    def _direct_children(self) -> list[SubscriptionNode]:
+        direct: list[SubscriptionNode] = [self.name, self.type, self.admin_status, self.oper_status, self.last_change, self.if_index, self.phys_address, self.higher_layer_if, self.lower_layer_if, self.speed, self.statistics, self.ipv4, self.ipv6]
+        return direct
+
+class ietf_interfaces__interfaces_state__interface_entry_subs(SubscriptionNode):
+    name: SubscriptionNode
+    type: SubscriptionNode
+    admin_status: SubscriptionNode
+    oper_status: SubscriptionNode
+    last_change: SubscriptionNode
+    if_index: SubscriptionNode
+    phys_address: SubscriptionNode
+    higher_layer_if: SubscriptionNode
+    lower_layer_if: SubscriptionNode
+    speed: SubscriptionNode
+    statistics: ietf_interfaces__interfaces_state__interface__statistics_subs
+    ipv4: ietf_interfaces__interfaces_state__interface__ipv4_subs
+    ipv6: ietf_interfaces__interfaces_state__interface__ipv6_subs
+
+    def __init__(self, path: ?SubscriptionPath=None):
+        SubscriptionNode.__init__(self, path)
+        self.name = SubscriptionNode(SubscriptionPath(yang.gdata.Id(NS_ietf_interfaces, 'name'), parent=path))
+        self.type = SubscriptionNode(SubscriptionPath(yang.gdata.Id(NS_ietf_interfaces, 'type'), parent=path))
+        self.admin_status = SubscriptionNode(SubscriptionPath(yang.gdata.Id(NS_ietf_interfaces, 'admin-status'), parent=path))
+        self.oper_status = SubscriptionNode(SubscriptionPath(yang.gdata.Id(NS_ietf_interfaces, 'oper-status'), parent=path))
+        self.last_change = SubscriptionNode(SubscriptionPath(yang.gdata.Id(NS_ietf_interfaces, 'last-change'), parent=path))
+        self.if_index = SubscriptionNode(SubscriptionPath(yang.gdata.Id(NS_ietf_interfaces, 'if-index'), parent=path))
+        self.phys_address = SubscriptionNode(SubscriptionPath(yang.gdata.Id(NS_ietf_interfaces, 'phys-address'), parent=path))
+        self.higher_layer_if = SubscriptionNode(SubscriptionPath(yang.gdata.Id(NS_ietf_interfaces, 'higher-layer-if'), parent=path))
+        self.lower_layer_if = SubscriptionNode(SubscriptionPath(yang.gdata.Id(NS_ietf_interfaces, 'lower-layer-if'), parent=path))
+        self.speed = SubscriptionNode(SubscriptionPath(yang.gdata.Id(NS_ietf_interfaces, 'speed'), parent=path))
+        self.statistics = ietf_interfaces__interfaces_state__interface__statistics_subs(SubscriptionPath(yang.gdata.Id(NS_ietf_interfaces, 'statistics'), parent=path))
+        self.ipv4 = ietf_interfaces__interfaces_state__interface__ipv4_subs(SubscriptionPath(yang.gdata.Id(NS_ietf_ip, 'ipv4'), parent=path))
+        self.ipv6 = ietf_interfaces__interfaces_state__interface__ipv6_subs(SubscriptionPath(yang.gdata.Id(NS_ietf_ip, 'ipv6'), parent=path))
+
+    def _direct_children(self) -> list[SubscriptionNode]:
+        direct: list[SubscriptionNode] = [self.name, self.type, self.admin_status, self.oper_status, self.last_change, self.if_index, self.phys_address, self.higher_layer_if, self.lower_layer_if, self.speed, self.statistics, self.ipv4, self.ipv6]
+        return direct
+
+class ietf_interfaces__interfaces_state_subs(SubscriptionNode):
+    interface: ietf_interfaces__interfaces_state__interface_subs
+
+    def __init__(self, path: ?SubscriptionPath=None):
+        SubscriptionNode.__init__(self, path)
+        self.interface = ietf_interfaces__interfaces_state__interface_subs(SubscriptionPath(yang.gdata.Id(NS_ietf_interfaces, 'interface'), parent=path))
+
+    def _direct_children(self) -> list[SubscriptionNode]:
+        direct: list[SubscriptionNode] = [self.interface]
+        return direct
+
+class root_subs(SubscriptionNode):
+    nacm: ietf_netconf_acm__nacm_subs
+    system: ietf_system__system_subs
+    system_state: ietf_system__system_state_subs
+    interfaces: ietf_interfaces__interfaces_subs
+    interfaces_state: ietf_interfaces__interfaces_state_subs
+
+    def __init__(self, path: ?SubscriptionPath=None):
+        SubscriptionNode.__init__(self, path)
+        self.nacm = ietf_netconf_acm__nacm_subs(SubscriptionPath(yang.gdata.Id(NS_ietf_netconf_acm, 'nacm'), parent=path))
+        self.system = ietf_system__system_subs(SubscriptionPath(yang.gdata.Id(NS_ietf_system, 'system'), parent=path))
+        self.system_state = ietf_system__system_state_subs(SubscriptionPath(yang.gdata.Id(NS_ietf_system, 'system-state'), parent=path))
+        self.interfaces = ietf_interfaces__interfaces_subs(SubscriptionPath(yang.gdata.Id(NS_ietf_interfaces, 'interfaces'), parent=path))
+        self.interfaces_state = ietf_interfaces__interfaces_state_subs(SubscriptionPath(yang.gdata.Id(NS_ietf_interfaces, 'interfaces-state'), parent=path))
+
+    def _direct_children(self) -> list[SubscriptionNode]:
+        direct: list[SubscriptionNode] = [self.nacm, self.system, self.system_state, self.interfaces, self.interfaces_state]
+        return direct
+
+subs = root_subs()
+
+actor DstAdapter(cb: action(?root, ?Exception) -> None):
+    def on_update(n: ?yang.gdata.Node, err: ?Exception):
+        if err is not None:
+            cb(None, err)
+            return
+        if n is not None:
+            cb(root.from_gdata(n), None)
+            return
+        cb(None, None)
+
+def dst(cb: action(?root, ?Exception) -> None) -> yang.gdata.Dst:
+    adapter = DstAdapter(cb)
+    return yang.gdata.Dst(adapter.on_update)

--- a/minisys/src/mini/rfs.act
+++ b/minisys/src/mini/rfs.act
@@ -2,7 +2,6 @@ import logging
 import yang.adata
 import yang.gdata as gdata
 import stratoweave.device as swdev
-import yang.gdata
 import stratoweave.ttt
 from stratoweave.exception import UnsupportedDevice
 
@@ -11,12 +10,8 @@ from mini.layers.y_1 import stratoweave_rfs__rfs__base_config__dynstate as BaseC
 import mini.layers.y_1 as y1
 
 import mini.devices.ietf as ietf_dev
-from mini.devices.ietf import root as ietf_root
-
-NS_IETF_SYSTEM = "urn:ietf:params:xml:ns:yang:ietf-system"
-
-def _q_sys(name: str) -> gdata.Id:
-    return gdata.Id(NS_IETF_SYSTEM, name)
+import mini.devices.ietf_oper as ietf_oper
+from mini.devices.ietf_oper import root as ietf_oper_root
 
 def unwrap[T](t: ?T) -> T:
     if t is not None:
@@ -39,27 +34,24 @@ class BaseConfig(base.BaseConfig):
         raise UnsupportedDevice()
 
 actor BaseConfigTransform(path, update_dynstate: proc(?BaseConfigDynstate)->None, dev: swdev.DeviceMgr):
-    var dynstate = base.BaseConfig.dynstate_type()()
+    _subs = gdata.SubscriptionManager(dev.tree_provider(), str(path))
+    _dynstate = base.BaseConfig.dynstate_type()()
 
-    def on_state(t: ?yang.gdata.Node, err: ?Exception):
+    def on_state(root: ?ietf_oper_root, err: ?Exception):
         if err is not None:
             print("BaseConfigTransform subscription error: {err}", err=True)
             return
-        root = ietf_root.from_gdata(t)
-        dynstate.current_datetime = root?.system_state?.clock?.current_datetime
-        update_dynstate(dynstate)
-
-    var subs = gdata.SubscriptionManager(dev.tree_provider(), str(path), on_state)
+        _dynstate.current_datetime = root?.system_state?.clock?.current_datetime
+        update_dynstate(_dynstate)
 
     def on_conf(conf: y1.stratoweave_rfs__rfs__base_config):
-        want = set()
-        want.add(gdata.SubscriptionSpec(_system_state_filter(), period=0.01))
-        subs.declare(want)
-
-def _system_state_filter() -> gdata.FNode:
-    return gdata.FNode(None, None, [
-        gdata.FNode(_q_sys("system-state"), children=[])
-    ])
+        want: set[gdata.Delivery] = set()
+        if "ietf-system" in dev.get_modules().0:
+            state_dst = ietf_oper.dst(on_state)
+            want.add(state_dst.deliver({
+                ietf_oper.subs.system_state.clock.subscribe(period=0.01)
+            }))
+        _subs.declare(want)
 
 
 class L3vpnEndpoint(base.L3vpnEndpoint):

--- a/minisys/src/mini/sysspec.act
+++ b/minisys/src/mini/sysspec.act
@@ -16,12 +16,14 @@ import mini.layers.y_1
 import mini.layers.t_0
 import mini.layers.y_0
 import mini.devices.ietf
+import mini.devices.ietf_oper
 
 
 device_types: dict[str, swdev.DeviceType] = {
     "ietf": swdev.DeviceType(name="ietf",
             adapter_type=swdev.NetconfAdapter,
             src_dnode=mini.devices.ietf.SRC_DNODE,
+            oper_src_dnode=mini.devices.ietf_oper.SRC_DNODE,
         ),
 }
 

--- a/minisys/src/test_mini_oper.act
+++ b/minisys/src/test_mini_oper.act
@@ -1,0 +1,142 @@
+import testing
+import yang.gdata as gdata
+
+import mini.devices.ietf_oper as ietf_oper
+
+NS_IETF_SYSTEM = "urn:ietf:params:xml:ns:yang:ietf-system"
+NS_IETF_INTERFACES = "urn:ietf:params:xml:ns:yang:ietf-interfaces"
+NS_IETF_IP = "urn:ietf:params:xml:ns:yang:ietf-ip"
+
+
+def q_sys(n: str) -> gdata.Id:
+    return gdata.Id(NS_IETF_SYSTEM, n)
+
+
+def q_if(n: str) -> gdata.Id:
+    return gdata.Id(NS_IETF_INTERFACES, n)
+
+
+def q_ip(n: str) -> gdata.Id:
+    return gdata.Id(NS_IETF_IP, n)
+
+
+def fail(t: testing.EnvT, msg: str):
+    t.failure(ValueError(msg))
+
+
+actor _test_oper_paths(t: testing.EnvT):
+    oper = ietf_oper.subs
+
+    clock = oper.system_state.clock
+    expect_clock_filt = gdata.FNode(q_sys("system-state"), children=[
+        gdata.FNode(q_sys("clock")),
+    ])
+    got_clock_filt = clock.filt()
+    expect_clock_subtree = gdata.SubscriptionSpec(
+        gdata.FNode(q_sys("system-state"), children=[
+            gdata.FNode(q_sys("clock")),
+        ]),
+        period=0.01,
+    )
+    got_clock_subtree = clock.subscribe(period=0.01)
+    expect_clock = gdata.SubscriptionSpec(
+        gdata.FNode(q_sys("system-state"), children=[
+            gdata.FNode(q_sys("clock"), children=[
+                gdata.FNode(q_sys("current-datetime")),
+                gdata.FNode(q_sys("boot-datetime")),
+            ]),
+        ]),
+        period=0.01,
+    )
+    got_clock = clock.subscribe(depth=1, period=0.01)
+    iface = oper.interfaces.interface.entry("eth0")
+    expect_iface_subtree = gdata.SubscriptionSpec(
+        gdata.FNode(q_if("interfaces"), children=[
+            gdata.FNode(q_if("interface"), children=[
+                gdata.FNode(q_if("name"), value_match="eth0"),
+            ]),
+        ]),
+        period=1.0,
+    )
+    got_iface_subtree = iface.subscribe(period=1.0)
+    expect_grouped = gdata.SubscriptionSpec(
+        gdata.FNode(q_if("interfaces"), children=[
+            gdata.FNode(q_if("interface"), children=[
+                gdata.FNode(q_if("name"), value_match="eth0"),
+                gdata.FNode(q_if("statistics")),
+                gdata.FNode(q_ip("ipv4")),
+            ]),
+        ]),
+        period=1.0,
+    )
+    got_grouped = iface.subscribe(select=[iface.statistics, iface.ipv4], period=1.0)
+
+    expect_deep = gdata.SubscriptionSpec(
+        gdata.FNode(q_if("interfaces"), children=[
+            gdata.FNode(q_if("interface"), children=[
+                gdata.FNode(q_if("name"), value_match="eth0"),
+                gdata.FNode(q_if("statistics"), children=[
+                    gdata.FNode(q_if("in-octets")),
+                    gdata.FNode(q_if("out-octets")),
+                ]),
+            ]),
+        ]),
+        period=1.0,
+    )
+    got_deep = iface.subscribe(select=[
+        iface.statistics.in_octets,
+        iface.statistics.out_octets,
+    ], period=1.0)
+
+    expect_list = gdata.SubscriptionSpec(
+        gdata.FNode(q_if("interfaces"), children=[
+            gdata.FNode(q_if("interface"), children=[
+                gdata.FNode(q_if("name")),
+                gdata.FNode(q_if("description")),
+                gdata.FNode(q_if("type")),
+                gdata.FNode(q_if("enabled")),
+                gdata.FNode(q_if("link-up-down-trap-enable")),
+                gdata.FNode(q_if("admin-status")),
+                gdata.FNode(q_if("oper-status")),
+                gdata.FNode(q_if("last-change")),
+                gdata.FNode(q_if("if-index")),
+                gdata.FNode(q_if("phys-address")),
+                gdata.FNode(q_if("higher-layer-if")),
+                gdata.FNode(q_if("lower-layer-if")),
+                gdata.FNode(q_if("speed")),
+                gdata.FNode(q_if("statistics")),
+                gdata.FNode(q_ip("ipv4")),
+                gdata.FNode(q_ip("ipv6")),
+            ]),
+        ]),
+        period=1.0,
+    )
+    got_list = oper.interfaces.interface.subscribe(depth=1, period=1.0)
+    expect_clock_on_change = gdata.SubscriptionSpec(
+        gdata.FNode(q_sys("system-state"), children=[
+            gdata.FNode(q_sys("clock"), children=[
+                gdata.FNode(q_sys("current-datetime")),
+                gdata.FNode(q_sys("boot-datetime")),
+            ]),
+        ]),
+    )
+    got_clock_on_change = clock.subscribe(depth=1)
+
+    if got_clock_filt != expect_clock_filt:
+        fail(t, "Unexpected raw filter for system-state clock: {got_clock_filt}")
+    elif got_clock_subtree != expect_clock_subtree:
+        fail(t, "Unexpected subtree subscription for system-state clock: {got_clock_subtree}")
+    elif got_clock != expect_clock:
+        fail(t, "Unexpected direct child filter for system-state clock: {got_clock}")
+    elif got_iface_subtree != expect_iface_subtree:
+        fail(t, "Unexpected subtree subscription for interface entry: {got_iface_subtree}")
+    elif got_grouped != expect_grouped:
+        fail(t, "Unexpected grouped child filter for interface entry: {got_grouped}")
+    elif got_deep != expect_deep:
+        fail(t, "Unexpected merged descendant filter for interface entry: {got_deep}")
+    elif got_list != expect_list:
+        fail(t, "Unexpected direct child filter for interface list: {got_list}")
+    elif got_clock_on_change != expect_clock_on_change:
+        fail(t, "Unexpected on-change filter for system-state clock: {got_clock_on_change}")
+    else:
+        t.success()

--- a/src/stratoweave/build.act
+++ b/src/stratoweave/build.act
@@ -148,17 +148,29 @@ class CompiledSysSpec(object):
         syssrc_devtypes = ""
         for dev_type in self.dev_types.values():
             print("Generating device type {dev_type.name}")
+            # schema.prdaclass mutates the compiled tree when it strips
+            # config-false nodes. Emit the oper view first so the subsequent
+            # config-only module does not remove state nodes before the oper
+            # module is rendered.
+            oper_name = "{output_dir}/{self.name}/devices/{dev_type.name}_oper.act"
+            if _maybe_write_file(fc, oper_name, dev_type.print(loose=True, gen_json=False, include_state=True, include_subs=True)):
+                print("+ Device type {dev_type.name} oper changed")
+            else:
+                print("+ Device type {dev_type.name} oper unchanged")
+
             name = "{output_dir}/{self.name}/devices/{dev_type.name}.act"
-            if _maybe_write_file(fc, name, dev_type.print(loose=True, gen_json=False, include_state=True)):
+            if _maybe_write_file(fc, name, dev_type.print(loose=True, gen_json=False)):
                 print("+ Device type {dev_type.name} adata changed")
             else:
                 print("+ Device type {dev_type.name} adata unchanged")
 
             modname = "{self.name}.devices.{dev_type.name}"
             syssrc += "import {modname}\n"
+            syssrc += "import {modname}_oper\n"
             syssrc_devtypes += """    "{dev_type.name}": swdev.DeviceType(name="{dev_type.name}",
             adapter_type=swdev.NetconfAdapter,
             src_dnode={modname}.SRC_DNODE,
+            oper_src_dnode={modname}_oper.SRC_DNODE,
         ),
 """
         print("Generating app sysspec.act")
@@ -256,7 +268,7 @@ class CompiledLayerBase(object):
     root: yang.schema.DRoot
     src: list[str]
 
-    def print(self, loose=False, gen_json=True, include_state=False, exclude_ext: list[(name: str, namespace: str)]=[]):
+    def print(self, loose=False, gen_json=True, include_state=False, exclude_ext: list[(name: str, namespace: str)]=[], include_subs=False):
         """Print the Acton (adata) classes for the layer
 
         This prints the entire contents of the Acton module representing a
@@ -264,7 +276,7 @@ class CompiledLayerBase(object):
         classes, XML and JSON deserializers and the schema info. The schema is
         used by the XML and JSON schema-driven deserializers.
         """
-        return self.root.prdaclass(schema_yang=self.src, loose=loose, include_state=include_state, exclude_ext=exclude_ext)
+        return self.root.prdaclass(schema_yang=self.src, loose=loose, include_state=include_state, exclude_ext=exclude_ext, include_subs=include_subs)
 
 class CompiledLayer(CompiledLayerBase):
     def __init__(self, root: yang.schema.DRoot, src: list[str], name: ?str=None):

--- a/src/stratoweave/device.act
+++ b/src/stratoweave/device.act
@@ -30,10 +30,12 @@ class DeviceSchema(object):
     name: str
 
     src_dnode: yang.schema.DRoot
+    oper_src_dnode: yang.schema.DRoot
 
-    def __init__(self, name, src_dnode):
+    def __init__(self, name, src_dnode, oper_src_dnode: ?yang.schema.DRoot=None):
         self.name = name
         self.src_dnode = src_dnode
+        self.oper_src_dnode = oper_src_dnode if oper_src_dnode is not None else src_dnode
 
     @staticmethod
     def mock():
@@ -53,10 +55,10 @@ class DeviceType(object):
 
     bundled_schema: DeviceSchema
 
-    def __init__(self, name: str, adapter_type, src_dnode):
+    def __init__(self, name: str, adapter_type, src_dnode, oper_src_dnode: ?yang.schema.DRoot=None):
         self.name = name
         self.adapter_type = adapter_type
-        self.bundled_schema = DeviceSchema(name, src_dnode)
+        self.bundled_schema = DeviceSchema(name, src_dnode, oper_src_dnode)
 
 class MockRoot(yang.adata.MNode):
     """Mock root node for mock devices"""
@@ -959,6 +961,7 @@ actor DeviceMgr(dev_types: dict[str, DeviceType]={}, pcap: ?process.ProcessCap=N
     def get_capabilities():
         return adapter.get_capabilities()
 
+    # TODO: use named fields in the tuple
     def get_modules() -> (dict[str, ModCap], ?str):
         return modset, modset_id
 
@@ -1674,7 +1677,9 @@ actor NetconfDriver(dev: DeviceMgr, bundled_schema: DeviceSchema, init_dmc: Devi
             state = CONNECTING
             pipes = transport.actor_pipe_pair()
             bundled_caps = ["{ns}?module={meta.module}{"&revision={meta.revision}" if meta.revision is not None else ""}" for ns, meta in bundled_schema.src_dnode.module_metadata.items()]
-            mock_server = NetconfMockServer(pipes.server, _con_log_handler, _mock_capabilities_from_dmc(new_dmc) + bundled_caps, bundled_schema.src_dnode)
+            ms = NetconfMockServer(pipes.server, _con_log_handler, _mock_capabilities_from_dmc(new_dmc) + bundled_caps, bundled_schema.src_dnode)
+            mock_server = ms
+            ms.set_oper_ds(_netconf_mock_default_oper_ds(), bundled_schema.oper_src_dnode)
             client = netconf.Client(pcap,
                                     "dummy-address",
                                     0,
@@ -2239,7 +2244,7 @@ actor NetconfDriver(dev: DeviceMgr, bundled_schema: DeviceSchema, init_dmc: Devi
                 if fetched_schema is not None:
                     return yang.xml.from_xml(fetched_schema, data_tag, loose=True)
                 return None
-            return yang.xml.from_xml(bundled_schema.src_dnode, data_tag, loose=True)
+            return yang.xml.from_xml(bundled_schema.oper_src_dnode, data_tag, loose=True)
         return None
 
     def _owner_publish(owner_id: str, err: ?Exception=None):

--- a/src/stratoweave/ietf_yang_library.act
+++ b/src/stratoweave/ietf_yang_library.act
@@ -2329,9 +2329,11 @@ class ietf_yang_library__yang_library__module_set__import_only_module(yang.adata
             if e.name != name:
                 match = False
                 continue
-            if e.revision != revision:
-                match = False
-                continue
+            e_revision = e.revision
+            if isinstance(e_revision, str) and isinstance(revision, str):
+                if e_revision != revision:
+                    match = False
+                    continue
             if match:
                 e.namespace = namespace
                 return e

--- a/src/stratoweave/test_devicemgr_netconf.act
+++ b/src/stratoweave/test_devicemgr_netconf.act
@@ -256,6 +256,7 @@ actor _test_subscription_manager_declare(t: testing.EnvT):
     var phase = 0
     var mock_server: ?stratoweave.device.NetconfMockServer = None
     var subs: ?yang.gdata.SubscriptionManager = None
+    var dst: ?yang.gdata.Dst = None
 
     def noop_on_reconf(name: str):
         pass
@@ -278,17 +279,6 @@ actor _test_subscription_manager_declare(t: testing.EnvT):
         done = True
         close_subs()
         t.success()
-
-    def declare_both():
-        want = set([
-            yang.gdata.SubscriptionSpec(_current_datetime_filter(), period=0.05),
-            yang.gdata.SubscriptionSpec(_boot_datetime_filter(), period=0.05)
-        ])
-        yang.gdata.expect(subs, "subscription manager").declare(want)
-
-    def declare_current_only():
-        want = set([yang.gdata.SubscriptionSpec(_current_datetime_filter(), period=0.05)])
-        yang.gdata.expect(subs, "subscription manager").declare(want)
 
     def on_update(n: ?yang.gdata.Node, err: ?Exception):
         if done:
@@ -314,6 +304,23 @@ actor _test_subscription_manager_declare(t: testing.EnvT):
             succeed()
             return
 
+    def declare_both():
+        want = {
+            yang.gdata.expect(dst, "subscription destination").deliver({
+                yang.gdata.SubscriptionSpec(_current_datetime_filter(), period=0.05),
+                yang.gdata.SubscriptionSpec(_boot_datetime_filter(), period=0.05),
+            })
+        }
+        yang.gdata.expect(subs, "subscription manager").declare(want)
+
+    def declare_current_only():
+        want = {
+            yang.gdata.expect(dst, "subscription destination").deliver({
+                yang.gdata.SubscriptionSpec(_current_datetime_filter(), period=0.05)
+            })
+        }
+        yang.gdata.expect(subs, "subscription manager").declare(want)
+
     def start():
         adapter = dev.get_adapter()
         if isinstance(adapter, stratoweave.device.NetconfAdapter):
@@ -324,7 +331,8 @@ actor _test_subscription_manager_declare(t: testing.EnvT):
             ms = yang.gdata.expect(ms0, "mock server")
             mock_server = ms
             ms.set_oper_ds(_mock_oper_ds(mock_current_datetime_1, mock_boot_datetime))
-            subs = yang.gdata.SubscriptionManager(dev.tree_provider(), "test-subscription-manager", on_update)
+            dst = yang.gdata.Dst(on_update)
+            subs = yang.gdata.SubscriptionManager(dev.tree_provider(), "test-subscription-manager")
             declare_both()
         else:
             fail("Expected NetconfAdapter from DeviceMgr")
@@ -342,6 +350,7 @@ actor _test_subscription_manager_idempotent(t: testing.EnvT):
     var done = False
     var updates = 0
     var subs: ?yang.gdata.SubscriptionManager = None
+    var dst: ?yang.gdata.Dst = None
 
     def noop_on_reconf(name: str):
         pass
@@ -364,10 +373,6 @@ actor _test_subscription_manager_idempotent(t: testing.EnvT):
         done = True
         close_subs()
         t.success()
-
-    def declare_current_only():
-        want = set([yang.gdata.SubscriptionSpec(_current_datetime_filter(), period=0.05)])
-        yang.gdata.expect(subs, "subscription manager").declare(want)
 
     def on_update(n: ?yang.gdata.Node, err: ?Exception):
         if done:
@@ -393,6 +398,14 @@ actor _test_subscription_manager_idempotent(t: testing.EnvT):
         declare_current_only()
         after 0.15: succeed()
 
+    def declare_current_only():
+        want = {
+            yang.gdata.expect(dst, "subscription destination").deliver({
+                yang.gdata.SubscriptionSpec(_current_datetime_filter(), period=0.05)
+            })
+        }
+        yang.gdata.expect(subs, "subscription manager").declare(want)
+
     def start():
         adapter = dev.get_adapter()
         if isinstance(adapter, stratoweave.device.NetconfAdapter):
@@ -402,7 +415,8 @@ actor _test_subscription_manager_idempotent(t: testing.EnvT):
                 return
             ms = yang.gdata.expect(ms0, "mock server")
             ms.set_oper_ds(_mock_oper_ds(mock_current_datetime, mock_boot_datetime))
-            subs = yang.gdata.SubscriptionManager(dev.tree_provider(), "test-subscription-manager-idempotent", on_update)
+            dst = yang.gdata.Dst(on_update)
+            subs = yang.gdata.SubscriptionManager(dev.tree_provider(), "test-subscription-manager-idempotent")
             declare_current_only()
         else:
             fail("Expected NetconfAdapter from DeviceMgr")


### PR DESCRIPTION
This change emits a separate *_oper module with config-false state and the generated subs tree. This means our telemetry subscription related code can now switch to a typed interface. We register subscriptions using the new subscription tree, which is typed, and the telemetry data received comes in as tyedp adata - very nice!

The new *_oper module contains an adata tree both for config + config false. It means the normal adata tree can be focused on config true, so no one can accidentally try to set config false data in a transform.

acton-yang is upgraded to get the new version producing the subscription-tree.