### PR TITLE
Route TTT data filters through nodes

### DIFF
--- a/Build.act
+++ b/Build.act
@@ -23,8 +23,8 @@ dependencies = {
     ),
     "yang": (
         repo_url="https://github.com/stratoweave/acton-yang.git",
-        url="https://github.com/stratoweave/acton-yang/archive/716dfa5b43ca288c71dfb01d27edc9adc533da09.zip",
-        hash="N-V-__8AAKyzJADfger1LDjLG2bbJ4VMY5Bt8EL3TDFQLzs5"
+        url="https://github.com/stratoweave/acton-yang/archive/819d3204328331854fb4ec4912443a776629aec7.zip",
+        hash="N-V-__8AAG_nJACQ5F_-15AW3lbZ9p2XFqH4Fi8Cq3qdXFFO"
     )
 }
 zig_dependencies = {}

--- a/gen_adata/Build.act
+++ b/gen_adata/Build.act
@@ -3,8 +3,8 @@ fingerprint = 0x7d1c1e932a731ef0
 dependencies = {
     "yang": (
         repo_url="https://github.com/stratoweave/acton-yang.git",
-        url="https://github.com/stratoweave/acton-yang/archive/716dfa5b43ca288c71dfb01d27edc9adc533da09.zip",
-        hash="N-V-__8AAKyzJADfger1LDjLG2bbJ4VMY5Bt8EL3TDFQLzs5"
+        url="https://github.com/stratoweave/acton-yang/archive/819d3204328331854fb4ec4912443a776629aec7.zip",
+        hash="N-V-__8AAG_nJACQ5F_-15AW3lbZ9p2XFqH4Fi8Cq3qdXFFO"
     )
 }
 zig_dependencies = {}

--- a/minisys/Build.act
+++ b/minisys/Build.act
@@ -6,8 +6,8 @@ dependencies = {
     ),
     "yang": (
         repo_url="https://github.com/stratoweave/acton-yang.git",
-        url="https://github.com/stratoweave/acton-yang/archive/716dfa5b43ca288c71dfb01d27edc9adc533da09.zip",
-        hash="N-V-__8AAKyzJADfger1LDjLG2bbJ4VMY5Bt8EL3TDFQLzs5"
+        url="https://github.com/stratoweave/acton-yang/archive/819d3204328331854fb4ec4912443a776629aec7.zip",
+        hash="N-V-__8AAG_nJACQ5F_-15AW3lbZ9p2XFqH4Fi8Cq3qdXFFO"
     )
 }
 zig_dependencies = {}

--- a/minisys/gen/Build.act
+++ b/minisys/gen/Build.act
@@ -6,8 +6,8 @@ dependencies = {
     ),
     "yang": (
         repo_url="https://github.com/stratoweave/acton-yang.git",
-        url="https://github.com/stratoweave/acton-yang/archive/716dfa5b43ca288c71dfb01d27edc9adc533da09.zip",
-        hash="N-V-__8AAKyzJADfger1LDjLG2bbJ4VMY5Bt8EL3TDFQLzs5"
+        url="https://github.com/stratoweave/acton-yang/archive/819d3204328331854fb4ec4912443a776629aec7.zip",
+        hash="N-V-__8AAG_nJACQ5F_-15AW3lbZ9p2XFqH4Fi8Cq3qdXFFO"
     )
 }
 zig_dependencies = {}

--- a/minisys/src/mini/devices/ietf.act
+++ b/minisys/src/mini/devices/ietf.act
@@ -8583,7 +8583,7 @@ class ietf_netconf_acm__nacm__groups__group_entry(yang.adata.MNode):
     name: str
     user_name: list[str]
 
-    mut def __init__(self, name: str, user_name: ?list[str]=None):
+    mut def __init__(self, name: str, user_name: ?list[str]=None) -> None:
         self._ns = 'urn:ietf:params:xml:ns:yang:ietf-netconf-acm'
         self.name = name
         self.user_name = user_name if user_name is not None else []
@@ -8601,19 +8601,19 @@ class ietf_netconf_acm__nacm__groups__group_entry(yang.adata.MNode):
     mut def from_gdata(n: yang.gdata.Node) -> ietf_netconf_acm__nacm__groups__group_entry:
         return ietf_netconf_acm__nacm__groups__group_entry(name=n.get_str(yang.gdata.Id(NS_ietf_netconf_acm, 'name')), user_name=n.get_opt_strs(yang.gdata.Id(NS_ietf_netconf_acm, 'user-name')))
 
-    def copy(self):
+    def copy(self) -> ietf_netconf_acm__nacm__groups__group_entry:
         """Create a deep copy of this adata object"""
         return ietf_netconf_acm__nacm__groups__group_entry.from_gdata(self.to_gdata())
 
 _breaker2 = None
 class ietf_netconf_acm__nacm__groups__group(yang.adata.MNode):
     elements: list[ietf_netconf_acm__nacm__groups__group_entry]
-    mut def __init__(self, elements=[]):
+    mut def __init__(self, elements: list[ietf_netconf_acm__nacm__groups__group_entry]=[]) -> None:
         self._ns = 'urn:ietf:params:xml:ns:yang:ietf-netconf-acm'
         self._name = 'group'
         self.elements = elements
 
-    mut def create(self, name):
+    mut def create(self, name: str) -> ietf_netconf_acm__nacm__groups__group_entry:
         for e in self:
             match = True
             if e.name != name:
@@ -8632,7 +8632,7 @@ class ietf_netconf_acm__nacm__groups__group(yang.adata.MNode):
             return [ietf_netconf_acm__nacm__groups__group_entry.from_gdata(e) for e in n.elements]
         return []
 
-    def copy(self):
+    def copy(self) -> ietf_netconf_acm__nacm__groups__group:
         """Create a deep copy of this list object"""
         # Copy each element in the list
         copied_elements = []
@@ -8650,7 +8650,7 @@ _breaker3 = None
 class ietf_netconf_acm__nacm__groups(yang.adata.MNode):
     group: ietf_netconf_acm__nacm__groups__group
 
-    mut def __init__(self, group: list[ietf_netconf_acm__nacm__groups__group_entry]=[]):
+    mut def __init__(self, group: list[ietf_netconf_acm__nacm__groups__group_entry]=[]) -> None:
         self._ns = 'urn:ietf:params:xml:ns:yang:ietf-netconf-acm'
         self.group = ietf_netconf_acm__nacm__groups__group(elements=group)
 
@@ -8667,7 +8667,7 @@ class ietf_netconf_acm__nacm__groups(yang.adata.MNode):
             return ietf_netconf_acm__nacm__groups(group=ietf_netconf_acm__nacm__groups__group.from_gdata(n.get_opt_list(yang.gdata.Id(NS_ietf_netconf_acm, 'group'))))
         return ietf_netconf_acm__nacm__groups()
 
-    def copy(self):
+    def copy(self) -> ietf_netconf_acm__nacm__groups:
         """Create a deep copy of this adata object"""
         return ietf_netconf_acm__nacm__groups.from_gdata(self.to_gdata())
 
@@ -8683,7 +8683,7 @@ class ietf_netconf_acm__nacm__rule_list__rule_entry(yang.adata.MNode):
     action_: ?str
     comment: ?str
 
-    mut def __init__(self, name: str, module_name: ?str, rpc_name: ?str, notification_name: ?str, path: ?str, access_operations: ?value, action_: ?str, comment: ?str):
+    mut def __init__(self, name: str, module_name: ?str, rpc_name: ?str, notification_name: ?str, path: ?str, access_operations: ?value, action_: ?str, comment: ?str) -> None:
         self._ns = 'urn:ietf:params:xml:ns:yang:ietf-netconf-acm'
         self.name = name
         self.module_name = module_name
@@ -8719,19 +8719,19 @@ class ietf_netconf_acm__nacm__rule_list__rule_entry(yang.adata.MNode):
     mut def from_gdata(n: yang.gdata.Node) -> ietf_netconf_acm__nacm__rule_list__rule_entry:
         return ietf_netconf_acm__nacm__rule_list__rule_entry(name=n.get_str(yang.gdata.Id(NS_ietf_netconf_acm, 'name')), module_name=n.get_opt_str(yang.gdata.Id(NS_ietf_netconf_acm, 'module-name')), rpc_name=n.get_opt_str(yang.gdata.Id(NS_ietf_netconf_acm, 'rpc-name')), notification_name=n.get_opt_str(yang.gdata.Id(NS_ietf_netconf_acm, 'notification-name')), path=n.get_opt_str(yang.gdata.Id(NS_ietf_netconf_acm, 'path')), access_operations=n.get_opt_value(yang.gdata.Id(NS_ietf_netconf_acm, 'access-operations')), action_=n.get_opt_str(yang.gdata.Id(NS_ietf_netconf_acm, 'action')), comment=n.get_opt_str(yang.gdata.Id(NS_ietf_netconf_acm, 'comment')))
 
-    def copy(self):
+    def copy(self) -> ietf_netconf_acm__nacm__rule_list__rule_entry:
         """Create a deep copy of this adata object"""
         return ietf_netconf_acm__nacm__rule_list__rule_entry.from_gdata(self.to_gdata())
 
 _breaker5 = None
 class ietf_netconf_acm__nacm__rule_list__rule(yang.adata.MNode):
     elements: list[ietf_netconf_acm__nacm__rule_list__rule_entry]
-    mut def __init__(self, elements=[]):
+    mut def __init__(self, elements: list[ietf_netconf_acm__nacm__rule_list__rule_entry]=[]) -> None:
         self._ns = 'urn:ietf:params:xml:ns:yang:ietf-netconf-acm'
         self._name = 'rule'
         self.elements = elements
 
-    mut def create(self, name, module_name=None, rpc_name=None, notification_name=None, path=None, access_operations=None, action_=None, comment=None):
+    mut def create(self, name: str, module_name: ?str=None, rpc_name: ?str=None, notification_name: ?str=None, path: ?str=None, access_operations: ?value=None, action_: ?str=None, comment: ?str=None) -> ietf_netconf_acm__nacm__rule_list__rule_entry:
         for e in self:
             match = True
             if e.name != name:
@@ -8764,7 +8764,7 @@ class ietf_netconf_acm__nacm__rule_list__rule(yang.adata.MNode):
             return [ietf_netconf_acm__nacm__rule_list__rule_entry.from_gdata(e) for e in n.elements]
         return []
 
-    def copy(self):
+    def copy(self) -> ietf_netconf_acm__nacm__rule_list__rule:
         """Create a deep copy of this list object"""
         # Copy each element in the list
         copied_elements = []
@@ -8784,7 +8784,7 @@ class ietf_netconf_acm__nacm__rule_list_entry(yang.adata.MNode):
     group: list[str]
     rule: ietf_netconf_acm__nacm__rule_list__rule
 
-    mut def __init__(self, name: str, group: ?list[str]=None, rule: list[ietf_netconf_acm__nacm__rule_list__rule_entry]=[]):
+    mut def __init__(self, name: str, group: ?list[str]=None, rule: list[ietf_netconf_acm__nacm__rule_list__rule_entry]=[]) -> None:
         self._ns = 'urn:ietf:params:xml:ns:yang:ietf-netconf-acm'
         self.name = name
         self.group = group if group is not None else []
@@ -8805,19 +8805,19 @@ class ietf_netconf_acm__nacm__rule_list_entry(yang.adata.MNode):
     mut def from_gdata(n: yang.gdata.Node) -> ietf_netconf_acm__nacm__rule_list_entry:
         return ietf_netconf_acm__nacm__rule_list_entry(name=n.get_str(yang.gdata.Id(NS_ietf_netconf_acm, 'name')), group=n.get_opt_strs(yang.gdata.Id(NS_ietf_netconf_acm, 'group')), rule=ietf_netconf_acm__nacm__rule_list__rule.from_gdata(n.get_opt_list(yang.gdata.Id(NS_ietf_netconf_acm, 'rule'))))
 
-    def copy(self):
+    def copy(self) -> ietf_netconf_acm__nacm__rule_list_entry:
         """Create a deep copy of this adata object"""
         return ietf_netconf_acm__nacm__rule_list_entry.from_gdata(self.to_gdata())
 
 _breaker7 = None
 class ietf_netconf_acm__nacm__rule_list(yang.adata.MNode):
     elements: list[ietf_netconf_acm__nacm__rule_list_entry]
-    mut def __init__(self, elements=[]):
+    mut def __init__(self, elements: list[ietf_netconf_acm__nacm__rule_list_entry]=[]) -> None:
         self._ns = 'urn:ietf:params:xml:ns:yang:ietf-netconf-acm'
         self._name = 'rule-list'
         self.elements = elements
 
-    mut def create(self, name):
+    mut def create(self, name: str) -> ietf_netconf_acm__nacm__rule_list_entry:
         for e in self:
             match = True
             if e.name != name:
@@ -8836,7 +8836,7 @@ class ietf_netconf_acm__nacm__rule_list(yang.adata.MNode):
             return [ietf_netconf_acm__nacm__rule_list_entry.from_gdata(e) for e in n.elements]
         return []
 
-    def copy(self):
+    def copy(self) -> ietf_netconf_acm__nacm__rule_list:
         """Create a deep copy of this list object"""
         # Copy each element in the list
         copied_elements = []
@@ -8860,7 +8860,7 @@ class ietf_netconf_acm__nacm(yang.adata.MNode):
     groups: ietf_netconf_acm__nacm__groups
     rule_list: ietf_netconf_acm__nacm__rule_list
 
-    mut def __init__(self, enable_nacm: ?bool, read_default: ?str, write_default: ?str, exec_default: ?str, enable_external_groups: ?bool, groups: ?ietf_netconf_acm__nacm__groups=None, rule_list: list[ietf_netconf_acm__nacm__rule_list_entry]=[]):
+    mut def __init__(self, enable_nacm: ?bool, read_default: ?str, write_default: ?str, exec_default: ?str, enable_external_groups: ?bool, groups: ?ietf_netconf_acm__nacm__groups=None, rule_list: list[ietf_netconf_acm__nacm__rule_list_entry]=[]) -> None:
         self._ns = 'urn:ietf:params:xml:ns:yang:ietf-netconf-acm'
         self.enable_nacm = enable_nacm
         self.read_default = read_default
@@ -8895,7 +8895,7 @@ class ietf_netconf_acm__nacm(yang.adata.MNode):
             return ietf_netconf_acm__nacm(enable_nacm=n.get_opt_bool(yang.gdata.Id(NS_ietf_netconf_acm, 'enable-nacm')), read_default=n.get_opt_str(yang.gdata.Id(NS_ietf_netconf_acm, 'read-default')), write_default=n.get_opt_str(yang.gdata.Id(NS_ietf_netconf_acm, 'write-default')), exec_default=n.get_opt_str(yang.gdata.Id(NS_ietf_netconf_acm, 'exec-default')), enable_external_groups=n.get_opt_bool(yang.gdata.Id(NS_ietf_netconf_acm, 'enable-external-groups')), groups=ietf_netconf_acm__nacm__groups.from_gdata(n.get_opt_cnt(yang.gdata.Id(NS_ietf_netconf_acm, 'groups'))), rule_list=ietf_netconf_acm__nacm__rule_list.from_gdata(n.get_opt_list(yang.gdata.Id(NS_ietf_netconf_acm, 'rule-list'))))
         return ietf_netconf_acm__nacm()
 
-    def copy(self):
+    def copy(self) -> ietf_netconf_acm__nacm:
         """Create a deep copy of this adata object"""
         return ietf_netconf_acm__nacm.from_gdata(self.to_gdata())
 
@@ -8905,7 +8905,7 @@ class ietf_system__system__clock(yang.adata.MNode):
     timezone_name: ?str
     timezone_utc_offset: ?int
 
-    mut def __init__(self, timezone_name: ?str, timezone_utc_offset: ?int):
+    mut def __init__(self, timezone_name: ?str, timezone_utc_offset: ?int) -> None:
         self._ns = 'urn:ietf:params:xml:ns:yang:ietf-system'
         self.timezone_name = timezone_name
         self.timezone_utc_offset = timezone_utc_offset
@@ -8925,7 +8925,7 @@ class ietf_system__system__clock(yang.adata.MNode):
             return ietf_system__system__clock(timezone_name=n.get_opt_str(yang.gdata.Id(NS_ietf_system, 'timezone-name')), timezone_utc_offset=n.get_opt_int(yang.gdata.Id(NS_ietf_system, 'timezone-utc-offset')))
         return ietf_system__system__clock()
 
-    def copy(self):
+    def copy(self) -> ietf_system__system__clock:
         """Create a deep copy of this adata object"""
         return ietf_system__system__clock.from_gdata(self.to_gdata())
 
@@ -8935,7 +8935,7 @@ class ietf_system__system__ntp__server__udp(yang.adata.MNode):
     address: ?str
     port: ?u64
 
-    mut def __init__(self, address: ?str, port: ?u64):
+    mut def __init__(self, address: ?str, port: ?u64) -> None:
         self._ns = 'urn:ietf:params:xml:ns:yang:ietf-system'
         self.address = address
         self.port = port
@@ -8955,7 +8955,7 @@ class ietf_system__system__ntp__server__udp(yang.adata.MNode):
             return ietf_system__system__ntp__server__udp(address=n.get_opt_str(yang.gdata.Id(NS_ietf_system, 'address')), port=n.get_opt_u64(yang.gdata.Id(NS_ietf_system, 'port')))
         return ietf_system__system__ntp__server__udp()
 
-    def copy(self):
+    def copy(self) -> ietf_system__system__ntp__server__udp:
         """Create a deep copy of this adata object"""
         return ietf_system__system__ntp__server__udp.from_gdata(self.to_gdata())
 
@@ -8968,7 +8968,7 @@ class ietf_system__system__ntp__server_entry(yang.adata.MNode):
     iburst: ?bool
     prefer: ?bool
 
-    mut def __init__(self, name: str, udp: ?ietf_system__system__ntp__server__udp=None, association_type: ?str, iburst: ?bool, prefer: ?bool):
+    mut def __init__(self, name: str, udp: ?ietf_system__system__ntp__server__udp=None, association_type: ?str, iburst: ?bool, prefer: ?bool) -> None:
         self._ns = 'urn:ietf:params:xml:ns:yang:ietf-system'
         self.name = name
         self.udp = udp if udp is not None else ietf_system__system__ntp__server__udp()
@@ -8995,19 +8995,19 @@ class ietf_system__system__ntp__server_entry(yang.adata.MNode):
     mut def from_gdata(n: yang.gdata.Node) -> ietf_system__system__ntp__server_entry:
         return ietf_system__system__ntp__server_entry(name=n.get_str(yang.gdata.Id(NS_ietf_system, 'name')), udp=ietf_system__system__ntp__server__udp.from_gdata(n.get_opt_cnt(yang.gdata.Id(NS_ietf_system, 'udp'))), association_type=n.get_opt_str(yang.gdata.Id(NS_ietf_system, 'association-type')), iburst=n.get_opt_bool(yang.gdata.Id(NS_ietf_system, 'iburst')), prefer=n.get_opt_bool(yang.gdata.Id(NS_ietf_system, 'prefer')))
 
-    def copy(self):
+    def copy(self) -> ietf_system__system__ntp__server_entry:
         """Create a deep copy of this adata object"""
         return ietf_system__system__ntp__server_entry.from_gdata(self.to_gdata())
 
 _breaker12 = None
 class ietf_system__system__ntp__server(yang.adata.MNode):
     elements: list[ietf_system__system__ntp__server_entry]
-    mut def __init__(self, elements=[]):
+    mut def __init__(self, elements: list[ietf_system__system__ntp__server_entry]=[]) -> None:
         self._ns = 'urn:ietf:params:xml:ns:yang:ietf-system'
         self._name = 'server'
         self.elements = elements
 
-    mut def create(self, name, association_type=None, iburst=None, prefer=None):
+    mut def create(self, name: str, association_type: ?str=None, iburst: ?bool=None, prefer: ?bool=None) -> ietf_system__system__ntp__server_entry:
         for e in self:
             match = True
             if e.name != name:
@@ -9032,7 +9032,7 @@ class ietf_system__system__ntp__server(yang.adata.MNode):
             return [ietf_system__system__ntp__server_entry.from_gdata(e) for e in n.elements]
         return []
 
-    def copy(self):
+    def copy(self) -> ietf_system__system__ntp__server:
         """Create a deep copy of this list object"""
         # Copy each element in the list
         copied_elements = []
@@ -9051,7 +9051,7 @@ class ietf_system__system__ntp(yang.adata.MNode):
     enabled: ?bool
     server: ietf_system__system__ntp__server
 
-    mut def __init__(self, enabled: ?bool, server: list[ietf_system__system__ntp__server_entry]=[]):
+    mut def __init__(self, enabled: ?bool, server: list[ietf_system__system__ntp__server_entry]=[]) -> None:
         self._ns = 'urn:ietf:params:xml:ns:yang:ietf-system'
         self.enabled = enabled
         self.server = ietf_system__system__ntp__server(elements=server)
@@ -9071,7 +9071,7 @@ class ietf_system__system__ntp(yang.adata.MNode):
             return ietf_system__system__ntp(enabled=n.get_opt_bool(yang.gdata.Id(NS_ietf_system, 'enabled')), server=ietf_system__system__ntp__server.from_gdata(n.get_opt_list(yang.gdata.Id(NS_ietf_system, 'server'))))
         return None
 
-    def copy(self):
+    def copy(self) -> ietf_system__system__ntp:
         """Create a deep copy of this adata object"""
         ad = ietf_system__system__ntp.from_gdata(self.to_gdata())
         if ad is not None:
@@ -9084,7 +9084,7 @@ class ietf_system__system__dns_resolver__server__udp_and_tcp(yang.adata.MNode):
     address: ?str
     port: ?u64
 
-    mut def __init__(self, address: ?str, port: ?u64):
+    mut def __init__(self, address: ?str, port: ?u64) -> None:
         self._ns = 'urn:ietf:params:xml:ns:yang:ietf-system'
         self.address = address
         self.port = port
@@ -9104,7 +9104,7 @@ class ietf_system__system__dns_resolver__server__udp_and_tcp(yang.adata.MNode):
             return ietf_system__system__dns_resolver__server__udp_and_tcp(address=n.get_opt_str(yang.gdata.Id(NS_ietf_system, 'address')), port=n.get_opt_u64(yang.gdata.Id(NS_ietf_system, 'port')))
         return ietf_system__system__dns_resolver__server__udp_and_tcp()
 
-    def copy(self):
+    def copy(self) -> ietf_system__system__dns_resolver__server__udp_and_tcp:
         """Create a deep copy of this adata object"""
         return ietf_system__system__dns_resolver__server__udp_and_tcp.from_gdata(self.to_gdata())
 
@@ -9114,7 +9114,7 @@ class ietf_system__system__dns_resolver__server_entry(yang.adata.MNode):
     name: str
     udp_and_tcp: ietf_system__system__dns_resolver__server__udp_and_tcp
 
-    mut def __init__(self, name: str, udp_and_tcp: ?ietf_system__system__dns_resolver__server__udp_and_tcp=None):
+    mut def __init__(self, name: str, udp_and_tcp: ?ietf_system__system__dns_resolver__server__udp_and_tcp=None) -> None:
         self._ns = 'urn:ietf:params:xml:ns:yang:ietf-system'
         self.name = name
         self.udp_and_tcp = udp_and_tcp if udp_and_tcp is not None else ietf_system__system__dns_resolver__server__udp_and_tcp()
@@ -9132,19 +9132,19 @@ class ietf_system__system__dns_resolver__server_entry(yang.adata.MNode):
     mut def from_gdata(n: yang.gdata.Node) -> ietf_system__system__dns_resolver__server_entry:
         return ietf_system__system__dns_resolver__server_entry(name=n.get_str(yang.gdata.Id(NS_ietf_system, 'name')), udp_and_tcp=ietf_system__system__dns_resolver__server__udp_and_tcp.from_gdata(n.get_opt_cnt(yang.gdata.Id(NS_ietf_system, 'udp-and-tcp'))))
 
-    def copy(self):
+    def copy(self) -> ietf_system__system__dns_resolver__server_entry:
         """Create a deep copy of this adata object"""
         return ietf_system__system__dns_resolver__server_entry.from_gdata(self.to_gdata())
 
 _breaker16 = None
 class ietf_system__system__dns_resolver__server(yang.adata.MNode):
     elements: list[ietf_system__system__dns_resolver__server_entry]
-    mut def __init__(self, elements=[]):
+    mut def __init__(self, elements: list[ietf_system__system__dns_resolver__server_entry]=[]) -> None:
         self._ns = 'urn:ietf:params:xml:ns:yang:ietf-system'
         self._name = 'server'
         self.elements = elements
 
-    mut def create(self, name):
+    mut def create(self, name: str) -> ietf_system__system__dns_resolver__server_entry:
         for e in self:
             match = True
             if e.name != name:
@@ -9163,7 +9163,7 @@ class ietf_system__system__dns_resolver__server(yang.adata.MNode):
             return [ietf_system__system__dns_resolver__server_entry.from_gdata(e) for e in n.elements]
         return []
 
-    def copy(self):
+    def copy(self) -> ietf_system__system__dns_resolver__server:
         """Create a deep copy of this list object"""
         # Copy each element in the list
         copied_elements = []
@@ -9182,7 +9182,7 @@ class ietf_system__system__dns_resolver__options(yang.adata.MNode):
     timeout: ?u64
     attempts: ?u64
 
-    mut def __init__(self, timeout: ?u64, attempts: ?u64):
+    mut def __init__(self, timeout: ?u64, attempts: ?u64) -> None:
         self._ns = 'urn:ietf:params:xml:ns:yang:ietf-system'
         self.timeout = timeout
         self.attempts = attempts
@@ -9202,7 +9202,7 @@ class ietf_system__system__dns_resolver__options(yang.adata.MNode):
             return ietf_system__system__dns_resolver__options(timeout=n.get_opt_u64(yang.gdata.Id(NS_ietf_system, 'timeout')), attempts=n.get_opt_u64(yang.gdata.Id(NS_ietf_system, 'attempts')))
         return ietf_system__system__dns_resolver__options()
 
-    def copy(self):
+    def copy(self) -> ietf_system__system__dns_resolver__options:
         """Create a deep copy of this adata object"""
         return ietf_system__system__dns_resolver__options.from_gdata(self.to_gdata())
 
@@ -9213,7 +9213,7 @@ class ietf_system__system__dns_resolver(yang.adata.MNode):
     server: ietf_system__system__dns_resolver__server
     options: ietf_system__system__dns_resolver__options
 
-    mut def __init__(self, search: ?list[str]=None, server: list[ietf_system__system__dns_resolver__server_entry]=[], options: ?ietf_system__system__dns_resolver__options=None):
+    mut def __init__(self, search: ?list[str]=None, server: list[ietf_system__system__dns_resolver__server_entry]=[], options: ?ietf_system__system__dns_resolver__options=None) -> None:
         self._ns = 'urn:ietf:params:xml:ns:yang:ietf-system'
         self.search = search if search is not None else []
         self.server = ietf_system__system__dns_resolver__server(elements=server)
@@ -9236,7 +9236,7 @@ class ietf_system__system__dns_resolver(yang.adata.MNode):
             return ietf_system__system__dns_resolver(search=n.get_opt_strs(yang.gdata.Id(NS_ietf_system, 'search')), server=ietf_system__system__dns_resolver__server.from_gdata(n.get_opt_list(yang.gdata.Id(NS_ietf_system, 'server'))), options=ietf_system__system__dns_resolver__options.from_gdata(n.get_opt_cnt(yang.gdata.Id(NS_ietf_system, 'options'))))
         return ietf_system__system__dns_resolver()
 
-    def copy(self):
+    def copy(self) -> ietf_system__system__dns_resolver:
         """Create a deep copy of this adata object"""
         return ietf_system__system__dns_resolver.from_gdata(self.to_gdata())
 
@@ -9247,7 +9247,7 @@ class ietf_system__system__radius__server__udp(yang.adata.MNode):
     authentication_port: ?u64
     shared_secret: ?str
 
-    mut def __init__(self, address: ?str, authentication_port: ?u64, shared_secret: ?str):
+    mut def __init__(self, address: ?str, authentication_port: ?u64, shared_secret: ?str) -> None:
         self._ns = 'urn:ietf:params:xml:ns:yang:ietf-system'
         self.address = address
         self.authentication_port = authentication_port
@@ -9270,7 +9270,7 @@ class ietf_system__system__radius__server__udp(yang.adata.MNode):
             return ietf_system__system__radius__server__udp(address=n.get_opt_str(yang.gdata.Id(NS_ietf_system, 'address')), authentication_port=n.get_opt_u64(yang.gdata.Id(NS_ietf_system, 'authentication-port')), shared_secret=n.get_opt_str(yang.gdata.Id(NS_ietf_system, 'shared-secret')))
         return ietf_system__system__radius__server__udp()
 
-    def copy(self):
+    def copy(self) -> ietf_system__system__radius__server__udp:
         """Create a deep copy of this adata object"""
         return ietf_system__system__radius__server__udp.from_gdata(self.to_gdata())
 
@@ -9281,7 +9281,7 @@ class ietf_system__system__radius__server_entry(yang.adata.MNode):
     udp: ietf_system__system__radius__server__udp
     authentication_type: ?Identityref
 
-    mut def __init__(self, name: str, udp: ?ietf_system__system__radius__server__udp=None, authentication_type: ?Identityref):
+    mut def __init__(self, name: str, udp: ?ietf_system__system__radius__server__udp=None, authentication_type: ?Identityref) -> None:
         self._ns = 'urn:ietf:params:xml:ns:yang:ietf-system'
         self.name = name
         self.udp = udp if udp is not None else ietf_system__system__radius__server__udp()
@@ -9302,19 +9302,19 @@ class ietf_system__system__radius__server_entry(yang.adata.MNode):
     mut def from_gdata(n: yang.gdata.Node) -> ietf_system__system__radius__server_entry:
         return ietf_system__system__radius__server_entry(name=n.get_str(yang.gdata.Id(NS_ietf_system, 'name')), udp=ietf_system__system__radius__server__udp.from_gdata(n.get_opt_cnt(yang.gdata.Id(NS_ietf_system, 'udp'))), authentication_type=n.get_opt_Identityref(yang.gdata.Id(NS_ietf_system, 'authentication-type')))
 
-    def copy(self):
+    def copy(self) -> ietf_system__system__radius__server_entry:
         """Create a deep copy of this adata object"""
         return ietf_system__system__radius__server_entry.from_gdata(self.to_gdata())
 
 _breaker21 = None
 class ietf_system__system__radius__server(yang.adata.MNode):
     elements: list[ietf_system__system__radius__server_entry]
-    mut def __init__(self, elements=[]):
+    mut def __init__(self, elements: list[ietf_system__system__radius__server_entry]=[]) -> None:
         self._ns = 'urn:ietf:params:xml:ns:yang:ietf-system'
         self._name = 'server'
         self.elements = elements
 
-    mut def create(self, name, authentication_type=None):
+    mut def create(self, name: str, authentication_type: ?Identityref=None) -> ietf_system__system__radius__server_entry:
         for e in self:
             match = True
             if e.name != name:
@@ -9335,7 +9335,7 @@ class ietf_system__system__radius__server(yang.adata.MNode):
             return [ietf_system__system__radius__server_entry.from_gdata(e) for e in n.elements]
         return []
 
-    def copy(self):
+    def copy(self) -> ietf_system__system__radius__server:
         """Create a deep copy of this list object"""
         # Copy each element in the list
         copied_elements = []
@@ -9354,7 +9354,7 @@ class ietf_system__system__radius__options(yang.adata.MNode):
     timeout: ?u64
     attempts: ?u64
 
-    mut def __init__(self, timeout: ?u64, attempts: ?u64):
+    mut def __init__(self, timeout: ?u64, attempts: ?u64) -> None:
         self._ns = 'urn:ietf:params:xml:ns:yang:ietf-system'
         self.timeout = timeout
         self.attempts = attempts
@@ -9374,7 +9374,7 @@ class ietf_system__system__radius__options(yang.adata.MNode):
             return ietf_system__system__radius__options(timeout=n.get_opt_u64(yang.gdata.Id(NS_ietf_system, 'timeout')), attempts=n.get_opt_u64(yang.gdata.Id(NS_ietf_system, 'attempts')))
         return ietf_system__system__radius__options()
 
-    def copy(self):
+    def copy(self) -> ietf_system__system__radius__options:
         """Create a deep copy of this adata object"""
         return ietf_system__system__radius__options.from_gdata(self.to_gdata())
 
@@ -9384,7 +9384,7 @@ class ietf_system__system__radius(yang.adata.MNode):
     server: ietf_system__system__radius__server
     options: ietf_system__system__radius__options
 
-    mut def __init__(self, server: list[ietf_system__system__radius__server_entry]=[], options: ?ietf_system__system__radius__options=None):
+    mut def __init__(self, server: list[ietf_system__system__radius__server_entry]=[], options: ?ietf_system__system__radius__options=None) -> None:
         self._ns = 'urn:ietf:params:xml:ns:yang:ietf-system'
         self.server = ietf_system__system__radius__server(elements=server)
         self.options = options if options is not None else ietf_system__system__radius__options()
@@ -9404,7 +9404,7 @@ class ietf_system__system__radius(yang.adata.MNode):
             return ietf_system__system__radius(server=ietf_system__system__radius__server.from_gdata(n.get_opt_list(yang.gdata.Id(NS_ietf_system, 'server'))), options=ietf_system__system__radius__options.from_gdata(n.get_opt_cnt(yang.gdata.Id(NS_ietf_system, 'options'))))
         return ietf_system__system__radius()
 
-    def copy(self):
+    def copy(self) -> ietf_system__system__radius:
         """Create a deep copy of this adata object"""
         return ietf_system__system__radius.from_gdata(self.to_gdata())
 
@@ -9415,7 +9415,7 @@ class ietf_system__system__authentication__user__authorized_key_entry(yang.adata
     algorithm: ?str
     key_data: ?bytes
 
-    mut def __init__(self, name: str, algorithm: ?str, key_data: ?bytes):
+    mut def __init__(self, name: str, algorithm: ?str, key_data: ?bytes) -> None:
         self._ns = 'urn:ietf:params:xml:ns:yang:ietf-system'
         self.name = name
         self.algorithm = algorithm
@@ -9436,19 +9436,19 @@ class ietf_system__system__authentication__user__authorized_key_entry(yang.adata
     mut def from_gdata(n: yang.gdata.Node) -> ietf_system__system__authentication__user__authorized_key_entry:
         return ietf_system__system__authentication__user__authorized_key_entry(name=n.get_str(yang.gdata.Id(NS_ietf_system, 'name')), algorithm=n.get_opt_str(yang.gdata.Id(NS_ietf_system, 'algorithm')), key_data=n.get_opt_bytes(yang.gdata.Id(NS_ietf_system, 'key-data')))
 
-    def copy(self):
+    def copy(self) -> ietf_system__system__authentication__user__authorized_key_entry:
         """Create a deep copy of this adata object"""
         return ietf_system__system__authentication__user__authorized_key_entry.from_gdata(self.to_gdata())
 
 _breaker25 = None
 class ietf_system__system__authentication__user__authorized_key(yang.adata.MNode):
     elements: list[ietf_system__system__authentication__user__authorized_key_entry]
-    mut def __init__(self, elements=[]):
+    mut def __init__(self, elements: list[ietf_system__system__authentication__user__authorized_key_entry]=[]) -> None:
         self._ns = 'urn:ietf:params:xml:ns:yang:ietf-system'
         self._name = 'authorized-key'
         self.elements = elements
 
-    mut def create(self, name, algorithm=None, key_data=None):
+    mut def create(self, name: str, algorithm: ?str=None, key_data: ?bytes=None) -> ietf_system__system__authentication__user__authorized_key_entry:
         for e in self:
             match = True
             if e.name != name:
@@ -9471,7 +9471,7 @@ class ietf_system__system__authentication__user__authorized_key(yang.adata.MNode
             return [ietf_system__system__authentication__user__authorized_key_entry.from_gdata(e) for e in n.elements]
         return []
 
-    def copy(self):
+    def copy(self) -> ietf_system__system__authentication__user__authorized_key:
         """Create a deep copy of this list object"""
         # Copy each element in the list
         copied_elements = []
@@ -9491,7 +9491,7 @@ class ietf_system__system__authentication__user_entry(yang.adata.MNode):
     password: ?str
     authorized_key: ietf_system__system__authentication__user__authorized_key
 
-    mut def __init__(self, name: str, password: ?str, authorized_key: list[ietf_system__system__authentication__user__authorized_key_entry]=[]):
+    mut def __init__(self, name: str, password: ?str, authorized_key: list[ietf_system__system__authentication__user__authorized_key_entry]=[]) -> None:
         self._ns = 'urn:ietf:params:xml:ns:yang:ietf-system'
         self.name = name
         self.password = password
@@ -9512,19 +9512,19 @@ class ietf_system__system__authentication__user_entry(yang.adata.MNode):
     mut def from_gdata(n: yang.gdata.Node) -> ietf_system__system__authentication__user_entry:
         return ietf_system__system__authentication__user_entry(name=n.get_str(yang.gdata.Id(NS_ietf_system, 'name')), password=n.get_opt_str(yang.gdata.Id(NS_ietf_system, 'password')), authorized_key=ietf_system__system__authentication__user__authorized_key.from_gdata(n.get_opt_list(yang.gdata.Id(NS_ietf_system, 'authorized-key'))))
 
-    def copy(self):
+    def copy(self) -> ietf_system__system__authentication__user_entry:
         """Create a deep copy of this adata object"""
         return ietf_system__system__authentication__user_entry.from_gdata(self.to_gdata())
 
 _breaker27 = None
 class ietf_system__system__authentication__user(yang.adata.MNode):
     elements: list[ietf_system__system__authentication__user_entry]
-    mut def __init__(self, elements=[]):
+    mut def __init__(self, elements: list[ietf_system__system__authentication__user_entry]=[]) -> None:
         self._ns = 'urn:ietf:params:xml:ns:yang:ietf-system'
         self._name = 'user'
         self.elements = elements
 
-    mut def create(self, name, password=None):
+    mut def create(self, name: str, password: ?str=None) -> ietf_system__system__authentication__user_entry:
         for e in self:
             match = True
             if e.name != name:
@@ -9545,7 +9545,7 @@ class ietf_system__system__authentication__user(yang.adata.MNode):
             return [ietf_system__system__authentication__user_entry.from_gdata(e) for e in n.elements]
         return []
 
-    def copy(self):
+    def copy(self) -> ietf_system__system__authentication__user:
         """Create a deep copy of this list object"""
         # Copy each element in the list
         copied_elements = []
@@ -9564,7 +9564,7 @@ class ietf_system__system__authentication(yang.adata.MNode):
     user_authentication_order: list[Identityref]
     user: ietf_system__system__authentication__user
 
-    mut def __init__(self, user_authentication_order: ?list[Identityref]=None, user: list[ietf_system__system__authentication__user_entry]=[]):
+    mut def __init__(self, user_authentication_order: ?list[Identityref]=None, user: list[ietf_system__system__authentication__user_entry]=[]) -> None:
         self._ns = 'urn:ietf:params:xml:ns:yang:ietf-system'
         self.user_authentication_order = user_authentication_order if user_authentication_order is not None else []
         self.user = ietf_system__system__authentication__user(elements=user)
@@ -9584,7 +9584,7 @@ class ietf_system__system__authentication(yang.adata.MNode):
             return ietf_system__system__authentication(user_authentication_order=n.get_opt_Identityrefs(yang.gdata.Id(NS_ietf_system, 'user-authentication-order')), user=ietf_system__system__authentication__user.from_gdata(n.get_opt_list(yang.gdata.Id(NS_ietf_system, 'user'))))
         return ietf_system__system__authentication()
 
-    def copy(self):
+    def copy(self) -> ietf_system__system__authentication:
         """Create a deep copy of this adata object"""
         return ietf_system__system__authentication.from_gdata(self.to_gdata())
 
@@ -9600,7 +9600,7 @@ class ietf_system__system(yang.adata.MNode):
     radius: ietf_system__system__radius
     authentication: ietf_system__system__authentication
 
-    mut def __init__(self, contact: ?str, hostname: ?str, location: ?str, clock: ?ietf_system__system__clock=None, ntp: ?ietf_system__system__ntp=None, dns_resolver: ?ietf_system__system__dns_resolver=None, radius: ?ietf_system__system__radius=None, authentication: ?ietf_system__system__authentication=None):
+    mut def __init__(self, contact: ?str, hostname: ?str, location: ?str, clock: ?ietf_system__system__clock=None, ntp: ?ietf_system__system__ntp=None, dns_resolver: ?ietf_system__system__dns_resolver=None, radius: ?ietf_system__system__radius=None, authentication: ?ietf_system__system__authentication=None) -> None:
         self._ns = 'urn:ietf:params:xml:ns:yang:ietf-system'
         self.contact = contact
         self.hostname = hostname
@@ -9611,7 +9611,7 @@ class ietf_system__system(yang.adata.MNode):
         self.radius = radius if radius is not None else ietf_system__system__radius()
         self.authentication = authentication if authentication is not None else ietf_system__system__authentication()
 
-    mut def create_ntp(self, enabled=None):
+    mut def create_ntp(self, enabled: ?bool=None) -> ietf_system__system__ntp:
         existing = self.ntp
         if existing is not None:
             if enabled is not None:
@@ -9648,7 +9648,7 @@ class ietf_system__system(yang.adata.MNode):
             return ietf_system__system(contact=n.get_opt_str(yang.gdata.Id(NS_ietf_system, 'contact')), hostname=n.get_opt_str(yang.gdata.Id(NS_ietf_system, 'hostname')), location=n.get_opt_str(yang.gdata.Id(NS_ietf_system, 'location')), clock=ietf_system__system__clock.from_gdata(n.get_opt_cnt(yang.gdata.Id(NS_ietf_system, 'clock'))), ntp=ietf_system__system__ntp.from_gdata(n.get_opt_cnt(yang.gdata.Id(NS_ietf_system, 'ntp'))), dns_resolver=ietf_system__system__dns_resolver.from_gdata(n.get_opt_cnt(yang.gdata.Id(NS_ietf_system, 'dns-resolver'))), radius=ietf_system__system__radius.from_gdata(n.get_opt_cnt(yang.gdata.Id(NS_ietf_system, 'radius'))), authentication=ietf_system__system__authentication.from_gdata(n.get_opt_cnt(yang.gdata.Id(NS_ietf_system, 'authentication'))))
         return ietf_system__system()
 
-    def copy(self):
+    def copy(self) -> ietf_system__system:
         """Create a deep copy of this adata object"""
         return ietf_system__system.from_gdata(self.to_gdata())
 
@@ -9659,7 +9659,7 @@ class ietf_interfaces__interfaces__interface__ipv4__address_entry(yang.adata.MNo
     prefix_length: ?u64
     netmask: ?str
 
-    mut def __init__(self, ip: str, prefix_length: ?u64, netmask: ?str):
+    mut def __init__(self, ip: str, prefix_length: ?u64, netmask: ?str) -> None:
         self._ns = 'urn:ietf:params:xml:ns:yang:ietf-ip'
         self.ip = ip
         self.prefix_length = prefix_length
@@ -9680,19 +9680,19 @@ class ietf_interfaces__interfaces__interface__ipv4__address_entry(yang.adata.MNo
     mut def from_gdata(n: yang.gdata.Node) -> ietf_interfaces__interfaces__interface__ipv4__address_entry:
         return ietf_interfaces__interfaces__interface__ipv4__address_entry(ip=n.get_str(yang.gdata.Id(NS_ietf_ip, 'ip')), prefix_length=n.get_opt_u64(yang.gdata.Id(NS_ietf_ip, 'prefix-length')), netmask=n.get_opt_str(yang.gdata.Id(NS_ietf_ip, 'netmask')))
 
-    def copy(self):
+    def copy(self) -> ietf_interfaces__interfaces__interface__ipv4__address_entry:
         """Create a deep copy of this adata object"""
         return ietf_interfaces__interfaces__interface__ipv4__address_entry.from_gdata(self.to_gdata())
 
 _breaker31 = None
 class ietf_interfaces__interfaces__interface__ipv4__address(yang.adata.MNode):
     elements: list[ietf_interfaces__interfaces__interface__ipv4__address_entry]
-    mut def __init__(self, elements=[]):
+    mut def __init__(self, elements: list[ietf_interfaces__interfaces__interface__ipv4__address_entry]=[]) -> None:
         self._ns = 'urn:ietf:params:xml:ns:yang:ietf-ip'
         self._name = 'address'
         self.elements = elements
 
-    mut def create(self, ip, prefix_length=None, netmask=None):
+    mut def create(self, ip: str, prefix_length: ?u64=None, netmask: ?str=None) -> ietf_interfaces__interfaces__interface__ipv4__address_entry:
         for e in self:
             match = True
             if e.ip != ip:
@@ -9715,7 +9715,7 @@ class ietf_interfaces__interfaces__interface__ipv4__address(yang.adata.MNode):
             return [ietf_interfaces__interfaces__interface__ipv4__address_entry.from_gdata(e) for e in n.elements]
         return []
 
-    def copy(self):
+    def copy(self) -> ietf_interfaces__interfaces__interface__ipv4__address:
         """Create a deep copy of this list object"""
         # Copy each element in the list
         copied_elements = []
@@ -9734,7 +9734,7 @@ class ietf_interfaces__interfaces__interface__ipv4__neighbor_entry(yang.adata.MN
     ip: str
     link_layer_address: ?str
 
-    mut def __init__(self, ip: str, link_layer_address: ?str):
+    mut def __init__(self, ip: str, link_layer_address: ?str) -> None:
         self._ns = 'urn:ietf:params:xml:ns:yang:ietf-ip'
         self.ip = ip
         self.link_layer_address = link_layer_address
@@ -9752,19 +9752,19 @@ class ietf_interfaces__interfaces__interface__ipv4__neighbor_entry(yang.adata.MN
     mut def from_gdata(n: yang.gdata.Node) -> ietf_interfaces__interfaces__interface__ipv4__neighbor_entry:
         return ietf_interfaces__interfaces__interface__ipv4__neighbor_entry(ip=n.get_str(yang.gdata.Id(NS_ietf_ip, 'ip')), link_layer_address=n.get_opt_str(yang.gdata.Id(NS_ietf_ip, 'link-layer-address')))
 
-    def copy(self):
+    def copy(self) -> ietf_interfaces__interfaces__interface__ipv4__neighbor_entry:
         """Create a deep copy of this adata object"""
         return ietf_interfaces__interfaces__interface__ipv4__neighbor_entry.from_gdata(self.to_gdata())
 
 _breaker33 = None
 class ietf_interfaces__interfaces__interface__ipv4__neighbor(yang.adata.MNode):
     elements: list[ietf_interfaces__interfaces__interface__ipv4__neighbor_entry]
-    mut def __init__(self, elements=[]):
+    mut def __init__(self, elements: list[ietf_interfaces__interfaces__interface__ipv4__neighbor_entry]=[]) -> None:
         self._ns = 'urn:ietf:params:xml:ns:yang:ietf-ip'
         self._name = 'neighbor'
         self.elements = elements
 
-    mut def create(self, ip, link_layer_address=None):
+    mut def create(self, ip: str, link_layer_address: ?str=None) -> ietf_interfaces__interfaces__interface__ipv4__neighbor_entry:
         for e in self:
             match = True
             if e.ip != ip:
@@ -9785,7 +9785,7 @@ class ietf_interfaces__interfaces__interface__ipv4__neighbor(yang.adata.MNode):
             return [ietf_interfaces__interfaces__interface__ipv4__neighbor_entry.from_gdata(e) for e in n.elements]
         return []
 
-    def copy(self):
+    def copy(self) -> ietf_interfaces__interfaces__interface__ipv4__neighbor:
         """Create a deep copy of this list object"""
         # Copy each element in the list
         copied_elements = []
@@ -9807,7 +9807,7 @@ class ietf_interfaces__interfaces__interface__ipv4(yang.adata.MNode):
     address: ietf_interfaces__interfaces__interface__ipv4__address
     neighbor: ietf_interfaces__interfaces__interface__ipv4__neighbor
 
-    mut def __init__(self, enabled: ?bool, forwarding: ?bool, mtu: ?u64, address: list[ietf_interfaces__interfaces__interface__ipv4__address_entry]=[], neighbor: list[ietf_interfaces__interfaces__interface__ipv4__neighbor_entry]=[]):
+    mut def __init__(self, enabled: ?bool, forwarding: ?bool, mtu: ?u64, address: list[ietf_interfaces__interfaces__interface__ipv4__address_entry]=[], neighbor: list[ietf_interfaces__interfaces__interface__ipv4__neighbor_entry]=[]) -> None:
         self._ns = 'urn:ietf:params:xml:ns:yang:ietf-ip'
         self.enabled = enabled
         self.forwarding = forwarding
@@ -9836,7 +9836,7 @@ class ietf_interfaces__interfaces__interface__ipv4(yang.adata.MNode):
             return ietf_interfaces__interfaces__interface__ipv4(enabled=n.get_opt_bool(yang.gdata.Id(NS_ietf_ip, 'enabled')), forwarding=n.get_opt_bool(yang.gdata.Id(NS_ietf_ip, 'forwarding')), mtu=n.get_opt_u64(yang.gdata.Id(NS_ietf_ip, 'mtu')), address=ietf_interfaces__interfaces__interface__ipv4__address.from_gdata(n.get_opt_list(yang.gdata.Id(NS_ietf_ip, 'address'))), neighbor=ietf_interfaces__interfaces__interface__ipv4__neighbor.from_gdata(n.get_opt_list(yang.gdata.Id(NS_ietf_ip, 'neighbor'))))
         return None
 
-    def copy(self):
+    def copy(self) -> ietf_interfaces__interfaces__interface__ipv4:
         """Create a deep copy of this adata object"""
         ad = ietf_interfaces__interfaces__interface__ipv4.from_gdata(self.to_gdata())
         if ad is not None:
@@ -9849,7 +9849,7 @@ class ietf_interfaces__interfaces__interface__ipv6__address_entry(yang.adata.MNo
     ip: str
     prefix_length: ?u64
 
-    mut def __init__(self, ip: str, prefix_length: ?u64):
+    mut def __init__(self, ip: str, prefix_length: ?u64) -> None:
         self._ns = 'urn:ietf:params:xml:ns:yang:ietf-ip'
         self.ip = ip
         self.prefix_length = prefix_length
@@ -9867,19 +9867,19 @@ class ietf_interfaces__interfaces__interface__ipv6__address_entry(yang.adata.MNo
     mut def from_gdata(n: yang.gdata.Node) -> ietf_interfaces__interfaces__interface__ipv6__address_entry:
         return ietf_interfaces__interfaces__interface__ipv6__address_entry(ip=n.get_str(yang.gdata.Id(NS_ietf_ip, 'ip')), prefix_length=n.get_opt_u64(yang.gdata.Id(NS_ietf_ip, 'prefix-length')))
 
-    def copy(self):
+    def copy(self) -> ietf_interfaces__interfaces__interface__ipv6__address_entry:
         """Create a deep copy of this adata object"""
         return ietf_interfaces__interfaces__interface__ipv6__address_entry.from_gdata(self.to_gdata())
 
 _breaker36 = None
 class ietf_interfaces__interfaces__interface__ipv6__address(yang.adata.MNode):
     elements: list[ietf_interfaces__interfaces__interface__ipv6__address_entry]
-    mut def __init__(self, elements=[]):
+    mut def __init__(self, elements: list[ietf_interfaces__interfaces__interface__ipv6__address_entry]=[]) -> None:
         self._ns = 'urn:ietf:params:xml:ns:yang:ietf-ip'
         self._name = 'address'
         self.elements = elements
 
-    mut def create(self, ip, prefix_length=None):
+    mut def create(self, ip: str, prefix_length: ?u64=None) -> ietf_interfaces__interfaces__interface__ipv6__address_entry:
         for e in self:
             match = True
             if e.ip != ip:
@@ -9900,7 +9900,7 @@ class ietf_interfaces__interfaces__interface__ipv6__address(yang.adata.MNode):
             return [ietf_interfaces__interfaces__interface__ipv6__address_entry.from_gdata(e) for e in n.elements]
         return []
 
-    def copy(self):
+    def copy(self) -> ietf_interfaces__interfaces__interface__ipv6__address:
         """Create a deep copy of this list object"""
         # Copy each element in the list
         copied_elements = []
@@ -9919,7 +9919,7 @@ class ietf_interfaces__interfaces__interface__ipv6__neighbor_entry(yang.adata.MN
     ip: str
     link_layer_address: ?str
 
-    mut def __init__(self, ip: str, link_layer_address: ?str):
+    mut def __init__(self, ip: str, link_layer_address: ?str) -> None:
         self._ns = 'urn:ietf:params:xml:ns:yang:ietf-ip'
         self.ip = ip
         self.link_layer_address = link_layer_address
@@ -9937,19 +9937,19 @@ class ietf_interfaces__interfaces__interface__ipv6__neighbor_entry(yang.adata.MN
     mut def from_gdata(n: yang.gdata.Node) -> ietf_interfaces__interfaces__interface__ipv6__neighbor_entry:
         return ietf_interfaces__interfaces__interface__ipv6__neighbor_entry(ip=n.get_str(yang.gdata.Id(NS_ietf_ip, 'ip')), link_layer_address=n.get_opt_str(yang.gdata.Id(NS_ietf_ip, 'link-layer-address')))
 
-    def copy(self):
+    def copy(self) -> ietf_interfaces__interfaces__interface__ipv6__neighbor_entry:
         """Create a deep copy of this adata object"""
         return ietf_interfaces__interfaces__interface__ipv6__neighbor_entry.from_gdata(self.to_gdata())
 
 _breaker38 = None
 class ietf_interfaces__interfaces__interface__ipv6__neighbor(yang.adata.MNode):
     elements: list[ietf_interfaces__interfaces__interface__ipv6__neighbor_entry]
-    mut def __init__(self, elements=[]):
+    mut def __init__(self, elements: list[ietf_interfaces__interfaces__interface__ipv6__neighbor_entry]=[]) -> None:
         self._ns = 'urn:ietf:params:xml:ns:yang:ietf-ip'
         self._name = 'neighbor'
         self.elements = elements
 
-    mut def create(self, ip, link_layer_address=None):
+    mut def create(self, ip: str, link_layer_address: ?str=None) -> ietf_interfaces__interfaces__interface__ipv6__neighbor_entry:
         for e in self:
             match = True
             if e.ip != ip:
@@ -9970,7 +9970,7 @@ class ietf_interfaces__interfaces__interface__ipv6__neighbor(yang.adata.MNode):
             return [ietf_interfaces__interfaces__interface__ipv6__neighbor_entry.from_gdata(e) for e in n.elements]
         return []
 
-    def copy(self):
+    def copy(self) -> ietf_interfaces__interfaces__interface__ipv6__neighbor:
         """Create a deep copy of this list object"""
         # Copy each element in the list
         copied_elements = []
@@ -9991,7 +9991,7 @@ class ietf_interfaces__interfaces__interface__ipv6__autoconf(yang.adata.MNode):
     temporary_valid_lifetime: ?u64
     temporary_preferred_lifetime: ?u64
 
-    mut def __init__(self, create_global_addresses: ?bool, create_temporary_addresses: ?bool, temporary_valid_lifetime: ?u64, temporary_preferred_lifetime: ?u64):
+    mut def __init__(self, create_global_addresses: ?bool, create_temporary_addresses: ?bool, temporary_valid_lifetime: ?u64, temporary_preferred_lifetime: ?u64) -> None:
         self._ns = 'urn:ietf:params:xml:ns:yang:ietf-ip'
         self.create_global_addresses = create_global_addresses
         self.create_temporary_addresses = create_temporary_addresses
@@ -10017,7 +10017,7 @@ class ietf_interfaces__interfaces__interface__ipv6__autoconf(yang.adata.MNode):
             return ietf_interfaces__interfaces__interface__ipv6__autoconf(create_global_addresses=n.get_opt_bool(yang.gdata.Id(NS_ietf_ip, 'create-global-addresses')), create_temporary_addresses=n.get_opt_bool(yang.gdata.Id(NS_ietf_ip, 'create-temporary-addresses')), temporary_valid_lifetime=n.get_opt_u64(yang.gdata.Id(NS_ietf_ip, 'temporary-valid-lifetime')), temporary_preferred_lifetime=n.get_opt_u64(yang.gdata.Id(NS_ietf_ip, 'temporary-preferred-lifetime')))
         return ietf_interfaces__interfaces__interface__ipv6__autoconf()
 
-    def copy(self):
+    def copy(self) -> ietf_interfaces__interfaces__interface__ipv6__autoconf:
         """Create a deep copy of this adata object"""
         return ietf_interfaces__interfaces__interface__ipv6__autoconf.from_gdata(self.to_gdata())
 
@@ -10032,7 +10032,7 @@ class ietf_interfaces__interfaces__interface__ipv6(yang.adata.MNode):
     dup_addr_detect_transmits: ?u64
     autoconf: ietf_interfaces__interfaces__interface__ipv6__autoconf
 
-    mut def __init__(self, enabled: ?bool, forwarding: ?bool, mtu: ?u64, address: list[ietf_interfaces__interfaces__interface__ipv6__address_entry]=[], neighbor: list[ietf_interfaces__interfaces__interface__ipv6__neighbor_entry]=[], dup_addr_detect_transmits: ?u64, autoconf: ?ietf_interfaces__interfaces__interface__ipv6__autoconf=None):
+    mut def __init__(self, enabled: ?bool, forwarding: ?bool, mtu: ?u64, address: list[ietf_interfaces__interfaces__interface__ipv6__address_entry]=[], neighbor: list[ietf_interfaces__interfaces__interface__ipv6__neighbor_entry]=[], dup_addr_detect_transmits: ?u64, autoconf: ?ietf_interfaces__interfaces__interface__ipv6__autoconf=None) -> None:
         self._ns = 'urn:ietf:params:xml:ns:yang:ietf-ip'
         self.enabled = enabled
         self.forwarding = forwarding
@@ -10067,7 +10067,7 @@ class ietf_interfaces__interfaces__interface__ipv6(yang.adata.MNode):
             return ietf_interfaces__interfaces__interface__ipv6(enabled=n.get_opt_bool(yang.gdata.Id(NS_ietf_ip, 'enabled')), forwarding=n.get_opt_bool(yang.gdata.Id(NS_ietf_ip, 'forwarding')), mtu=n.get_opt_u64(yang.gdata.Id(NS_ietf_ip, 'mtu')), address=ietf_interfaces__interfaces__interface__ipv6__address.from_gdata(n.get_opt_list(yang.gdata.Id(NS_ietf_ip, 'address'))), neighbor=ietf_interfaces__interfaces__interface__ipv6__neighbor.from_gdata(n.get_opt_list(yang.gdata.Id(NS_ietf_ip, 'neighbor'))), dup_addr_detect_transmits=n.get_opt_u64(yang.gdata.Id(NS_ietf_ip, 'dup-addr-detect-transmits')), autoconf=ietf_interfaces__interfaces__interface__ipv6__autoconf.from_gdata(n.get_opt_cnt(yang.gdata.Id(NS_ietf_ip, 'autoconf'))))
         return None
 
-    def copy(self):
+    def copy(self) -> ietf_interfaces__interfaces__interface__ipv6:
         """Create a deep copy of this adata object"""
         ad = ietf_interfaces__interfaces__interface__ipv6.from_gdata(self.to_gdata())
         if ad is not None:
@@ -10085,7 +10085,7 @@ class ietf_interfaces__interfaces__interface_entry(yang.adata.MNode):
     ipv4: ?ietf_interfaces__interfaces__interface__ipv4
     ipv6: ?ietf_interfaces__interfaces__interface__ipv6
 
-    mut def __init__(self, name: str, description: ?str, type: ?Identityref, enabled: ?bool, link_up_down_trap_enable: ?str, ipv4: ?ietf_interfaces__interfaces__interface__ipv4=None, ipv6: ?ietf_interfaces__interfaces__interface__ipv6=None):
+    mut def __init__(self, name: str, description: ?str, type: ?Identityref, enabled: ?bool, link_up_down_trap_enable: ?str, ipv4: ?ietf_interfaces__interfaces__interface__ipv4=None, ipv6: ?ietf_interfaces__interfaces__interface__ipv6=None) -> None:
         self._ns = 'urn:ietf:params:xml:ns:yang:ietf-interfaces'
         self.name = name
         self.description = description
@@ -10095,7 +10095,7 @@ class ietf_interfaces__interfaces__interface_entry(yang.adata.MNode):
         self.ipv4 = ipv4
         self.ipv6 = ipv6
 
-    mut def create_ipv4(self, enabled=None, forwarding=None, mtu=None):
+    mut def create_ipv4(self, enabled: ?bool=None, forwarding: ?bool=None, mtu: ?u64=None) -> ietf_interfaces__interfaces__interface__ipv4:
         existing = self.ipv4
         if existing is not None:
             if enabled is not None:
@@ -10109,7 +10109,7 @@ class ietf_interfaces__interfaces__interface_entry(yang.adata.MNode):
         self.ipv4 = res
         return res
 
-    mut def create_ipv6(self, enabled=None, forwarding=None, mtu=None, dup_addr_detect_transmits=None):
+    mut def create_ipv6(self, enabled: ?bool=None, forwarding: ?bool=None, mtu: ?u64=None, dup_addr_detect_transmits: ?u64=None) -> ietf_interfaces__interfaces__interface__ipv6:
         existing = self.ipv6
         if existing is not None:
             if enabled is not None:
@@ -10148,19 +10148,19 @@ class ietf_interfaces__interfaces__interface_entry(yang.adata.MNode):
     mut def from_gdata(n: yang.gdata.Node) -> ietf_interfaces__interfaces__interface_entry:
         return ietf_interfaces__interfaces__interface_entry(name=n.get_str(yang.gdata.Id(NS_ietf_interfaces, 'name')), description=n.get_opt_str(yang.gdata.Id(NS_ietf_interfaces, 'description')), type=n.get_opt_Identityref(yang.gdata.Id(NS_ietf_interfaces, 'type')), enabled=n.get_opt_bool(yang.gdata.Id(NS_ietf_interfaces, 'enabled')), link_up_down_trap_enable=n.get_opt_str(yang.gdata.Id(NS_ietf_interfaces, 'link-up-down-trap-enable')), ipv4=ietf_interfaces__interfaces__interface__ipv4.from_gdata(n.get_opt_cnt(yang.gdata.Id(NS_ietf_ip, 'ipv4'))), ipv6=ietf_interfaces__interfaces__interface__ipv6.from_gdata(n.get_opt_cnt(yang.gdata.Id(NS_ietf_ip, 'ipv6'))))
 
-    def copy(self):
+    def copy(self) -> ietf_interfaces__interfaces__interface_entry:
         """Create a deep copy of this adata object"""
         return ietf_interfaces__interfaces__interface_entry.from_gdata(self.to_gdata())
 
 _breaker42 = None
 class ietf_interfaces__interfaces__interface(yang.adata.MNode):
     elements: list[ietf_interfaces__interfaces__interface_entry]
-    mut def __init__(self, elements=[]):
+    mut def __init__(self, elements: list[ietf_interfaces__interfaces__interface_entry]=[]) -> None:
         self._ns = 'urn:ietf:params:xml:ns:yang:ietf-interfaces'
         self._name = 'interface'
         self.elements = elements
 
-    mut def create(self, name, description=None, type=None, enabled=None, link_up_down_trap_enable=None):
+    mut def create(self, name: str, description: ?str=None, type: ?Identityref=None, enabled: ?bool=None, link_up_down_trap_enable: ?str=None) -> ietf_interfaces__interfaces__interface_entry:
         for e in self:
             match = True
             if e.name != name:
@@ -10187,7 +10187,7 @@ class ietf_interfaces__interfaces__interface(yang.adata.MNode):
             return [ietf_interfaces__interfaces__interface_entry.from_gdata(e) for e in n.elements]
         return []
 
-    def copy(self):
+    def copy(self) -> ietf_interfaces__interfaces__interface:
         """Create a deep copy of this list object"""
         # Copy each element in the list
         copied_elements = []
@@ -10205,7 +10205,7 @@ _breaker43 = None
 class ietf_interfaces__interfaces(yang.adata.MNode):
     interface: ietf_interfaces__interfaces__interface
 
-    mut def __init__(self, interface: list[ietf_interfaces__interfaces__interface_entry]=[]):
+    mut def __init__(self, interface: list[ietf_interfaces__interfaces__interface_entry]=[]) -> None:
         self._ns = 'urn:ietf:params:xml:ns:yang:ietf-interfaces'
         self.interface = ietf_interfaces__interfaces__interface(elements=interface)
 
@@ -10222,7 +10222,7 @@ class ietf_interfaces__interfaces(yang.adata.MNode):
             return ietf_interfaces__interfaces(interface=ietf_interfaces__interfaces__interface.from_gdata(n.get_opt_list(yang.gdata.Id(NS_ietf_interfaces, 'interface'))))
         return ietf_interfaces__interfaces()
 
-    def copy(self):
+    def copy(self) -> ietf_interfaces__interfaces:
         """Create a deep copy of this adata object"""
         return ietf_interfaces__interfaces.from_gdata(self.to_gdata())
 
@@ -10233,7 +10233,7 @@ class root(yang.adata.MNode):
     system: ietf_system__system
     interfaces: ietf_interfaces__interfaces
 
-    mut def __init__(self, nacm: ?ietf_netconf_acm__nacm=None, system: ?ietf_system__system=None, interfaces: ?ietf_interfaces__interfaces=None):
+    mut def __init__(self, nacm: ?ietf_netconf_acm__nacm=None, system: ?ietf_system__system=None, interfaces: ?ietf_interfaces__interfaces=None) -> None:
         self._ns = ''
         self.nacm = nacm if nacm is not None else ietf_netconf_acm__nacm()
         self.system = system if system is not None else ietf_system__system()
@@ -10256,7 +10256,7 @@ class root(yang.adata.MNode):
             return root(nacm=ietf_netconf_acm__nacm.from_gdata(n.get_opt_cnt(yang.gdata.Id(NS_ietf_netconf_acm, 'nacm'))), system=ietf_system__system.from_gdata(n.get_opt_cnt(yang.gdata.Id(NS_ietf_system, 'system'))), interfaces=ietf_interfaces__interfaces.from_gdata(n.get_opt_cnt(yang.gdata.Id(NS_ietf_interfaces, 'interfaces'))))
         return root()
 
-    def copy(self):
+    def copy(self) -> root:
         """Create a deep copy of this adata object"""
         return root.from_gdata(self.to_gdata())
 
@@ -10265,7 +10265,7 @@ _breaker45 = None
 class ietf_system__set_current_datetime__input(yang.adata.MNode):
     current_datetime: ?str
 
-    mut def __init__(self, current_datetime: ?str):
+    mut def __init__(self, current_datetime: ?str) -> None:
         self._ns = 'urn:ietf:params:xml:ns:yang:ietf-system'
         self.current_datetime = current_datetime
 
@@ -10282,7 +10282,7 @@ class ietf_system__set_current_datetime__input(yang.adata.MNode):
             return ietf_system__set_current_datetime__input(current_datetime=n.get_opt_str(yang.gdata.Id(NS_ietf_system, 'current-datetime')))
         return ietf_system__set_current_datetime__input()
 
-    def copy(self):
+    def copy(self) -> ietf_system__set_current_datetime__input:
         """Create a deep copy of this adata object"""
         return ietf_system__set_current_datetime__input.from_gdata(self.to_gdata())
 

--- a/minisys/src/mini/devices/ietf_oper.act
+++ b/minisys/src/mini/devices/ietf_oper.act
@@ -8726,7 +8726,7 @@ class ietf_netconf_acm__nacm__groups__group_entry(yang.adata.MNode):
     name: str
     user_name: list[str]
 
-    mut def __init__(self, name: str, user_name: ?list[str]=None):
+    mut def __init__(self, name: str, user_name: ?list[str]=None) -> None:
         self._ns = 'urn:ietf:params:xml:ns:yang:ietf-netconf-acm'
         self.name = name
         self.user_name = user_name if user_name is not None else []
@@ -8744,19 +8744,19 @@ class ietf_netconf_acm__nacm__groups__group_entry(yang.adata.MNode):
     mut def from_gdata(n: yang.gdata.Node) -> ietf_netconf_acm__nacm__groups__group_entry:
         return ietf_netconf_acm__nacm__groups__group_entry(name=n.get_str(yang.gdata.Id(NS_ietf_netconf_acm, 'name')), user_name=n.get_opt_strs(yang.gdata.Id(NS_ietf_netconf_acm, 'user-name')))
 
-    def copy(self):
+    def copy(self) -> ietf_netconf_acm__nacm__groups__group_entry:
         """Create a deep copy of this adata object"""
         return ietf_netconf_acm__nacm__groups__group_entry.from_gdata(self.to_gdata())
 
 _breaker2 = None
 class ietf_netconf_acm__nacm__groups__group(yang.adata.MNode):
     elements: list[ietf_netconf_acm__nacm__groups__group_entry]
-    mut def __init__(self, elements=[]):
+    mut def __init__(self, elements: list[ietf_netconf_acm__nacm__groups__group_entry]=[]) -> None:
         self._ns = 'urn:ietf:params:xml:ns:yang:ietf-netconf-acm'
         self._name = 'group'
         self.elements = elements
 
-    mut def create(self, name):
+    mut def create(self, name: str) -> ietf_netconf_acm__nacm__groups__group_entry:
         for e in self:
             match = True
             if e.name != name:
@@ -8775,7 +8775,7 @@ class ietf_netconf_acm__nacm__groups__group(yang.adata.MNode):
             return [ietf_netconf_acm__nacm__groups__group_entry.from_gdata(e) for e in n.elements]
         return []
 
-    def copy(self):
+    def copy(self) -> ietf_netconf_acm__nacm__groups__group:
         """Create a deep copy of this list object"""
         # Copy each element in the list
         copied_elements = []
@@ -8793,7 +8793,7 @@ _breaker3 = None
 class ietf_netconf_acm__nacm__groups(yang.adata.MNode):
     group: ietf_netconf_acm__nacm__groups__group
 
-    mut def __init__(self, group: list[ietf_netconf_acm__nacm__groups__group_entry]=[]):
+    mut def __init__(self, group: list[ietf_netconf_acm__nacm__groups__group_entry]=[]) -> None:
         self._ns = 'urn:ietf:params:xml:ns:yang:ietf-netconf-acm'
         self.group = ietf_netconf_acm__nacm__groups__group(elements=group)
 
@@ -8810,7 +8810,7 @@ class ietf_netconf_acm__nacm__groups(yang.adata.MNode):
             return ietf_netconf_acm__nacm__groups(group=ietf_netconf_acm__nacm__groups__group.from_gdata(n.get_opt_list(yang.gdata.Id(NS_ietf_netconf_acm, 'group'))))
         return ietf_netconf_acm__nacm__groups()
 
-    def copy(self):
+    def copy(self) -> ietf_netconf_acm__nacm__groups:
         """Create a deep copy of this adata object"""
         return ietf_netconf_acm__nacm__groups.from_gdata(self.to_gdata())
 
@@ -8826,7 +8826,7 @@ class ietf_netconf_acm__nacm__rule_list__rule_entry(yang.adata.MNode):
     action_: ?str
     comment: ?str
 
-    mut def __init__(self, name: str, module_name: ?str, rpc_name: ?str, notification_name: ?str, path: ?str, access_operations: ?value, action_: ?str, comment: ?str):
+    mut def __init__(self, name: str, module_name: ?str, rpc_name: ?str, notification_name: ?str, path: ?str, access_operations: ?value, action_: ?str, comment: ?str) -> None:
         self._ns = 'urn:ietf:params:xml:ns:yang:ietf-netconf-acm'
         self.name = name
         self.module_name = module_name
@@ -8862,19 +8862,19 @@ class ietf_netconf_acm__nacm__rule_list__rule_entry(yang.adata.MNode):
     mut def from_gdata(n: yang.gdata.Node) -> ietf_netconf_acm__nacm__rule_list__rule_entry:
         return ietf_netconf_acm__nacm__rule_list__rule_entry(name=n.get_str(yang.gdata.Id(NS_ietf_netconf_acm, 'name')), module_name=n.get_opt_str(yang.gdata.Id(NS_ietf_netconf_acm, 'module-name')), rpc_name=n.get_opt_str(yang.gdata.Id(NS_ietf_netconf_acm, 'rpc-name')), notification_name=n.get_opt_str(yang.gdata.Id(NS_ietf_netconf_acm, 'notification-name')), path=n.get_opt_str(yang.gdata.Id(NS_ietf_netconf_acm, 'path')), access_operations=n.get_opt_value(yang.gdata.Id(NS_ietf_netconf_acm, 'access-operations')), action_=n.get_opt_str(yang.gdata.Id(NS_ietf_netconf_acm, 'action')), comment=n.get_opt_str(yang.gdata.Id(NS_ietf_netconf_acm, 'comment')))
 
-    def copy(self):
+    def copy(self) -> ietf_netconf_acm__nacm__rule_list__rule_entry:
         """Create a deep copy of this adata object"""
         return ietf_netconf_acm__nacm__rule_list__rule_entry.from_gdata(self.to_gdata())
 
 _breaker5 = None
 class ietf_netconf_acm__nacm__rule_list__rule(yang.adata.MNode):
     elements: list[ietf_netconf_acm__nacm__rule_list__rule_entry]
-    mut def __init__(self, elements=[]):
+    mut def __init__(self, elements: list[ietf_netconf_acm__nacm__rule_list__rule_entry]=[]) -> None:
         self._ns = 'urn:ietf:params:xml:ns:yang:ietf-netconf-acm'
         self._name = 'rule'
         self.elements = elements
 
-    mut def create(self, name, module_name=None, rpc_name=None, notification_name=None, path=None, access_operations=None, action_=None, comment=None):
+    mut def create(self, name: str, module_name: ?str=None, rpc_name: ?str=None, notification_name: ?str=None, path: ?str=None, access_operations: ?value=None, action_: ?str=None, comment: ?str=None) -> ietf_netconf_acm__nacm__rule_list__rule_entry:
         for e in self:
             match = True
             if e.name != name:
@@ -8907,7 +8907,7 @@ class ietf_netconf_acm__nacm__rule_list__rule(yang.adata.MNode):
             return [ietf_netconf_acm__nacm__rule_list__rule_entry.from_gdata(e) for e in n.elements]
         return []
 
-    def copy(self):
+    def copy(self) -> ietf_netconf_acm__nacm__rule_list__rule:
         """Create a deep copy of this list object"""
         # Copy each element in the list
         copied_elements = []
@@ -8927,7 +8927,7 @@ class ietf_netconf_acm__nacm__rule_list_entry(yang.adata.MNode):
     group: list[str]
     rule: ietf_netconf_acm__nacm__rule_list__rule
 
-    mut def __init__(self, name: str, group: ?list[str]=None, rule: list[ietf_netconf_acm__nacm__rule_list__rule_entry]=[]):
+    mut def __init__(self, name: str, group: ?list[str]=None, rule: list[ietf_netconf_acm__nacm__rule_list__rule_entry]=[]) -> None:
         self._ns = 'urn:ietf:params:xml:ns:yang:ietf-netconf-acm'
         self.name = name
         self.group = group if group is not None else []
@@ -8948,19 +8948,19 @@ class ietf_netconf_acm__nacm__rule_list_entry(yang.adata.MNode):
     mut def from_gdata(n: yang.gdata.Node) -> ietf_netconf_acm__nacm__rule_list_entry:
         return ietf_netconf_acm__nacm__rule_list_entry(name=n.get_str(yang.gdata.Id(NS_ietf_netconf_acm, 'name')), group=n.get_opt_strs(yang.gdata.Id(NS_ietf_netconf_acm, 'group')), rule=ietf_netconf_acm__nacm__rule_list__rule.from_gdata(n.get_opt_list(yang.gdata.Id(NS_ietf_netconf_acm, 'rule'))))
 
-    def copy(self):
+    def copy(self) -> ietf_netconf_acm__nacm__rule_list_entry:
         """Create a deep copy of this adata object"""
         return ietf_netconf_acm__nacm__rule_list_entry.from_gdata(self.to_gdata())
 
 _breaker7 = None
 class ietf_netconf_acm__nacm__rule_list(yang.adata.MNode):
     elements: list[ietf_netconf_acm__nacm__rule_list_entry]
-    mut def __init__(self, elements=[]):
+    mut def __init__(self, elements: list[ietf_netconf_acm__nacm__rule_list_entry]=[]) -> None:
         self._ns = 'urn:ietf:params:xml:ns:yang:ietf-netconf-acm'
         self._name = 'rule-list'
         self.elements = elements
 
-    mut def create(self, name):
+    mut def create(self, name: str) -> ietf_netconf_acm__nacm__rule_list_entry:
         for e in self:
             match = True
             if e.name != name:
@@ -8979,7 +8979,7 @@ class ietf_netconf_acm__nacm__rule_list(yang.adata.MNode):
             return [ietf_netconf_acm__nacm__rule_list_entry.from_gdata(e) for e in n.elements]
         return []
 
-    def copy(self):
+    def copy(self) -> ietf_netconf_acm__nacm__rule_list:
         """Create a deep copy of this list object"""
         # Copy each element in the list
         copied_elements = []
@@ -9006,7 +9006,7 @@ class ietf_netconf_acm__nacm(yang.adata.MNode):
     groups: ietf_netconf_acm__nacm__groups
     rule_list: ietf_netconf_acm__nacm__rule_list
 
-    mut def __init__(self, enable_nacm: ?bool, read_default: ?str, write_default: ?str, exec_default: ?str, enable_external_groups: ?bool, denied_operations: ?u64, denied_data_writes: ?u64, denied_notifications: ?u64, groups: ?ietf_netconf_acm__nacm__groups=None, rule_list: list[ietf_netconf_acm__nacm__rule_list_entry]=[]):
+    mut def __init__(self, enable_nacm: ?bool, read_default: ?str, write_default: ?str, exec_default: ?str, enable_external_groups: ?bool, denied_operations: ?u64, denied_data_writes: ?u64, denied_notifications: ?u64, groups: ?ietf_netconf_acm__nacm__groups=None, rule_list: list[ietf_netconf_acm__nacm__rule_list_entry]=[]) -> None:
         self._ns = 'urn:ietf:params:xml:ns:yang:ietf-netconf-acm'
         self.enable_nacm = enable_nacm
         self.read_default = read_default
@@ -9050,7 +9050,7 @@ class ietf_netconf_acm__nacm(yang.adata.MNode):
             return ietf_netconf_acm__nacm(enable_nacm=n.get_opt_bool(yang.gdata.Id(NS_ietf_netconf_acm, 'enable-nacm')), read_default=n.get_opt_str(yang.gdata.Id(NS_ietf_netconf_acm, 'read-default')), write_default=n.get_opt_str(yang.gdata.Id(NS_ietf_netconf_acm, 'write-default')), exec_default=n.get_opt_str(yang.gdata.Id(NS_ietf_netconf_acm, 'exec-default')), enable_external_groups=n.get_opt_bool(yang.gdata.Id(NS_ietf_netconf_acm, 'enable-external-groups')), denied_operations=n.get_opt_u64(yang.gdata.Id(NS_ietf_netconf_acm, 'denied-operations')), denied_data_writes=n.get_opt_u64(yang.gdata.Id(NS_ietf_netconf_acm, 'denied-data-writes')), denied_notifications=n.get_opt_u64(yang.gdata.Id(NS_ietf_netconf_acm, 'denied-notifications')), groups=ietf_netconf_acm__nacm__groups.from_gdata(n.get_opt_cnt(yang.gdata.Id(NS_ietf_netconf_acm, 'groups'))), rule_list=ietf_netconf_acm__nacm__rule_list.from_gdata(n.get_opt_list(yang.gdata.Id(NS_ietf_netconf_acm, 'rule-list'))))
         return ietf_netconf_acm__nacm()
 
-    def copy(self):
+    def copy(self) -> ietf_netconf_acm__nacm:
         """Create a deep copy of this adata object"""
         return ietf_netconf_acm__nacm.from_gdata(self.to_gdata())
 
@@ -9060,7 +9060,7 @@ class ietf_system__system__clock(yang.adata.MNode):
     timezone_name: ?str
     timezone_utc_offset: ?int
 
-    mut def __init__(self, timezone_name: ?str, timezone_utc_offset: ?int):
+    mut def __init__(self, timezone_name: ?str, timezone_utc_offset: ?int) -> None:
         self._ns = 'urn:ietf:params:xml:ns:yang:ietf-system'
         self.timezone_name = timezone_name
         self.timezone_utc_offset = timezone_utc_offset
@@ -9080,7 +9080,7 @@ class ietf_system__system__clock(yang.adata.MNode):
             return ietf_system__system__clock(timezone_name=n.get_opt_str(yang.gdata.Id(NS_ietf_system, 'timezone-name')), timezone_utc_offset=n.get_opt_int(yang.gdata.Id(NS_ietf_system, 'timezone-utc-offset')))
         return ietf_system__system__clock()
 
-    def copy(self):
+    def copy(self) -> ietf_system__system__clock:
         """Create a deep copy of this adata object"""
         return ietf_system__system__clock.from_gdata(self.to_gdata())
 
@@ -9090,7 +9090,7 @@ class ietf_system__system__ntp__server__udp(yang.adata.MNode):
     address: ?str
     port: ?u64
 
-    mut def __init__(self, address: ?str, port: ?u64):
+    mut def __init__(self, address: ?str, port: ?u64) -> None:
         self._ns = 'urn:ietf:params:xml:ns:yang:ietf-system'
         self.address = address
         self.port = port
@@ -9110,7 +9110,7 @@ class ietf_system__system__ntp__server__udp(yang.adata.MNode):
             return ietf_system__system__ntp__server__udp(address=n.get_opt_str(yang.gdata.Id(NS_ietf_system, 'address')), port=n.get_opt_u64(yang.gdata.Id(NS_ietf_system, 'port')))
         return ietf_system__system__ntp__server__udp()
 
-    def copy(self):
+    def copy(self) -> ietf_system__system__ntp__server__udp:
         """Create a deep copy of this adata object"""
         return ietf_system__system__ntp__server__udp.from_gdata(self.to_gdata())
 
@@ -9123,7 +9123,7 @@ class ietf_system__system__ntp__server_entry(yang.adata.MNode):
     iburst: ?bool
     prefer: ?bool
 
-    mut def __init__(self, name: str, udp: ?ietf_system__system__ntp__server__udp=None, association_type: ?str, iburst: ?bool, prefer: ?bool):
+    mut def __init__(self, name: str, udp: ?ietf_system__system__ntp__server__udp=None, association_type: ?str, iburst: ?bool, prefer: ?bool) -> None:
         self._ns = 'urn:ietf:params:xml:ns:yang:ietf-system'
         self.name = name
         self.udp = udp if udp is not None else ietf_system__system__ntp__server__udp()
@@ -9150,19 +9150,19 @@ class ietf_system__system__ntp__server_entry(yang.adata.MNode):
     mut def from_gdata(n: yang.gdata.Node) -> ietf_system__system__ntp__server_entry:
         return ietf_system__system__ntp__server_entry(name=n.get_str(yang.gdata.Id(NS_ietf_system, 'name')), udp=ietf_system__system__ntp__server__udp.from_gdata(n.get_opt_cnt(yang.gdata.Id(NS_ietf_system, 'udp'))), association_type=n.get_opt_str(yang.gdata.Id(NS_ietf_system, 'association-type')), iburst=n.get_opt_bool(yang.gdata.Id(NS_ietf_system, 'iburst')), prefer=n.get_opt_bool(yang.gdata.Id(NS_ietf_system, 'prefer')))
 
-    def copy(self):
+    def copy(self) -> ietf_system__system__ntp__server_entry:
         """Create a deep copy of this adata object"""
         return ietf_system__system__ntp__server_entry.from_gdata(self.to_gdata())
 
 _breaker12 = None
 class ietf_system__system__ntp__server(yang.adata.MNode):
     elements: list[ietf_system__system__ntp__server_entry]
-    mut def __init__(self, elements=[]):
+    mut def __init__(self, elements: list[ietf_system__system__ntp__server_entry]=[]) -> None:
         self._ns = 'urn:ietf:params:xml:ns:yang:ietf-system'
         self._name = 'server'
         self.elements = elements
 
-    mut def create(self, name, association_type=None, iburst=None, prefer=None):
+    mut def create(self, name: str, association_type: ?str=None, iburst: ?bool=None, prefer: ?bool=None) -> ietf_system__system__ntp__server_entry:
         for e in self:
             match = True
             if e.name != name:
@@ -9187,7 +9187,7 @@ class ietf_system__system__ntp__server(yang.adata.MNode):
             return [ietf_system__system__ntp__server_entry.from_gdata(e) for e in n.elements]
         return []
 
-    def copy(self):
+    def copy(self) -> ietf_system__system__ntp__server:
         """Create a deep copy of this list object"""
         # Copy each element in the list
         copied_elements = []
@@ -9206,7 +9206,7 @@ class ietf_system__system__ntp(yang.adata.MNode):
     enabled: ?bool
     server: ietf_system__system__ntp__server
 
-    mut def __init__(self, enabled: ?bool, server: list[ietf_system__system__ntp__server_entry]=[]):
+    mut def __init__(self, enabled: ?bool, server: list[ietf_system__system__ntp__server_entry]=[]) -> None:
         self._ns = 'urn:ietf:params:xml:ns:yang:ietf-system'
         self.enabled = enabled
         self.server = ietf_system__system__ntp__server(elements=server)
@@ -9226,7 +9226,7 @@ class ietf_system__system__ntp(yang.adata.MNode):
             return ietf_system__system__ntp(enabled=n.get_opt_bool(yang.gdata.Id(NS_ietf_system, 'enabled')), server=ietf_system__system__ntp__server.from_gdata(n.get_opt_list(yang.gdata.Id(NS_ietf_system, 'server'))))
         return None
 
-    def copy(self):
+    def copy(self) -> ietf_system__system__ntp:
         """Create a deep copy of this adata object"""
         ad = ietf_system__system__ntp.from_gdata(self.to_gdata())
         if ad is not None:
@@ -9239,7 +9239,7 @@ class ietf_system__system__dns_resolver__server__udp_and_tcp(yang.adata.MNode):
     address: ?str
     port: ?u64
 
-    mut def __init__(self, address: ?str, port: ?u64):
+    mut def __init__(self, address: ?str, port: ?u64) -> None:
         self._ns = 'urn:ietf:params:xml:ns:yang:ietf-system'
         self.address = address
         self.port = port
@@ -9259,7 +9259,7 @@ class ietf_system__system__dns_resolver__server__udp_and_tcp(yang.adata.MNode):
             return ietf_system__system__dns_resolver__server__udp_and_tcp(address=n.get_opt_str(yang.gdata.Id(NS_ietf_system, 'address')), port=n.get_opt_u64(yang.gdata.Id(NS_ietf_system, 'port')))
         return ietf_system__system__dns_resolver__server__udp_and_tcp()
 
-    def copy(self):
+    def copy(self) -> ietf_system__system__dns_resolver__server__udp_and_tcp:
         """Create a deep copy of this adata object"""
         return ietf_system__system__dns_resolver__server__udp_and_tcp.from_gdata(self.to_gdata())
 
@@ -9269,7 +9269,7 @@ class ietf_system__system__dns_resolver__server_entry(yang.adata.MNode):
     name: str
     udp_and_tcp: ietf_system__system__dns_resolver__server__udp_and_tcp
 
-    mut def __init__(self, name: str, udp_and_tcp: ?ietf_system__system__dns_resolver__server__udp_and_tcp=None):
+    mut def __init__(self, name: str, udp_and_tcp: ?ietf_system__system__dns_resolver__server__udp_and_tcp=None) -> None:
         self._ns = 'urn:ietf:params:xml:ns:yang:ietf-system'
         self.name = name
         self.udp_and_tcp = udp_and_tcp if udp_and_tcp is not None else ietf_system__system__dns_resolver__server__udp_and_tcp()
@@ -9287,19 +9287,19 @@ class ietf_system__system__dns_resolver__server_entry(yang.adata.MNode):
     mut def from_gdata(n: yang.gdata.Node) -> ietf_system__system__dns_resolver__server_entry:
         return ietf_system__system__dns_resolver__server_entry(name=n.get_str(yang.gdata.Id(NS_ietf_system, 'name')), udp_and_tcp=ietf_system__system__dns_resolver__server__udp_and_tcp.from_gdata(n.get_opt_cnt(yang.gdata.Id(NS_ietf_system, 'udp-and-tcp'))))
 
-    def copy(self):
+    def copy(self) -> ietf_system__system__dns_resolver__server_entry:
         """Create a deep copy of this adata object"""
         return ietf_system__system__dns_resolver__server_entry.from_gdata(self.to_gdata())
 
 _breaker16 = None
 class ietf_system__system__dns_resolver__server(yang.adata.MNode):
     elements: list[ietf_system__system__dns_resolver__server_entry]
-    mut def __init__(self, elements=[]):
+    mut def __init__(self, elements: list[ietf_system__system__dns_resolver__server_entry]=[]) -> None:
         self._ns = 'urn:ietf:params:xml:ns:yang:ietf-system'
         self._name = 'server'
         self.elements = elements
 
-    mut def create(self, name):
+    mut def create(self, name: str) -> ietf_system__system__dns_resolver__server_entry:
         for e in self:
             match = True
             if e.name != name:
@@ -9318,7 +9318,7 @@ class ietf_system__system__dns_resolver__server(yang.adata.MNode):
             return [ietf_system__system__dns_resolver__server_entry.from_gdata(e) for e in n.elements]
         return []
 
-    def copy(self):
+    def copy(self) -> ietf_system__system__dns_resolver__server:
         """Create a deep copy of this list object"""
         # Copy each element in the list
         copied_elements = []
@@ -9337,7 +9337,7 @@ class ietf_system__system__dns_resolver__options(yang.adata.MNode):
     timeout: ?u64
     attempts: ?u64
 
-    mut def __init__(self, timeout: ?u64, attempts: ?u64):
+    mut def __init__(self, timeout: ?u64, attempts: ?u64) -> None:
         self._ns = 'urn:ietf:params:xml:ns:yang:ietf-system'
         self.timeout = timeout
         self.attempts = attempts
@@ -9357,7 +9357,7 @@ class ietf_system__system__dns_resolver__options(yang.adata.MNode):
             return ietf_system__system__dns_resolver__options(timeout=n.get_opt_u64(yang.gdata.Id(NS_ietf_system, 'timeout')), attempts=n.get_opt_u64(yang.gdata.Id(NS_ietf_system, 'attempts')))
         return ietf_system__system__dns_resolver__options()
 
-    def copy(self):
+    def copy(self) -> ietf_system__system__dns_resolver__options:
         """Create a deep copy of this adata object"""
         return ietf_system__system__dns_resolver__options.from_gdata(self.to_gdata())
 
@@ -9368,7 +9368,7 @@ class ietf_system__system__dns_resolver(yang.adata.MNode):
     server: ietf_system__system__dns_resolver__server
     options: ietf_system__system__dns_resolver__options
 
-    mut def __init__(self, search: ?list[str]=None, server: list[ietf_system__system__dns_resolver__server_entry]=[], options: ?ietf_system__system__dns_resolver__options=None):
+    mut def __init__(self, search: ?list[str]=None, server: list[ietf_system__system__dns_resolver__server_entry]=[], options: ?ietf_system__system__dns_resolver__options=None) -> None:
         self._ns = 'urn:ietf:params:xml:ns:yang:ietf-system'
         self.search = search if search is not None else []
         self.server = ietf_system__system__dns_resolver__server(elements=server)
@@ -9391,7 +9391,7 @@ class ietf_system__system__dns_resolver(yang.adata.MNode):
             return ietf_system__system__dns_resolver(search=n.get_opt_strs(yang.gdata.Id(NS_ietf_system, 'search')), server=ietf_system__system__dns_resolver__server.from_gdata(n.get_opt_list(yang.gdata.Id(NS_ietf_system, 'server'))), options=ietf_system__system__dns_resolver__options.from_gdata(n.get_opt_cnt(yang.gdata.Id(NS_ietf_system, 'options'))))
         return ietf_system__system__dns_resolver()
 
-    def copy(self):
+    def copy(self) -> ietf_system__system__dns_resolver:
         """Create a deep copy of this adata object"""
         return ietf_system__system__dns_resolver.from_gdata(self.to_gdata())
 
@@ -9402,7 +9402,7 @@ class ietf_system__system__radius__server__udp(yang.adata.MNode):
     authentication_port: ?u64
     shared_secret: ?str
 
-    mut def __init__(self, address: ?str, authentication_port: ?u64, shared_secret: ?str):
+    mut def __init__(self, address: ?str, authentication_port: ?u64, shared_secret: ?str) -> None:
         self._ns = 'urn:ietf:params:xml:ns:yang:ietf-system'
         self.address = address
         self.authentication_port = authentication_port
@@ -9425,7 +9425,7 @@ class ietf_system__system__radius__server__udp(yang.adata.MNode):
             return ietf_system__system__radius__server__udp(address=n.get_opt_str(yang.gdata.Id(NS_ietf_system, 'address')), authentication_port=n.get_opt_u64(yang.gdata.Id(NS_ietf_system, 'authentication-port')), shared_secret=n.get_opt_str(yang.gdata.Id(NS_ietf_system, 'shared-secret')))
         return ietf_system__system__radius__server__udp()
 
-    def copy(self):
+    def copy(self) -> ietf_system__system__radius__server__udp:
         """Create a deep copy of this adata object"""
         return ietf_system__system__radius__server__udp.from_gdata(self.to_gdata())
 
@@ -9436,7 +9436,7 @@ class ietf_system__system__radius__server_entry(yang.adata.MNode):
     udp: ietf_system__system__radius__server__udp
     authentication_type: ?Identityref
 
-    mut def __init__(self, name: str, udp: ?ietf_system__system__radius__server__udp=None, authentication_type: ?Identityref):
+    mut def __init__(self, name: str, udp: ?ietf_system__system__radius__server__udp=None, authentication_type: ?Identityref) -> None:
         self._ns = 'urn:ietf:params:xml:ns:yang:ietf-system'
         self.name = name
         self.udp = udp if udp is not None else ietf_system__system__radius__server__udp()
@@ -9457,19 +9457,19 @@ class ietf_system__system__radius__server_entry(yang.adata.MNode):
     mut def from_gdata(n: yang.gdata.Node) -> ietf_system__system__radius__server_entry:
         return ietf_system__system__radius__server_entry(name=n.get_str(yang.gdata.Id(NS_ietf_system, 'name')), udp=ietf_system__system__radius__server__udp.from_gdata(n.get_opt_cnt(yang.gdata.Id(NS_ietf_system, 'udp'))), authentication_type=n.get_opt_Identityref(yang.gdata.Id(NS_ietf_system, 'authentication-type')))
 
-    def copy(self):
+    def copy(self) -> ietf_system__system__radius__server_entry:
         """Create a deep copy of this adata object"""
         return ietf_system__system__radius__server_entry.from_gdata(self.to_gdata())
 
 _breaker21 = None
 class ietf_system__system__radius__server(yang.adata.MNode):
     elements: list[ietf_system__system__radius__server_entry]
-    mut def __init__(self, elements=[]):
+    mut def __init__(self, elements: list[ietf_system__system__radius__server_entry]=[]) -> None:
         self._ns = 'urn:ietf:params:xml:ns:yang:ietf-system'
         self._name = 'server'
         self.elements = elements
 
-    mut def create(self, name, authentication_type=None):
+    mut def create(self, name: str, authentication_type: ?Identityref=None) -> ietf_system__system__radius__server_entry:
         for e in self:
             match = True
             if e.name != name:
@@ -9490,7 +9490,7 @@ class ietf_system__system__radius__server(yang.adata.MNode):
             return [ietf_system__system__radius__server_entry.from_gdata(e) for e in n.elements]
         return []
 
-    def copy(self):
+    def copy(self) -> ietf_system__system__radius__server:
         """Create a deep copy of this list object"""
         # Copy each element in the list
         copied_elements = []
@@ -9509,7 +9509,7 @@ class ietf_system__system__radius__options(yang.adata.MNode):
     timeout: ?u64
     attempts: ?u64
 
-    mut def __init__(self, timeout: ?u64, attempts: ?u64):
+    mut def __init__(self, timeout: ?u64, attempts: ?u64) -> None:
         self._ns = 'urn:ietf:params:xml:ns:yang:ietf-system'
         self.timeout = timeout
         self.attempts = attempts
@@ -9529,7 +9529,7 @@ class ietf_system__system__radius__options(yang.adata.MNode):
             return ietf_system__system__radius__options(timeout=n.get_opt_u64(yang.gdata.Id(NS_ietf_system, 'timeout')), attempts=n.get_opt_u64(yang.gdata.Id(NS_ietf_system, 'attempts')))
         return ietf_system__system__radius__options()
 
-    def copy(self):
+    def copy(self) -> ietf_system__system__radius__options:
         """Create a deep copy of this adata object"""
         return ietf_system__system__radius__options.from_gdata(self.to_gdata())
 
@@ -9539,7 +9539,7 @@ class ietf_system__system__radius(yang.adata.MNode):
     server: ietf_system__system__radius__server
     options: ietf_system__system__radius__options
 
-    mut def __init__(self, server: list[ietf_system__system__radius__server_entry]=[], options: ?ietf_system__system__radius__options=None):
+    mut def __init__(self, server: list[ietf_system__system__radius__server_entry]=[], options: ?ietf_system__system__radius__options=None) -> None:
         self._ns = 'urn:ietf:params:xml:ns:yang:ietf-system'
         self.server = ietf_system__system__radius__server(elements=server)
         self.options = options if options is not None else ietf_system__system__radius__options()
@@ -9559,7 +9559,7 @@ class ietf_system__system__radius(yang.adata.MNode):
             return ietf_system__system__radius(server=ietf_system__system__radius__server.from_gdata(n.get_opt_list(yang.gdata.Id(NS_ietf_system, 'server'))), options=ietf_system__system__radius__options.from_gdata(n.get_opt_cnt(yang.gdata.Id(NS_ietf_system, 'options'))))
         return ietf_system__system__radius()
 
-    def copy(self):
+    def copy(self) -> ietf_system__system__radius:
         """Create a deep copy of this adata object"""
         return ietf_system__system__radius.from_gdata(self.to_gdata())
 
@@ -9570,7 +9570,7 @@ class ietf_system__system__authentication__user__authorized_key_entry(yang.adata
     algorithm: ?str
     key_data: ?bytes
 
-    mut def __init__(self, name: str, algorithm: ?str, key_data: ?bytes):
+    mut def __init__(self, name: str, algorithm: ?str, key_data: ?bytes) -> None:
         self._ns = 'urn:ietf:params:xml:ns:yang:ietf-system'
         self.name = name
         self.algorithm = algorithm
@@ -9591,19 +9591,19 @@ class ietf_system__system__authentication__user__authorized_key_entry(yang.adata
     mut def from_gdata(n: yang.gdata.Node) -> ietf_system__system__authentication__user__authorized_key_entry:
         return ietf_system__system__authentication__user__authorized_key_entry(name=n.get_str(yang.gdata.Id(NS_ietf_system, 'name')), algorithm=n.get_opt_str(yang.gdata.Id(NS_ietf_system, 'algorithm')), key_data=n.get_opt_bytes(yang.gdata.Id(NS_ietf_system, 'key-data')))
 
-    def copy(self):
+    def copy(self) -> ietf_system__system__authentication__user__authorized_key_entry:
         """Create a deep copy of this adata object"""
         return ietf_system__system__authentication__user__authorized_key_entry.from_gdata(self.to_gdata())
 
 _breaker25 = None
 class ietf_system__system__authentication__user__authorized_key(yang.adata.MNode):
     elements: list[ietf_system__system__authentication__user__authorized_key_entry]
-    mut def __init__(self, elements=[]):
+    mut def __init__(self, elements: list[ietf_system__system__authentication__user__authorized_key_entry]=[]) -> None:
         self._ns = 'urn:ietf:params:xml:ns:yang:ietf-system'
         self._name = 'authorized-key'
         self.elements = elements
 
-    mut def create(self, name, algorithm=None, key_data=None):
+    mut def create(self, name: str, algorithm: ?str=None, key_data: ?bytes=None) -> ietf_system__system__authentication__user__authorized_key_entry:
         for e in self:
             match = True
             if e.name != name:
@@ -9626,7 +9626,7 @@ class ietf_system__system__authentication__user__authorized_key(yang.adata.MNode
             return [ietf_system__system__authentication__user__authorized_key_entry.from_gdata(e) for e in n.elements]
         return []
 
-    def copy(self):
+    def copy(self) -> ietf_system__system__authentication__user__authorized_key:
         """Create a deep copy of this list object"""
         # Copy each element in the list
         copied_elements = []
@@ -9646,7 +9646,7 @@ class ietf_system__system__authentication__user_entry(yang.adata.MNode):
     password: ?str
     authorized_key: ietf_system__system__authentication__user__authorized_key
 
-    mut def __init__(self, name: str, password: ?str, authorized_key: list[ietf_system__system__authentication__user__authorized_key_entry]=[]):
+    mut def __init__(self, name: str, password: ?str, authorized_key: list[ietf_system__system__authentication__user__authorized_key_entry]=[]) -> None:
         self._ns = 'urn:ietf:params:xml:ns:yang:ietf-system'
         self.name = name
         self.password = password
@@ -9667,19 +9667,19 @@ class ietf_system__system__authentication__user_entry(yang.adata.MNode):
     mut def from_gdata(n: yang.gdata.Node) -> ietf_system__system__authentication__user_entry:
         return ietf_system__system__authentication__user_entry(name=n.get_str(yang.gdata.Id(NS_ietf_system, 'name')), password=n.get_opt_str(yang.gdata.Id(NS_ietf_system, 'password')), authorized_key=ietf_system__system__authentication__user__authorized_key.from_gdata(n.get_opt_list(yang.gdata.Id(NS_ietf_system, 'authorized-key'))))
 
-    def copy(self):
+    def copy(self) -> ietf_system__system__authentication__user_entry:
         """Create a deep copy of this adata object"""
         return ietf_system__system__authentication__user_entry.from_gdata(self.to_gdata())
 
 _breaker27 = None
 class ietf_system__system__authentication__user(yang.adata.MNode):
     elements: list[ietf_system__system__authentication__user_entry]
-    mut def __init__(self, elements=[]):
+    mut def __init__(self, elements: list[ietf_system__system__authentication__user_entry]=[]) -> None:
         self._ns = 'urn:ietf:params:xml:ns:yang:ietf-system'
         self._name = 'user'
         self.elements = elements
 
-    mut def create(self, name, password=None):
+    mut def create(self, name: str, password: ?str=None) -> ietf_system__system__authentication__user_entry:
         for e in self:
             match = True
             if e.name != name:
@@ -9700,7 +9700,7 @@ class ietf_system__system__authentication__user(yang.adata.MNode):
             return [ietf_system__system__authentication__user_entry.from_gdata(e) for e in n.elements]
         return []
 
-    def copy(self):
+    def copy(self) -> ietf_system__system__authentication__user:
         """Create a deep copy of this list object"""
         # Copy each element in the list
         copied_elements = []
@@ -9719,7 +9719,7 @@ class ietf_system__system__authentication(yang.adata.MNode):
     user_authentication_order: list[Identityref]
     user: ietf_system__system__authentication__user
 
-    mut def __init__(self, user_authentication_order: ?list[Identityref]=None, user: list[ietf_system__system__authentication__user_entry]=[]):
+    mut def __init__(self, user_authentication_order: ?list[Identityref]=None, user: list[ietf_system__system__authentication__user_entry]=[]) -> None:
         self._ns = 'urn:ietf:params:xml:ns:yang:ietf-system'
         self.user_authentication_order = user_authentication_order if user_authentication_order is not None else []
         self.user = ietf_system__system__authentication__user(elements=user)
@@ -9739,7 +9739,7 @@ class ietf_system__system__authentication(yang.adata.MNode):
             return ietf_system__system__authentication(user_authentication_order=n.get_opt_Identityrefs(yang.gdata.Id(NS_ietf_system, 'user-authentication-order')), user=ietf_system__system__authentication__user.from_gdata(n.get_opt_list(yang.gdata.Id(NS_ietf_system, 'user'))))
         return ietf_system__system__authentication()
 
-    def copy(self):
+    def copy(self) -> ietf_system__system__authentication:
         """Create a deep copy of this adata object"""
         return ietf_system__system__authentication.from_gdata(self.to_gdata())
 
@@ -9755,7 +9755,7 @@ class ietf_system__system(yang.adata.MNode):
     radius: ietf_system__system__radius
     authentication: ietf_system__system__authentication
 
-    mut def __init__(self, contact: ?str, hostname: ?str, location: ?str, clock: ?ietf_system__system__clock=None, ntp: ?ietf_system__system__ntp=None, dns_resolver: ?ietf_system__system__dns_resolver=None, radius: ?ietf_system__system__radius=None, authentication: ?ietf_system__system__authentication=None):
+    mut def __init__(self, contact: ?str, hostname: ?str, location: ?str, clock: ?ietf_system__system__clock=None, ntp: ?ietf_system__system__ntp=None, dns_resolver: ?ietf_system__system__dns_resolver=None, radius: ?ietf_system__system__radius=None, authentication: ?ietf_system__system__authentication=None) -> None:
         self._ns = 'urn:ietf:params:xml:ns:yang:ietf-system'
         self.contact = contact
         self.hostname = hostname
@@ -9766,7 +9766,7 @@ class ietf_system__system(yang.adata.MNode):
         self.radius = radius if radius is not None else ietf_system__system__radius()
         self.authentication = authentication if authentication is not None else ietf_system__system__authentication()
 
-    mut def create_ntp(self, enabled=None):
+    mut def create_ntp(self, enabled: ?bool=None) -> ietf_system__system__ntp:
         existing = self.ntp
         if existing is not None:
             if enabled is not None:
@@ -9803,7 +9803,7 @@ class ietf_system__system(yang.adata.MNode):
             return ietf_system__system(contact=n.get_opt_str(yang.gdata.Id(NS_ietf_system, 'contact')), hostname=n.get_opt_str(yang.gdata.Id(NS_ietf_system, 'hostname')), location=n.get_opt_str(yang.gdata.Id(NS_ietf_system, 'location')), clock=ietf_system__system__clock.from_gdata(n.get_opt_cnt(yang.gdata.Id(NS_ietf_system, 'clock'))), ntp=ietf_system__system__ntp.from_gdata(n.get_opt_cnt(yang.gdata.Id(NS_ietf_system, 'ntp'))), dns_resolver=ietf_system__system__dns_resolver.from_gdata(n.get_opt_cnt(yang.gdata.Id(NS_ietf_system, 'dns-resolver'))), radius=ietf_system__system__radius.from_gdata(n.get_opt_cnt(yang.gdata.Id(NS_ietf_system, 'radius'))), authentication=ietf_system__system__authentication.from_gdata(n.get_opt_cnt(yang.gdata.Id(NS_ietf_system, 'authentication'))))
         return ietf_system__system()
 
-    def copy(self):
+    def copy(self) -> ietf_system__system:
         """Create a deep copy of this adata object"""
         return ietf_system__system.from_gdata(self.to_gdata())
 
@@ -9815,7 +9815,7 @@ class ietf_system__system_state__platform(yang.adata.MNode):
     os_version: ?str
     machine: ?str
 
-    mut def __init__(self, os_name: ?str, os_release: ?str, os_version: ?str, machine: ?str):
+    mut def __init__(self, os_name: ?str, os_release: ?str, os_version: ?str, machine: ?str) -> None:
         self._ns = 'urn:ietf:params:xml:ns:yang:ietf-system'
         self.os_name = os_name
         self.os_release = os_release
@@ -9841,7 +9841,7 @@ class ietf_system__system_state__platform(yang.adata.MNode):
             return ietf_system__system_state__platform(os_name=n.get_opt_str(yang.gdata.Id(NS_ietf_system, 'os-name')), os_release=n.get_opt_str(yang.gdata.Id(NS_ietf_system, 'os-release')), os_version=n.get_opt_str(yang.gdata.Id(NS_ietf_system, 'os-version')), machine=n.get_opt_str(yang.gdata.Id(NS_ietf_system, 'machine')))
         return ietf_system__system_state__platform()
 
-    def copy(self):
+    def copy(self) -> ietf_system__system_state__platform:
         """Create a deep copy of this adata object"""
         return ietf_system__system_state__platform.from_gdata(self.to_gdata())
 
@@ -9851,7 +9851,7 @@ class ietf_system__system_state__clock(yang.adata.MNode):
     current_datetime: ?str
     boot_datetime: ?str
 
-    mut def __init__(self, current_datetime: ?str, boot_datetime: ?str):
+    mut def __init__(self, current_datetime: ?str, boot_datetime: ?str) -> None:
         self._ns = 'urn:ietf:params:xml:ns:yang:ietf-system'
         self.current_datetime = current_datetime
         self.boot_datetime = boot_datetime
@@ -9871,7 +9871,7 @@ class ietf_system__system_state__clock(yang.adata.MNode):
             return ietf_system__system_state__clock(current_datetime=n.get_opt_str(yang.gdata.Id(NS_ietf_system, 'current-datetime')), boot_datetime=n.get_opt_str(yang.gdata.Id(NS_ietf_system, 'boot-datetime')))
         return ietf_system__system_state__clock()
 
-    def copy(self):
+    def copy(self) -> ietf_system__system_state__clock:
         """Create a deep copy of this adata object"""
         return ietf_system__system_state__clock.from_gdata(self.to_gdata())
 
@@ -9881,7 +9881,7 @@ class ietf_system__system_state(yang.adata.MNode):
     platform: ietf_system__system_state__platform
     clock: ietf_system__system_state__clock
 
-    mut def __init__(self, platform: ?ietf_system__system_state__platform=None, clock: ?ietf_system__system_state__clock=None):
+    mut def __init__(self, platform: ?ietf_system__system_state__platform=None, clock: ?ietf_system__system_state__clock=None) -> None:
         self._ns = 'urn:ietf:params:xml:ns:yang:ietf-system'
         self.platform = platform if platform is not None else ietf_system__system_state__platform()
         self.clock = clock if clock is not None else ietf_system__system_state__clock()
@@ -9901,7 +9901,7 @@ class ietf_system__system_state(yang.adata.MNode):
             return ietf_system__system_state(platform=ietf_system__system_state__platform.from_gdata(n.get_opt_cnt(yang.gdata.Id(NS_ietf_system, 'platform'))), clock=ietf_system__system_state__clock.from_gdata(n.get_opt_cnt(yang.gdata.Id(NS_ietf_system, 'clock'))))
         return ietf_system__system_state()
 
-    def copy(self):
+    def copy(self) -> ietf_system__system_state:
         """Create a deep copy of this adata object"""
         return ietf_system__system_state.from_gdata(self.to_gdata())
 
@@ -9923,7 +9923,7 @@ class ietf_interfaces__interfaces__interface__statistics(yang.adata.MNode):
     out_discards: ?u64
     out_errors: ?u64
 
-    mut def __init__(self, discontinuity_time: ?str, in_octets: ?u64, in_unicast_pkts: ?u64, in_broadcast_pkts: ?u64, in_multicast_pkts: ?u64, in_discards: ?u64, in_errors: ?u64, in_unknown_protos: ?u64, out_octets: ?u64, out_unicast_pkts: ?u64, out_broadcast_pkts: ?u64, out_multicast_pkts: ?u64, out_discards: ?u64, out_errors: ?u64):
+    mut def __init__(self, discontinuity_time: ?str, in_octets: ?u64, in_unicast_pkts: ?u64, in_broadcast_pkts: ?u64, in_multicast_pkts: ?u64, in_discards: ?u64, in_errors: ?u64, in_unknown_protos: ?u64, out_octets: ?u64, out_unicast_pkts: ?u64, out_broadcast_pkts: ?u64, out_multicast_pkts: ?u64, out_discards: ?u64, out_errors: ?u64) -> None:
         self._ns = 'urn:ietf:params:xml:ns:yang:ietf-interfaces'
         self.discontinuity_time = discontinuity_time
         self.in_octets = in_octets
@@ -9979,7 +9979,7 @@ class ietf_interfaces__interfaces__interface__statistics(yang.adata.MNode):
             return ietf_interfaces__interfaces__interface__statistics(discontinuity_time=n.get_opt_str(yang.gdata.Id(NS_ietf_interfaces, 'discontinuity-time')), in_octets=n.get_opt_u64(yang.gdata.Id(NS_ietf_interfaces, 'in-octets')), in_unicast_pkts=n.get_opt_u64(yang.gdata.Id(NS_ietf_interfaces, 'in-unicast-pkts')), in_broadcast_pkts=n.get_opt_u64(yang.gdata.Id(NS_ietf_interfaces, 'in-broadcast-pkts')), in_multicast_pkts=n.get_opt_u64(yang.gdata.Id(NS_ietf_interfaces, 'in-multicast-pkts')), in_discards=n.get_opt_u64(yang.gdata.Id(NS_ietf_interfaces, 'in-discards')), in_errors=n.get_opt_u64(yang.gdata.Id(NS_ietf_interfaces, 'in-errors')), in_unknown_protos=n.get_opt_u64(yang.gdata.Id(NS_ietf_interfaces, 'in-unknown-protos')), out_octets=n.get_opt_u64(yang.gdata.Id(NS_ietf_interfaces, 'out-octets')), out_unicast_pkts=n.get_opt_u64(yang.gdata.Id(NS_ietf_interfaces, 'out-unicast-pkts')), out_broadcast_pkts=n.get_opt_u64(yang.gdata.Id(NS_ietf_interfaces, 'out-broadcast-pkts')), out_multicast_pkts=n.get_opt_u64(yang.gdata.Id(NS_ietf_interfaces, 'out-multicast-pkts')), out_discards=n.get_opt_u64(yang.gdata.Id(NS_ietf_interfaces, 'out-discards')), out_errors=n.get_opt_u64(yang.gdata.Id(NS_ietf_interfaces, 'out-errors')))
         return ietf_interfaces__interfaces__interface__statistics()
 
-    def copy(self):
+    def copy(self) -> ietf_interfaces__interfaces__interface__statistics:
         """Create a deep copy of this adata object"""
         return ietf_interfaces__interfaces__interface__statistics.from_gdata(self.to_gdata())
 
@@ -9991,7 +9991,7 @@ class ietf_interfaces__interfaces__interface__ipv4__address_entry(yang.adata.MNo
     netmask: ?str
     origin: ?str
 
-    mut def __init__(self, ip: str, prefix_length: ?u64, netmask: ?str, origin: ?str):
+    mut def __init__(self, ip: str, prefix_length: ?u64, netmask: ?str, origin: ?str) -> None:
         self._ns = 'urn:ietf:params:xml:ns:yang:ietf-ip'
         self.ip = ip
         self.prefix_length = prefix_length
@@ -10015,19 +10015,19 @@ class ietf_interfaces__interfaces__interface__ipv4__address_entry(yang.adata.MNo
     mut def from_gdata(n: yang.gdata.Node) -> ietf_interfaces__interfaces__interface__ipv4__address_entry:
         return ietf_interfaces__interfaces__interface__ipv4__address_entry(ip=n.get_str(yang.gdata.Id(NS_ietf_ip, 'ip')), prefix_length=n.get_opt_u64(yang.gdata.Id(NS_ietf_ip, 'prefix-length')), netmask=n.get_opt_str(yang.gdata.Id(NS_ietf_ip, 'netmask')), origin=n.get_opt_str(yang.gdata.Id(NS_ietf_ip, 'origin')))
 
-    def copy(self):
+    def copy(self) -> ietf_interfaces__interfaces__interface__ipv4__address_entry:
         """Create a deep copy of this adata object"""
         return ietf_interfaces__interfaces__interface__ipv4__address_entry.from_gdata(self.to_gdata())
 
 _breaker35 = None
 class ietf_interfaces__interfaces__interface__ipv4__address(yang.adata.MNode):
     elements: list[ietf_interfaces__interfaces__interface__ipv4__address_entry]
-    mut def __init__(self, elements=[]):
+    mut def __init__(self, elements: list[ietf_interfaces__interfaces__interface__ipv4__address_entry]=[]) -> None:
         self._ns = 'urn:ietf:params:xml:ns:yang:ietf-ip'
         self._name = 'address'
         self.elements = elements
 
-    mut def create(self, ip, prefix_length=None, netmask=None, origin=None):
+    mut def create(self, ip: str, prefix_length: ?u64=None, netmask: ?str=None, origin: ?str=None) -> ietf_interfaces__interfaces__interface__ipv4__address_entry:
         for e in self:
             match = True
             if e.ip != ip:
@@ -10052,7 +10052,7 @@ class ietf_interfaces__interfaces__interface__ipv4__address(yang.adata.MNode):
             return [ietf_interfaces__interfaces__interface__ipv4__address_entry.from_gdata(e) for e in n.elements]
         return []
 
-    def copy(self):
+    def copy(self) -> ietf_interfaces__interfaces__interface__ipv4__address:
         """Create a deep copy of this list object"""
         # Copy each element in the list
         copied_elements = []
@@ -10072,7 +10072,7 @@ class ietf_interfaces__interfaces__interface__ipv4__neighbor_entry(yang.adata.MN
     link_layer_address: ?str
     origin: ?str
 
-    mut def __init__(self, ip: str, link_layer_address: ?str, origin: ?str):
+    mut def __init__(self, ip: str, link_layer_address: ?str, origin: ?str) -> None:
         self._ns = 'urn:ietf:params:xml:ns:yang:ietf-ip'
         self.ip = ip
         self.link_layer_address = link_layer_address
@@ -10093,19 +10093,19 @@ class ietf_interfaces__interfaces__interface__ipv4__neighbor_entry(yang.adata.MN
     mut def from_gdata(n: yang.gdata.Node) -> ietf_interfaces__interfaces__interface__ipv4__neighbor_entry:
         return ietf_interfaces__interfaces__interface__ipv4__neighbor_entry(ip=n.get_str(yang.gdata.Id(NS_ietf_ip, 'ip')), link_layer_address=n.get_opt_str(yang.gdata.Id(NS_ietf_ip, 'link-layer-address')), origin=n.get_opt_str(yang.gdata.Id(NS_ietf_ip, 'origin')))
 
-    def copy(self):
+    def copy(self) -> ietf_interfaces__interfaces__interface__ipv4__neighbor_entry:
         """Create a deep copy of this adata object"""
         return ietf_interfaces__interfaces__interface__ipv4__neighbor_entry.from_gdata(self.to_gdata())
 
 _breaker37 = None
 class ietf_interfaces__interfaces__interface__ipv4__neighbor(yang.adata.MNode):
     elements: list[ietf_interfaces__interfaces__interface__ipv4__neighbor_entry]
-    mut def __init__(self, elements=[]):
+    mut def __init__(self, elements: list[ietf_interfaces__interfaces__interface__ipv4__neighbor_entry]=[]) -> None:
         self._ns = 'urn:ietf:params:xml:ns:yang:ietf-ip'
         self._name = 'neighbor'
         self.elements = elements
 
-    mut def create(self, ip, link_layer_address=None, origin=None):
+    mut def create(self, ip: str, link_layer_address: ?str=None, origin: ?str=None) -> ietf_interfaces__interfaces__interface__ipv4__neighbor_entry:
         for e in self:
             match = True
             if e.ip != ip:
@@ -10128,7 +10128,7 @@ class ietf_interfaces__interfaces__interface__ipv4__neighbor(yang.adata.MNode):
             return [ietf_interfaces__interfaces__interface__ipv4__neighbor_entry.from_gdata(e) for e in n.elements]
         return []
 
-    def copy(self):
+    def copy(self) -> ietf_interfaces__interfaces__interface__ipv4__neighbor:
         """Create a deep copy of this list object"""
         # Copy each element in the list
         copied_elements = []
@@ -10150,7 +10150,7 @@ class ietf_interfaces__interfaces__interface__ipv4(yang.adata.MNode):
     address: ietf_interfaces__interfaces__interface__ipv4__address
     neighbor: ietf_interfaces__interfaces__interface__ipv4__neighbor
 
-    mut def __init__(self, enabled: ?bool, forwarding: ?bool, mtu: ?u64, address: list[ietf_interfaces__interfaces__interface__ipv4__address_entry]=[], neighbor: list[ietf_interfaces__interfaces__interface__ipv4__neighbor_entry]=[]):
+    mut def __init__(self, enabled: ?bool, forwarding: ?bool, mtu: ?u64, address: list[ietf_interfaces__interfaces__interface__ipv4__address_entry]=[], neighbor: list[ietf_interfaces__interfaces__interface__ipv4__neighbor_entry]=[]) -> None:
         self._ns = 'urn:ietf:params:xml:ns:yang:ietf-ip'
         self.enabled = enabled
         self.forwarding = forwarding
@@ -10179,7 +10179,7 @@ class ietf_interfaces__interfaces__interface__ipv4(yang.adata.MNode):
             return ietf_interfaces__interfaces__interface__ipv4(enabled=n.get_opt_bool(yang.gdata.Id(NS_ietf_ip, 'enabled')), forwarding=n.get_opt_bool(yang.gdata.Id(NS_ietf_ip, 'forwarding')), mtu=n.get_opt_u64(yang.gdata.Id(NS_ietf_ip, 'mtu')), address=ietf_interfaces__interfaces__interface__ipv4__address.from_gdata(n.get_opt_list(yang.gdata.Id(NS_ietf_ip, 'address'))), neighbor=ietf_interfaces__interfaces__interface__ipv4__neighbor.from_gdata(n.get_opt_list(yang.gdata.Id(NS_ietf_ip, 'neighbor'))))
         return None
 
-    def copy(self):
+    def copy(self) -> ietf_interfaces__interfaces__interface__ipv4:
         """Create a deep copy of this adata object"""
         ad = ietf_interfaces__interfaces__interface__ipv4.from_gdata(self.to_gdata())
         if ad is not None:
@@ -10194,7 +10194,7 @@ class ietf_interfaces__interfaces__interface__ipv6__address_entry(yang.adata.MNo
     origin: ?str
     status: ?str
 
-    mut def __init__(self, ip: str, prefix_length: ?u64, origin: ?str, status: ?str):
+    mut def __init__(self, ip: str, prefix_length: ?u64, origin: ?str, status: ?str) -> None:
         self._ns = 'urn:ietf:params:xml:ns:yang:ietf-ip'
         self.ip = ip
         self.prefix_length = prefix_length
@@ -10218,19 +10218,19 @@ class ietf_interfaces__interfaces__interface__ipv6__address_entry(yang.adata.MNo
     mut def from_gdata(n: yang.gdata.Node) -> ietf_interfaces__interfaces__interface__ipv6__address_entry:
         return ietf_interfaces__interfaces__interface__ipv6__address_entry(ip=n.get_str(yang.gdata.Id(NS_ietf_ip, 'ip')), prefix_length=n.get_opt_u64(yang.gdata.Id(NS_ietf_ip, 'prefix-length')), origin=n.get_opt_str(yang.gdata.Id(NS_ietf_ip, 'origin')), status=n.get_opt_str(yang.gdata.Id(NS_ietf_ip, 'status')))
 
-    def copy(self):
+    def copy(self) -> ietf_interfaces__interfaces__interface__ipv6__address_entry:
         """Create a deep copy of this adata object"""
         return ietf_interfaces__interfaces__interface__ipv6__address_entry.from_gdata(self.to_gdata())
 
 _breaker40 = None
 class ietf_interfaces__interfaces__interface__ipv6__address(yang.adata.MNode):
     elements: list[ietf_interfaces__interfaces__interface__ipv6__address_entry]
-    mut def __init__(self, elements=[]):
+    mut def __init__(self, elements: list[ietf_interfaces__interfaces__interface__ipv6__address_entry]=[]) -> None:
         self._ns = 'urn:ietf:params:xml:ns:yang:ietf-ip'
         self._name = 'address'
         self.elements = elements
 
-    mut def create(self, ip, prefix_length=None, origin=None, status=None):
+    mut def create(self, ip: str, prefix_length: ?u64=None, origin: ?str=None, status: ?str=None) -> ietf_interfaces__interfaces__interface__ipv6__address_entry:
         for e in self:
             match = True
             if e.ip != ip:
@@ -10255,7 +10255,7 @@ class ietf_interfaces__interfaces__interface__ipv6__address(yang.adata.MNode):
             return [ietf_interfaces__interfaces__interface__ipv6__address_entry.from_gdata(e) for e in n.elements]
         return []
 
-    def copy(self):
+    def copy(self) -> ietf_interfaces__interfaces__interface__ipv6__address:
         """Create a deep copy of this list object"""
         # Copy each element in the list
         copied_elements = []
@@ -10277,7 +10277,7 @@ class ietf_interfaces__interfaces__interface__ipv6__neighbor_entry(yang.adata.MN
     is_router: ?bool
     state: ?str
 
-    mut def __init__(self, ip: str, link_layer_address: ?str, origin: ?str, is_router: ?bool, state: ?str):
+    mut def __init__(self, ip: str, link_layer_address: ?str, origin: ?str, is_router: ?bool, state: ?str) -> None:
         self._ns = 'urn:ietf:params:xml:ns:yang:ietf-ip'
         self.ip = ip
         self.link_layer_address = link_layer_address
@@ -10304,19 +10304,19 @@ class ietf_interfaces__interfaces__interface__ipv6__neighbor_entry(yang.adata.MN
     mut def from_gdata(n: yang.gdata.Node) -> ietf_interfaces__interfaces__interface__ipv6__neighbor_entry:
         return ietf_interfaces__interfaces__interface__ipv6__neighbor_entry(ip=n.get_str(yang.gdata.Id(NS_ietf_ip, 'ip')), link_layer_address=n.get_opt_str(yang.gdata.Id(NS_ietf_ip, 'link-layer-address')), origin=n.get_opt_str(yang.gdata.Id(NS_ietf_ip, 'origin')), is_router=n.get_opt_empty(yang.gdata.Id(NS_ietf_ip, 'is-router')), state=n.get_opt_str(yang.gdata.Id(NS_ietf_ip, 'state')))
 
-    def copy(self):
+    def copy(self) -> ietf_interfaces__interfaces__interface__ipv6__neighbor_entry:
         """Create a deep copy of this adata object"""
         return ietf_interfaces__interfaces__interface__ipv6__neighbor_entry.from_gdata(self.to_gdata())
 
 _breaker42 = None
 class ietf_interfaces__interfaces__interface__ipv6__neighbor(yang.adata.MNode):
     elements: list[ietf_interfaces__interfaces__interface__ipv6__neighbor_entry]
-    mut def __init__(self, elements=[]):
+    mut def __init__(self, elements: list[ietf_interfaces__interfaces__interface__ipv6__neighbor_entry]=[]) -> None:
         self._ns = 'urn:ietf:params:xml:ns:yang:ietf-ip'
         self._name = 'neighbor'
         self.elements = elements
 
-    mut def create(self, ip, link_layer_address=None, origin=None, is_router=None, state=None):
+    mut def create(self, ip: str, link_layer_address: ?str=None, origin: ?str=None, is_router: ?bool=None, state: ?str=None) -> ietf_interfaces__interfaces__interface__ipv6__neighbor_entry:
         for e in self:
             match = True
             if e.ip != ip:
@@ -10343,7 +10343,7 @@ class ietf_interfaces__interfaces__interface__ipv6__neighbor(yang.adata.MNode):
             return [ietf_interfaces__interfaces__interface__ipv6__neighbor_entry.from_gdata(e) for e in n.elements]
         return []
 
-    def copy(self):
+    def copy(self) -> ietf_interfaces__interfaces__interface__ipv6__neighbor:
         """Create a deep copy of this list object"""
         # Copy each element in the list
         copied_elements = []
@@ -10364,7 +10364,7 @@ class ietf_interfaces__interfaces__interface__ipv6__autoconf(yang.adata.MNode):
     temporary_valid_lifetime: ?u64
     temporary_preferred_lifetime: ?u64
 
-    mut def __init__(self, create_global_addresses: ?bool, create_temporary_addresses: ?bool, temporary_valid_lifetime: ?u64, temporary_preferred_lifetime: ?u64):
+    mut def __init__(self, create_global_addresses: ?bool, create_temporary_addresses: ?bool, temporary_valid_lifetime: ?u64, temporary_preferred_lifetime: ?u64) -> None:
         self._ns = 'urn:ietf:params:xml:ns:yang:ietf-ip'
         self.create_global_addresses = create_global_addresses
         self.create_temporary_addresses = create_temporary_addresses
@@ -10390,7 +10390,7 @@ class ietf_interfaces__interfaces__interface__ipv6__autoconf(yang.adata.MNode):
             return ietf_interfaces__interfaces__interface__ipv6__autoconf(create_global_addresses=n.get_opt_bool(yang.gdata.Id(NS_ietf_ip, 'create-global-addresses')), create_temporary_addresses=n.get_opt_bool(yang.gdata.Id(NS_ietf_ip, 'create-temporary-addresses')), temporary_valid_lifetime=n.get_opt_u64(yang.gdata.Id(NS_ietf_ip, 'temporary-valid-lifetime')), temporary_preferred_lifetime=n.get_opt_u64(yang.gdata.Id(NS_ietf_ip, 'temporary-preferred-lifetime')))
         return ietf_interfaces__interfaces__interface__ipv6__autoconf()
 
-    def copy(self):
+    def copy(self) -> ietf_interfaces__interfaces__interface__ipv6__autoconf:
         """Create a deep copy of this adata object"""
         return ietf_interfaces__interfaces__interface__ipv6__autoconf.from_gdata(self.to_gdata())
 
@@ -10405,7 +10405,7 @@ class ietf_interfaces__interfaces__interface__ipv6(yang.adata.MNode):
     dup_addr_detect_transmits: ?u64
     autoconf: ietf_interfaces__interfaces__interface__ipv6__autoconf
 
-    mut def __init__(self, enabled: ?bool, forwarding: ?bool, mtu: ?u64, address: list[ietf_interfaces__interfaces__interface__ipv6__address_entry]=[], neighbor: list[ietf_interfaces__interfaces__interface__ipv6__neighbor_entry]=[], dup_addr_detect_transmits: ?u64, autoconf: ?ietf_interfaces__interfaces__interface__ipv6__autoconf=None):
+    mut def __init__(self, enabled: ?bool, forwarding: ?bool, mtu: ?u64, address: list[ietf_interfaces__interfaces__interface__ipv6__address_entry]=[], neighbor: list[ietf_interfaces__interfaces__interface__ipv6__neighbor_entry]=[], dup_addr_detect_transmits: ?u64, autoconf: ?ietf_interfaces__interfaces__interface__ipv6__autoconf=None) -> None:
         self._ns = 'urn:ietf:params:xml:ns:yang:ietf-ip'
         self.enabled = enabled
         self.forwarding = forwarding
@@ -10440,7 +10440,7 @@ class ietf_interfaces__interfaces__interface__ipv6(yang.adata.MNode):
             return ietf_interfaces__interfaces__interface__ipv6(enabled=n.get_opt_bool(yang.gdata.Id(NS_ietf_ip, 'enabled')), forwarding=n.get_opt_bool(yang.gdata.Id(NS_ietf_ip, 'forwarding')), mtu=n.get_opt_u64(yang.gdata.Id(NS_ietf_ip, 'mtu')), address=ietf_interfaces__interfaces__interface__ipv6__address.from_gdata(n.get_opt_list(yang.gdata.Id(NS_ietf_ip, 'address'))), neighbor=ietf_interfaces__interfaces__interface__ipv6__neighbor.from_gdata(n.get_opt_list(yang.gdata.Id(NS_ietf_ip, 'neighbor'))), dup_addr_detect_transmits=n.get_opt_u64(yang.gdata.Id(NS_ietf_ip, 'dup-addr-detect-transmits')), autoconf=ietf_interfaces__interfaces__interface__ipv6__autoconf.from_gdata(n.get_opt_cnt(yang.gdata.Id(NS_ietf_ip, 'autoconf'))))
         return None
 
-    def copy(self):
+    def copy(self) -> ietf_interfaces__interfaces__interface__ipv6:
         """Create a deep copy of this adata object"""
         ad = ietf_interfaces__interfaces__interface__ipv6.from_gdata(self.to_gdata())
         if ad is not None:
@@ -10467,7 +10467,7 @@ class ietf_interfaces__interfaces__interface_entry(yang.adata.MNode):
     ipv4: ?ietf_interfaces__interfaces__interface__ipv4
     ipv6: ?ietf_interfaces__interfaces__interface__ipv6
 
-    mut def __init__(self, name: str, description: ?str, type: ?Identityref, enabled: ?bool, link_up_down_trap_enable: ?str, admin_status: ?str, oper_status: ?str, last_change: ?str, if_index: ?int, phys_address: ?str, higher_layer_if: ?list[str]=None, lower_layer_if: ?list[str]=None, speed: ?u64, statistics: ?ietf_interfaces__interfaces__interface__statistics=None, ipv4: ?ietf_interfaces__interfaces__interface__ipv4=None, ipv6: ?ietf_interfaces__interfaces__interface__ipv6=None):
+    mut def __init__(self, name: str, description: ?str, type: ?Identityref, enabled: ?bool, link_up_down_trap_enable: ?str, admin_status: ?str, oper_status: ?str, last_change: ?str, if_index: ?int, phys_address: ?str, higher_layer_if: ?list[str]=None, lower_layer_if: ?list[str]=None, speed: ?u64, statistics: ?ietf_interfaces__interfaces__interface__statistics=None, ipv4: ?ietf_interfaces__interfaces__interface__ipv4=None, ipv6: ?ietf_interfaces__interfaces__interface__ipv6=None) -> None:
         self._ns = 'urn:ietf:params:xml:ns:yang:ietf-interfaces'
         self.name = name
         self.description = description
@@ -10486,7 +10486,7 @@ class ietf_interfaces__interfaces__interface_entry(yang.adata.MNode):
         self.ipv4 = ipv4
         self.ipv6 = ipv6
 
-    mut def create_ipv4(self, enabled=None, forwarding=None, mtu=None):
+    mut def create_ipv4(self, enabled: ?bool=None, forwarding: ?bool=None, mtu: ?u64=None) -> ietf_interfaces__interfaces__interface__ipv4:
         existing = self.ipv4
         if existing is not None:
             if enabled is not None:
@@ -10500,7 +10500,7 @@ class ietf_interfaces__interfaces__interface_entry(yang.adata.MNode):
         self.ipv4 = res
         return res
 
-    mut def create_ipv6(self, enabled=None, forwarding=None, mtu=None, dup_addr_detect_transmits=None):
+    mut def create_ipv6(self, enabled: ?bool=None, forwarding: ?bool=None, mtu: ?u64=None, dup_addr_detect_transmits: ?u64=None) -> ietf_interfaces__interfaces__interface__ipv6:
         existing = self.ipv6
         if existing is not None:
             if enabled is not None:
@@ -10557,19 +10557,19 @@ class ietf_interfaces__interfaces__interface_entry(yang.adata.MNode):
     mut def from_gdata(n: yang.gdata.Node) -> ietf_interfaces__interfaces__interface_entry:
         return ietf_interfaces__interfaces__interface_entry(name=n.get_str(yang.gdata.Id(NS_ietf_interfaces, 'name')), description=n.get_opt_str(yang.gdata.Id(NS_ietf_interfaces, 'description')), type=n.get_opt_Identityref(yang.gdata.Id(NS_ietf_interfaces, 'type')), enabled=n.get_opt_bool(yang.gdata.Id(NS_ietf_interfaces, 'enabled')), link_up_down_trap_enable=n.get_opt_str(yang.gdata.Id(NS_ietf_interfaces, 'link-up-down-trap-enable')), admin_status=n.get_opt_str(yang.gdata.Id(NS_ietf_interfaces, 'admin-status')), oper_status=n.get_opt_str(yang.gdata.Id(NS_ietf_interfaces, 'oper-status')), last_change=n.get_opt_str(yang.gdata.Id(NS_ietf_interfaces, 'last-change')), if_index=n.get_opt_int(yang.gdata.Id(NS_ietf_interfaces, 'if-index')), phys_address=n.get_opt_str(yang.gdata.Id(NS_ietf_interfaces, 'phys-address')), higher_layer_if=n.get_opt_strs(yang.gdata.Id(NS_ietf_interfaces, 'higher-layer-if')), lower_layer_if=n.get_opt_strs(yang.gdata.Id(NS_ietf_interfaces, 'lower-layer-if')), speed=n.get_opt_u64(yang.gdata.Id(NS_ietf_interfaces, 'speed')), statistics=ietf_interfaces__interfaces__interface__statistics.from_gdata(n.get_opt_cnt(yang.gdata.Id(NS_ietf_interfaces, 'statistics'))), ipv4=ietf_interfaces__interfaces__interface__ipv4.from_gdata(n.get_opt_cnt(yang.gdata.Id(NS_ietf_ip, 'ipv4'))), ipv6=ietf_interfaces__interfaces__interface__ipv6.from_gdata(n.get_opt_cnt(yang.gdata.Id(NS_ietf_ip, 'ipv6'))))
 
-    def copy(self):
+    def copy(self) -> ietf_interfaces__interfaces__interface_entry:
         """Create a deep copy of this adata object"""
         return ietf_interfaces__interfaces__interface_entry.from_gdata(self.to_gdata())
 
 _breaker46 = None
 class ietf_interfaces__interfaces__interface(yang.adata.MNode):
     elements: list[ietf_interfaces__interfaces__interface_entry]
-    mut def __init__(self, elements=[]):
+    mut def __init__(self, elements: list[ietf_interfaces__interfaces__interface_entry]=[]) -> None:
         self._ns = 'urn:ietf:params:xml:ns:yang:ietf-interfaces'
         self._name = 'interface'
         self.elements = elements
 
-    mut def create(self, name, description=None, type=None, enabled=None, link_up_down_trap_enable=None, admin_status=None, oper_status=None, last_change=None, if_index=None, phys_address=None, speed=None):
+    mut def create(self, name: str, description: ?str=None, type: ?Identityref=None, enabled: ?bool=None, link_up_down_trap_enable: ?str=None, admin_status: ?str=None, oper_status: ?str=None, last_change: ?str=None, if_index: ?int=None, phys_address: ?str=None, speed: ?u64=None) -> ietf_interfaces__interfaces__interface_entry:
         for e in self:
             match = True
             if e.name != name:
@@ -10608,7 +10608,7 @@ class ietf_interfaces__interfaces__interface(yang.adata.MNode):
             return [ietf_interfaces__interfaces__interface_entry.from_gdata(e) for e in n.elements]
         return []
 
-    def copy(self):
+    def copy(self) -> ietf_interfaces__interfaces__interface:
         """Create a deep copy of this list object"""
         # Copy each element in the list
         copied_elements = []
@@ -10626,7 +10626,7 @@ _breaker47 = None
 class ietf_interfaces__interfaces(yang.adata.MNode):
     interface: ietf_interfaces__interfaces__interface
 
-    mut def __init__(self, interface: list[ietf_interfaces__interfaces__interface_entry]=[]):
+    mut def __init__(self, interface: list[ietf_interfaces__interfaces__interface_entry]=[]) -> None:
         self._ns = 'urn:ietf:params:xml:ns:yang:ietf-interfaces'
         self.interface = ietf_interfaces__interfaces__interface(elements=interface)
 
@@ -10643,7 +10643,7 @@ class ietf_interfaces__interfaces(yang.adata.MNode):
             return ietf_interfaces__interfaces(interface=ietf_interfaces__interfaces__interface.from_gdata(n.get_opt_list(yang.gdata.Id(NS_ietf_interfaces, 'interface'))))
         return ietf_interfaces__interfaces()
 
-    def copy(self):
+    def copy(self) -> ietf_interfaces__interfaces:
         """Create a deep copy of this adata object"""
         return ietf_interfaces__interfaces.from_gdata(self.to_gdata())
 
@@ -10665,7 +10665,7 @@ class ietf_interfaces__interfaces_state__interface__statistics(yang.adata.MNode)
     out_discards: ?u64
     out_errors: ?u64
 
-    mut def __init__(self, discontinuity_time: ?str, in_octets: ?u64, in_unicast_pkts: ?u64, in_broadcast_pkts: ?u64, in_multicast_pkts: ?u64, in_discards: ?u64, in_errors: ?u64, in_unknown_protos: ?u64, out_octets: ?u64, out_unicast_pkts: ?u64, out_broadcast_pkts: ?u64, out_multicast_pkts: ?u64, out_discards: ?u64, out_errors: ?u64):
+    mut def __init__(self, discontinuity_time: ?str, in_octets: ?u64, in_unicast_pkts: ?u64, in_broadcast_pkts: ?u64, in_multicast_pkts: ?u64, in_discards: ?u64, in_errors: ?u64, in_unknown_protos: ?u64, out_octets: ?u64, out_unicast_pkts: ?u64, out_broadcast_pkts: ?u64, out_multicast_pkts: ?u64, out_discards: ?u64, out_errors: ?u64) -> None:
         self._ns = 'urn:ietf:params:xml:ns:yang:ietf-interfaces'
         self.discontinuity_time = discontinuity_time
         self.in_octets = in_octets
@@ -10721,7 +10721,7 @@ class ietf_interfaces__interfaces_state__interface__statistics(yang.adata.MNode)
             return ietf_interfaces__interfaces_state__interface__statistics(discontinuity_time=n.get_opt_str(yang.gdata.Id(NS_ietf_interfaces, 'discontinuity-time')), in_octets=n.get_opt_u64(yang.gdata.Id(NS_ietf_interfaces, 'in-octets')), in_unicast_pkts=n.get_opt_u64(yang.gdata.Id(NS_ietf_interfaces, 'in-unicast-pkts')), in_broadcast_pkts=n.get_opt_u64(yang.gdata.Id(NS_ietf_interfaces, 'in-broadcast-pkts')), in_multicast_pkts=n.get_opt_u64(yang.gdata.Id(NS_ietf_interfaces, 'in-multicast-pkts')), in_discards=n.get_opt_u64(yang.gdata.Id(NS_ietf_interfaces, 'in-discards')), in_errors=n.get_opt_u64(yang.gdata.Id(NS_ietf_interfaces, 'in-errors')), in_unknown_protos=n.get_opt_u64(yang.gdata.Id(NS_ietf_interfaces, 'in-unknown-protos')), out_octets=n.get_opt_u64(yang.gdata.Id(NS_ietf_interfaces, 'out-octets')), out_unicast_pkts=n.get_opt_u64(yang.gdata.Id(NS_ietf_interfaces, 'out-unicast-pkts')), out_broadcast_pkts=n.get_opt_u64(yang.gdata.Id(NS_ietf_interfaces, 'out-broadcast-pkts')), out_multicast_pkts=n.get_opt_u64(yang.gdata.Id(NS_ietf_interfaces, 'out-multicast-pkts')), out_discards=n.get_opt_u64(yang.gdata.Id(NS_ietf_interfaces, 'out-discards')), out_errors=n.get_opt_u64(yang.gdata.Id(NS_ietf_interfaces, 'out-errors')))
         return ietf_interfaces__interfaces_state__interface__statistics()
 
-    def copy(self):
+    def copy(self) -> ietf_interfaces__interfaces_state__interface__statistics:
         """Create a deep copy of this adata object"""
         return ietf_interfaces__interfaces_state__interface__statistics.from_gdata(self.to_gdata())
 
@@ -10733,7 +10733,7 @@ class ietf_interfaces__interfaces_state__interface__ipv4__address_entry(yang.ada
     netmask: ?str
     origin: ?str
 
-    mut def __init__(self, ip: str, prefix_length: ?u64, netmask: ?str, origin: ?str):
+    mut def __init__(self, ip: str, prefix_length: ?u64, netmask: ?str, origin: ?str) -> None:
         self._ns = 'urn:ietf:params:xml:ns:yang:ietf-ip'
         self.ip = ip
         self.prefix_length = prefix_length
@@ -10757,19 +10757,19 @@ class ietf_interfaces__interfaces_state__interface__ipv4__address_entry(yang.ada
     mut def from_gdata(n: yang.gdata.Node) -> ietf_interfaces__interfaces_state__interface__ipv4__address_entry:
         return ietf_interfaces__interfaces_state__interface__ipv4__address_entry(ip=n.get_str(yang.gdata.Id(NS_ietf_ip, 'ip')), prefix_length=n.get_opt_u64(yang.gdata.Id(NS_ietf_ip, 'prefix-length')), netmask=n.get_opt_str(yang.gdata.Id(NS_ietf_ip, 'netmask')), origin=n.get_opt_str(yang.gdata.Id(NS_ietf_ip, 'origin')))
 
-    def copy(self):
+    def copy(self) -> ietf_interfaces__interfaces_state__interface__ipv4__address_entry:
         """Create a deep copy of this adata object"""
         return ietf_interfaces__interfaces_state__interface__ipv4__address_entry.from_gdata(self.to_gdata())
 
 _breaker50 = None
 class ietf_interfaces__interfaces_state__interface__ipv4__address(yang.adata.MNode):
     elements: list[ietf_interfaces__interfaces_state__interface__ipv4__address_entry]
-    mut def __init__(self, elements=[]):
+    mut def __init__(self, elements: list[ietf_interfaces__interfaces_state__interface__ipv4__address_entry]=[]) -> None:
         self._ns = 'urn:ietf:params:xml:ns:yang:ietf-ip'
         self._name = 'address'
         self.elements = elements
 
-    mut def create(self, ip, prefix_length=None, netmask=None, origin=None):
+    mut def create(self, ip: str, prefix_length: ?u64=None, netmask: ?str=None, origin: ?str=None) -> ietf_interfaces__interfaces_state__interface__ipv4__address_entry:
         for e in self:
             match = True
             if e.ip != ip:
@@ -10794,7 +10794,7 @@ class ietf_interfaces__interfaces_state__interface__ipv4__address(yang.adata.MNo
             return [ietf_interfaces__interfaces_state__interface__ipv4__address_entry.from_gdata(e) for e in n.elements]
         return []
 
-    def copy(self):
+    def copy(self) -> ietf_interfaces__interfaces_state__interface__ipv4__address:
         """Create a deep copy of this list object"""
         # Copy each element in the list
         copied_elements = []
@@ -10814,7 +10814,7 @@ class ietf_interfaces__interfaces_state__interface__ipv4__neighbor_entry(yang.ad
     link_layer_address: ?str
     origin: ?str
 
-    mut def __init__(self, ip: str, link_layer_address: ?str, origin: ?str):
+    mut def __init__(self, ip: str, link_layer_address: ?str, origin: ?str) -> None:
         self._ns = 'urn:ietf:params:xml:ns:yang:ietf-ip'
         self.ip = ip
         self.link_layer_address = link_layer_address
@@ -10835,19 +10835,19 @@ class ietf_interfaces__interfaces_state__interface__ipv4__neighbor_entry(yang.ad
     mut def from_gdata(n: yang.gdata.Node) -> ietf_interfaces__interfaces_state__interface__ipv4__neighbor_entry:
         return ietf_interfaces__interfaces_state__interface__ipv4__neighbor_entry(ip=n.get_str(yang.gdata.Id(NS_ietf_ip, 'ip')), link_layer_address=n.get_opt_str(yang.gdata.Id(NS_ietf_ip, 'link-layer-address')), origin=n.get_opt_str(yang.gdata.Id(NS_ietf_ip, 'origin')))
 
-    def copy(self):
+    def copy(self) -> ietf_interfaces__interfaces_state__interface__ipv4__neighbor_entry:
         """Create a deep copy of this adata object"""
         return ietf_interfaces__interfaces_state__interface__ipv4__neighbor_entry.from_gdata(self.to_gdata())
 
 _breaker52 = None
 class ietf_interfaces__interfaces_state__interface__ipv4__neighbor(yang.adata.MNode):
     elements: list[ietf_interfaces__interfaces_state__interface__ipv4__neighbor_entry]
-    mut def __init__(self, elements=[]):
+    mut def __init__(self, elements: list[ietf_interfaces__interfaces_state__interface__ipv4__neighbor_entry]=[]) -> None:
         self._ns = 'urn:ietf:params:xml:ns:yang:ietf-ip'
         self._name = 'neighbor'
         self.elements = elements
 
-    mut def create(self, ip, link_layer_address=None, origin=None):
+    mut def create(self, ip: str, link_layer_address: ?str=None, origin: ?str=None) -> ietf_interfaces__interfaces_state__interface__ipv4__neighbor_entry:
         for e in self:
             match = True
             if e.ip != ip:
@@ -10870,7 +10870,7 @@ class ietf_interfaces__interfaces_state__interface__ipv4__neighbor(yang.adata.MN
             return [ietf_interfaces__interfaces_state__interface__ipv4__neighbor_entry.from_gdata(e) for e in n.elements]
         return []
 
-    def copy(self):
+    def copy(self) -> ietf_interfaces__interfaces_state__interface__ipv4__neighbor:
         """Create a deep copy of this list object"""
         # Copy each element in the list
         copied_elements = []
@@ -10891,7 +10891,7 @@ class ietf_interfaces__interfaces_state__interface__ipv4(yang.adata.MNode):
     address: ietf_interfaces__interfaces_state__interface__ipv4__address
     neighbor: ietf_interfaces__interfaces_state__interface__ipv4__neighbor
 
-    mut def __init__(self, forwarding: ?bool, mtu: ?u64, address: list[ietf_interfaces__interfaces_state__interface__ipv4__address_entry]=[], neighbor: list[ietf_interfaces__interfaces_state__interface__ipv4__neighbor_entry]=[]):
+    mut def __init__(self, forwarding: ?bool, mtu: ?u64, address: list[ietf_interfaces__interfaces_state__interface__ipv4__address_entry]=[], neighbor: list[ietf_interfaces__interfaces_state__interface__ipv4__neighbor_entry]=[]) -> None:
         self._ns = 'urn:ietf:params:xml:ns:yang:ietf-ip'
         self.forwarding = forwarding
         self.mtu = mtu
@@ -10917,7 +10917,7 @@ class ietf_interfaces__interfaces_state__interface__ipv4(yang.adata.MNode):
             return ietf_interfaces__interfaces_state__interface__ipv4(forwarding=n.get_opt_bool(yang.gdata.Id(NS_ietf_ip, 'forwarding')), mtu=n.get_opt_u64(yang.gdata.Id(NS_ietf_ip, 'mtu')), address=ietf_interfaces__interfaces_state__interface__ipv4__address.from_gdata(n.get_opt_list(yang.gdata.Id(NS_ietf_ip, 'address'))), neighbor=ietf_interfaces__interfaces_state__interface__ipv4__neighbor.from_gdata(n.get_opt_list(yang.gdata.Id(NS_ietf_ip, 'neighbor'))))
         return None
 
-    def copy(self):
+    def copy(self) -> ietf_interfaces__interfaces_state__interface__ipv4:
         """Create a deep copy of this adata object"""
         ad = ietf_interfaces__interfaces_state__interface__ipv4.from_gdata(self.to_gdata())
         if ad is not None:
@@ -10932,7 +10932,7 @@ class ietf_interfaces__interfaces_state__interface__ipv6__address_entry(yang.ada
     origin: ?str
     status: ?str
 
-    mut def __init__(self, ip: str, prefix_length: ?u64, origin: ?str, status: ?str):
+    mut def __init__(self, ip: str, prefix_length: ?u64, origin: ?str, status: ?str) -> None:
         self._ns = 'urn:ietf:params:xml:ns:yang:ietf-ip'
         self.ip = ip
         self.prefix_length = prefix_length
@@ -10956,19 +10956,19 @@ class ietf_interfaces__interfaces_state__interface__ipv6__address_entry(yang.ada
     mut def from_gdata(n: yang.gdata.Node) -> ietf_interfaces__interfaces_state__interface__ipv6__address_entry:
         return ietf_interfaces__interfaces_state__interface__ipv6__address_entry(ip=n.get_str(yang.gdata.Id(NS_ietf_ip, 'ip')), prefix_length=n.get_opt_u64(yang.gdata.Id(NS_ietf_ip, 'prefix-length')), origin=n.get_opt_str(yang.gdata.Id(NS_ietf_ip, 'origin')), status=n.get_opt_str(yang.gdata.Id(NS_ietf_ip, 'status')))
 
-    def copy(self):
+    def copy(self) -> ietf_interfaces__interfaces_state__interface__ipv6__address_entry:
         """Create a deep copy of this adata object"""
         return ietf_interfaces__interfaces_state__interface__ipv6__address_entry.from_gdata(self.to_gdata())
 
 _breaker55 = None
 class ietf_interfaces__interfaces_state__interface__ipv6__address(yang.adata.MNode):
     elements: list[ietf_interfaces__interfaces_state__interface__ipv6__address_entry]
-    mut def __init__(self, elements=[]):
+    mut def __init__(self, elements: list[ietf_interfaces__interfaces_state__interface__ipv6__address_entry]=[]) -> None:
         self._ns = 'urn:ietf:params:xml:ns:yang:ietf-ip'
         self._name = 'address'
         self.elements = elements
 
-    mut def create(self, ip, prefix_length=None, origin=None, status=None):
+    mut def create(self, ip: str, prefix_length: ?u64=None, origin: ?str=None, status: ?str=None) -> ietf_interfaces__interfaces_state__interface__ipv6__address_entry:
         for e in self:
             match = True
             if e.ip != ip:
@@ -10993,7 +10993,7 @@ class ietf_interfaces__interfaces_state__interface__ipv6__address(yang.adata.MNo
             return [ietf_interfaces__interfaces_state__interface__ipv6__address_entry.from_gdata(e) for e in n.elements]
         return []
 
-    def copy(self):
+    def copy(self) -> ietf_interfaces__interfaces_state__interface__ipv6__address:
         """Create a deep copy of this list object"""
         # Copy each element in the list
         copied_elements = []
@@ -11015,7 +11015,7 @@ class ietf_interfaces__interfaces_state__interface__ipv6__neighbor_entry(yang.ad
     is_router: ?bool
     state: ?str
 
-    mut def __init__(self, ip: str, link_layer_address: ?str, origin: ?str, is_router: ?bool, state: ?str):
+    mut def __init__(self, ip: str, link_layer_address: ?str, origin: ?str, is_router: ?bool, state: ?str) -> None:
         self._ns = 'urn:ietf:params:xml:ns:yang:ietf-ip'
         self.ip = ip
         self.link_layer_address = link_layer_address
@@ -11042,19 +11042,19 @@ class ietf_interfaces__interfaces_state__interface__ipv6__neighbor_entry(yang.ad
     mut def from_gdata(n: yang.gdata.Node) -> ietf_interfaces__interfaces_state__interface__ipv6__neighbor_entry:
         return ietf_interfaces__interfaces_state__interface__ipv6__neighbor_entry(ip=n.get_str(yang.gdata.Id(NS_ietf_ip, 'ip')), link_layer_address=n.get_opt_str(yang.gdata.Id(NS_ietf_ip, 'link-layer-address')), origin=n.get_opt_str(yang.gdata.Id(NS_ietf_ip, 'origin')), is_router=n.get_opt_empty(yang.gdata.Id(NS_ietf_ip, 'is-router')), state=n.get_opt_str(yang.gdata.Id(NS_ietf_ip, 'state')))
 
-    def copy(self):
+    def copy(self) -> ietf_interfaces__interfaces_state__interface__ipv6__neighbor_entry:
         """Create a deep copy of this adata object"""
         return ietf_interfaces__interfaces_state__interface__ipv6__neighbor_entry.from_gdata(self.to_gdata())
 
 _breaker57 = None
 class ietf_interfaces__interfaces_state__interface__ipv6__neighbor(yang.adata.MNode):
     elements: list[ietf_interfaces__interfaces_state__interface__ipv6__neighbor_entry]
-    mut def __init__(self, elements=[]):
+    mut def __init__(self, elements: list[ietf_interfaces__interfaces_state__interface__ipv6__neighbor_entry]=[]) -> None:
         self._ns = 'urn:ietf:params:xml:ns:yang:ietf-ip'
         self._name = 'neighbor'
         self.elements = elements
 
-    mut def create(self, ip, link_layer_address=None, origin=None, is_router=None, state=None):
+    mut def create(self, ip: str, link_layer_address: ?str=None, origin: ?str=None, is_router: ?bool=None, state: ?str=None) -> ietf_interfaces__interfaces_state__interface__ipv6__neighbor_entry:
         for e in self:
             match = True
             if e.ip != ip:
@@ -11081,7 +11081,7 @@ class ietf_interfaces__interfaces_state__interface__ipv6__neighbor(yang.adata.MN
             return [ietf_interfaces__interfaces_state__interface__ipv6__neighbor_entry.from_gdata(e) for e in n.elements]
         return []
 
-    def copy(self):
+    def copy(self) -> ietf_interfaces__interfaces_state__interface__ipv6__neighbor:
         """Create a deep copy of this list object"""
         # Copy each element in the list
         copied_elements = []
@@ -11102,7 +11102,7 @@ class ietf_interfaces__interfaces_state__interface__ipv6(yang.adata.MNode):
     address: ietf_interfaces__interfaces_state__interface__ipv6__address
     neighbor: ietf_interfaces__interfaces_state__interface__ipv6__neighbor
 
-    mut def __init__(self, forwarding: ?bool, mtu: ?u64, address: list[ietf_interfaces__interfaces_state__interface__ipv6__address_entry]=[], neighbor: list[ietf_interfaces__interfaces_state__interface__ipv6__neighbor_entry]=[]):
+    mut def __init__(self, forwarding: ?bool, mtu: ?u64, address: list[ietf_interfaces__interfaces_state__interface__ipv6__address_entry]=[], neighbor: list[ietf_interfaces__interfaces_state__interface__ipv6__neighbor_entry]=[]) -> None:
         self._ns = 'urn:ietf:params:xml:ns:yang:ietf-ip'
         self.forwarding = forwarding
         self.mtu = mtu
@@ -11128,7 +11128,7 @@ class ietf_interfaces__interfaces_state__interface__ipv6(yang.adata.MNode):
             return ietf_interfaces__interfaces_state__interface__ipv6(forwarding=n.get_opt_bool(yang.gdata.Id(NS_ietf_ip, 'forwarding')), mtu=n.get_opt_u64(yang.gdata.Id(NS_ietf_ip, 'mtu')), address=ietf_interfaces__interfaces_state__interface__ipv6__address.from_gdata(n.get_opt_list(yang.gdata.Id(NS_ietf_ip, 'address'))), neighbor=ietf_interfaces__interfaces_state__interface__ipv6__neighbor.from_gdata(n.get_opt_list(yang.gdata.Id(NS_ietf_ip, 'neighbor'))))
         return None
 
-    def copy(self):
+    def copy(self) -> ietf_interfaces__interfaces_state__interface__ipv6:
         """Create a deep copy of this adata object"""
         ad = ietf_interfaces__interfaces_state__interface__ipv6.from_gdata(self.to_gdata())
         if ad is not None:
@@ -11152,7 +11152,7 @@ class ietf_interfaces__interfaces_state__interface_entry(yang.adata.MNode):
     ipv4: ?ietf_interfaces__interfaces_state__interface__ipv4
     ipv6: ?ietf_interfaces__interfaces_state__interface__ipv6
 
-    mut def __init__(self, name: str, type: ?Identityref, admin_status: ?str, oper_status: ?str, last_change: ?str, if_index: ?int, phys_address: ?str, higher_layer_if: ?list[str]=None, lower_layer_if: ?list[str]=None, speed: ?u64, statistics: ?ietf_interfaces__interfaces_state__interface__statistics=None, ipv4: ?ietf_interfaces__interfaces_state__interface__ipv4=None, ipv6: ?ietf_interfaces__interfaces_state__interface__ipv6=None):
+    mut def __init__(self, name: str, type: ?Identityref, admin_status: ?str, oper_status: ?str, last_change: ?str, if_index: ?int, phys_address: ?str, higher_layer_if: ?list[str]=None, lower_layer_if: ?list[str]=None, speed: ?u64, statistics: ?ietf_interfaces__interfaces_state__interface__statistics=None, ipv4: ?ietf_interfaces__interfaces_state__interface__ipv4=None, ipv6: ?ietf_interfaces__interfaces_state__interface__ipv6=None) -> None:
         self._ns = 'urn:ietf:params:xml:ns:yang:ietf-interfaces'
         self.name = name
         self.type = type
@@ -11168,7 +11168,7 @@ class ietf_interfaces__interfaces_state__interface_entry(yang.adata.MNode):
         self.ipv4 = ipv4
         self.ipv6 = ipv6
 
-    mut def create_ipv4(self, forwarding=None, mtu=None):
+    mut def create_ipv4(self, forwarding: ?bool=None, mtu: ?u64=None) -> ietf_interfaces__interfaces_state__interface__ipv4:
         existing = self.ipv4
         if existing is not None:
             if forwarding is not None:
@@ -11180,7 +11180,7 @@ class ietf_interfaces__interfaces_state__interface_entry(yang.adata.MNode):
         self.ipv4 = res
         return res
 
-    mut def create_ipv6(self, forwarding=None, mtu=None):
+    mut def create_ipv6(self, forwarding: ?bool=None, mtu: ?u64=None) -> ietf_interfaces__interfaces_state__interface__ipv6:
         existing = self.ipv6
         if existing is not None:
             if forwarding is not None:
@@ -11227,19 +11227,19 @@ class ietf_interfaces__interfaces_state__interface_entry(yang.adata.MNode):
     mut def from_gdata(n: yang.gdata.Node) -> ietf_interfaces__interfaces_state__interface_entry:
         return ietf_interfaces__interfaces_state__interface_entry(name=n.get_str(yang.gdata.Id(NS_ietf_interfaces, 'name')), type=n.get_opt_Identityref(yang.gdata.Id(NS_ietf_interfaces, 'type')), admin_status=n.get_opt_str(yang.gdata.Id(NS_ietf_interfaces, 'admin-status')), oper_status=n.get_opt_str(yang.gdata.Id(NS_ietf_interfaces, 'oper-status')), last_change=n.get_opt_str(yang.gdata.Id(NS_ietf_interfaces, 'last-change')), if_index=n.get_opt_int(yang.gdata.Id(NS_ietf_interfaces, 'if-index')), phys_address=n.get_opt_str(yang.gdata.Id(NS_ietf_interfaces, 'phys-address')), higher_layer_if=n.get_opt_strs(yang.gdata.Id(NS_ietf_interfaces, 'higher-layer-if')), lower_layer_if=n.get_opt_strs(yang.gdata.Id(NS_ietf_interfaces, 'lower-layer-if')), speed=n.get_opt_u64(yang.gdata.Id(NS_ietf_interfaces, 'speed')), statistics=ietf_interfaces__interfaces_state__interface__statistics.from_gdata(n.get_opt_cnt(yang.gdata.Id(NS_ietf_interfaces, 'statistics'))), ipv4=ietf_interfaces__interfaces_state__interface__ipv4.from_gdata(n.get_opt_cnt(yang.gdata.Id(NS_ietf_ip, 'ipv4'))), ipv6=ietf_interfaces__interfaces_state__interface__ipv6.from_gdata(n.get_opt_cnt(yang.gdata.Id(NS_ietf_ip, 'ipv6'))))
 
-    def copy(self):
+    def copy(self) -> ietf_interfaces__interfaces_state__interface_entry:
         """Create a deep copy of this adata object"""
         return ietf_interfaces__interfaces_state__interface_entry.from_gdata(self.to_gdata())
 
 _breaker60 = None
 class ietf_interfaces__interfaces_state__interface(yang.adata.MNode):
     elements: list[ietf_interfaces__interfaces_state__interface_entry]
-    mut def __init__(self, elements=[]):
+    mut def __init__(self, elements: list[ietf_interfaces__interfaces_state__interface_entry]=[]) -> None:
         self._ns = 'urn:ietf:params:xml:ns:yang:ietf-interfaces'
         self._name = 'interface'
         self.elements = elements
 
-    mut def create(self, name, type=None, admin_status=None, oper_status=None, last_change=None, if_index=None, phys_address=None, speed=None):
+    mut def create(self, name: str, type: ?Identityref=None, admin_status: ?str=None, oper_status: ?str=None, last_change: ?str=None, if_index: ?int=None, phys_address: ?str=None, speed: ?u64=None) -> ietf_interfaces__interfaces_state__interface_entry:
         for e in self:
             match = True
             if e.name != name:
@@ -11272,7 +11272,7 @@ class ietf_interfaces__interfaces_state__interface(yang.adata.MNode):
             return [ietf_interfaces__interfaces_state__interface_entry.from_gdata(e) for e in n.elements]
         return []
 
-    def copy(self):
+    def copy(self) -> ietf_interfaces__interfaces_state__interface:
         """Create a deep copy of this list object"""
         # Copy each element in the list
         copied_elements = []
@@ -11290,7 +11290,7 @@ _breaker61 = None
 class ietf_interfaces__interfaces_state(yang.adata.MNode):
     interface: ietf_interfaces__interfaces_state__interface
 
-    mut def __init__(self, interface: list[ietf_interfaces__interfaces_state__interface_entry]=[]):
+    mut def __init__(self, interface: list[ietf_interfaces__interfaces_state__interface_entry]=[]) -> None:
         self._ns = 'urn:ietf:params:xml:ns:yang:ietf-interfaces'
         self.interface = ietf_interfaces__interfaces_state__interface(elements=interface)
 
@@ -11307,7 +11307,7 @@ class ietf_interfaces__interfaces_state(yang.adata.MNode):
             return ietf_interfaces__interfaces_state(interface=ietf_interfaces__interfaces_state__interface.from_gdata(n.get_opt_list(yang.gdata.Id(NS_ietf_interfaces, 'interface'))))
         return ietf_interfaces__interfaces_state()
 
-    def copy(self):
+    def copy(self) -> ietf_interfaces__interfaces_state:
         """Create a deep copy of this adata object"""
         return ietf_interfaces__interfaces_state.from_gdata(self.to_gdata())
 
@@ -11320,7 +11320,7 @@ class root(yang.adata.MNode):
     interfaces: ietf_interfaces__interfaces
     interfaces_state: ietf_interfaces__interfaces_state
 
-    mut def __init__(self, nacm: ?ietf_netconf_acm__nacm=None, system: ?ietf_system__system=None, system_state: ?ietf_system__system_state=None, interfaces: ?ietf_interfaces__interfaces=None, interfaces_state: ?ietf_interfaces__interfaces_state=None):
+    mut def __init__(self, nacm: ?ietf_netconf_acm__nacm=None, system: ?ietf_system__system=None, system_state: ?ietf_system__system_state=None, interfaces: ?ietf_interfaces__interfaces=None, interfaces_state: ?ietf_interfaces__interfaces_state=None) -> None:
         self._ns = ''
         self.nacm = nacm if nacm is not None else ietf_netconf_acm__nacm()
         self.system = system if system is not None else ietf_system__system()
@@ -11349,7 +11349,7 @@ class root(yang.adata.MNode):
             return root(nacm=ietf_netconf_acm__nacm.from_gdata(n.get_opt_cnt(yang.gdata.Id(NS_ietf_netconf_acm, 'nacm'))), system=ietf_system__system.from_gdata(n.get_opt_cnt(yang.gdata.Id(NS_ietf_system, 'system'))), system_state=ietf_system__system_state.from_gdata(n.get_opt_cnt(yang.gdata.Id(NS_ietf_system, 'system-state'))), interfaces=ietf_interfaces__interfaces.from_gdata(n.get_opt_cnt(yang.gdata.Id(NS_ietf_interfaces, 'interfaces'))), interfaces_state=ietf_interfaces__interfaces_state.from_gdata(n.get_opt_cnt(yang.gdata.Id(NS_ietf_interfaces, 'interfaces-state'))))
         return root()
 
-    def copy(self):
+    def copy(self) -> root:
         """Create a deep copy of this adata object"""
         return root.from_gdata(self.to_gdata())
 
@@ -11358,7 +11358,7 @@ _breaker63 = None
 class ietf_system__set_current_datetime__input(yang.adata.MNode):
     current_datetime: ?str
 
-    mut def __init__(self, current_datetime: ?str):
+    mut def __init__(self, current_datetime: ?str) -> None:
         self._ns = 'urn:ietf:params:xml:ns:yang:ietf-system'
         self.current_datetime = current_datetime
 
@@ -11375,7 +11375,7 @@ class ietf_system__set_current_datetime__input(yang.adata.MNode):
             return ietf_system__set_current_datetime__input(current_datetime=n.get_opt_str(yang.gdata.Id(NS_ietf_system, 'current-datetime')))
         return ietf_system__set_current_datetime__input()
 
-    def copy(self):
+    def copy(self) -> ietf_system__set_current_datetime__input:
         """Create a deep copy of this adata object"""
         return ietf_system__set_current_datetime__input.from_gdata(self.to_gdata())
 
@@ -11402,7 +11402,7 @@ actor rpc_root(tp: yang.gdata.TreeProvider):
 class ietf_netconf_acm__nacm__groups__group_subs(SubscriptionNode):
     name: SubscriptionNode
     user_name: SubscriptionNode
-    def __init__(self, path: ?SubscriptionPath=None):
+    def __init__(self, path: ?SubscriptionPath=None) -> None:
         SubscriptionNode.__init__(self, path)
         self.name = SubscriptionNode(SubscriptionPath(yang.gdata.Id(NS_ietf_netconf_acm, 'name'), parent=path))
         self.user_name = SubscriptionNode(SubscriptionPath(yang.gdata.Id(NS_ietf_netconf_acm, 'user-name'), parent=path))
@@ -11422,7 +11422,7 @@ class ietf_netconf_acm__nacm__groups__group_entry_subs(SubscriptionNode):
     name: SubscriptionNode
     user_name: SubscriptionNode
 
-    def __init__(self, path: ?SubscriptionPath=None):
+    def __init__(self, path: ?SubscriptionPath=None) -> None:
         SubscriptionNode.__init__(self, path)
         self.name = SubscriptionNode(SubscriptionPath(yang.gdata.Id(NS_ietf_netconf_acm, 'name'), parent=path))
         self.user_name = SubscriptionNode(SubscriptionPath(yang.gdata.Id(NS_ietf_netconf_acm, 'user-name'), parent=path))
@@ -11434,7 +11434,7 @@ class ietf_netconf_acm__nacm__groups__group_entry_subs(SubscriptionNode):
 class ietf_netconf_acm__nacm__groups_subs(SubscriptionNode):
     group: ietf_netconf_acm__nacm__groups__group_subs
 
-    def __init__(self, path: ?SubscriptionPath=None):
+    def __init__(self, path: ?SubscriptionPath=None) -> None:
         SubscriptionNode.__init__(self, path)
         self.group = ietf_netconf_acm__nacm__groups__group_subs(SubscriptionPath(yang.gdata.Id(NS_ietf_netconf_acm, 'group'), parent=path))
 
@@ -11451,7 +11451,7 @@ class ietf_netconf_acm__nacm__rule_list__rule_subs(SubscriptionNode):
     access_operations: SubscriptionNode
     action_: SubscriptionNode
     comment: SubscriptionNode
-    def __init__(self, path: ?SubscriptionPath=None):
+    def __init__(self, path: ?SubscriptionPath=None) -> None:
         SubscriptionNode.__init__(self, path)
         self.name = SubscriptionNode(SubscriptionPath(yang.gdata.Id(NS_ietf_netconf_acm, 'name'), parent=path))
         self.module_name = SubscriptionNode(SubscriptionPath(yang.gdata.Id(NS_ietf_netconf_acm, 'module-name'), parent=path))
@@ -11483,7 +11483,7 @@ class ietf_netconf_acm__nacm__rule_list__rule_entry_subs(SubscriptionNode):
     action_: SubscriptionNode
     comment: SubscriptionNode
 
-    def __init__(self, path: ?SubscriptionPath=None):
+    def __init__(self, path: ?SubscriptionPath=None) -> None:
         SubscriptionNode.__init__(self, path)
         self.name = SubscriptionNode(SubscriptionPath(yang.gdata.Id(NS_ietf_netconf_acm, 'name'), parent=path))
         self.module_name = SubscriptionNode(SubscriptionPath(yang.gdata.Id(NS_ietf_netconf_acm, 'module-name'), parent=path))
@@ -11502,7 +11502,7 @@ class ietf_netconf_acm__nacm__rule_list_subs(SubscriptionNode):
     name: SubscriptionNode
     group: SubscriptionNode
     rule: ietf_netconf_acm__nacm__rule_list__rule_subs
-    def __init__(self, path: ?SubscriptionPath=None):
+    def __init__(self, path: ?SubscriptionPath=None) -> None:
         SubscriptionNode.__init__(self, path)
         self.name = SubscriptionNode(SubscriptionPath(yang.gdata.Id(NS_ietf_netconf_acm, 'name'), parent=path))
         self.group = SubscriptionNode(SubscriptionPath(yang.gdata.Id(NS_ietf_netconf_acm, 'group'), parent=path))
@@ -11524,7 +11524,7 @@ class ietf_netconf_acm__nacm__rule_list_entry_subs(SubscriptionNode):
     group: SubscriptionNode
     rule: ietf_netconf_acm__nacm__rule_list__rule_subs
 
-    def __init__(self, path: ?SubscriptionPath=None):
+    def __init__(self, path: ?SubscriptionPath=None) -> None:
         SubscriptionNode.__init__(self, path)
         self.name = SubscriptionNode(SubscriptionPath(yang.gdata.Id(NS_ietf_netconf_acm, 'name'), parent=path))
         self.group = SubscriptionNode(SubscriptionPath(yang.gdata.Id(NS_ietf_netconf_acm, 'group'), parent=path))
@@ -11546,7 +11546,7 @@ class ietf_netconf_acm__nacm_subs(SubscriptionNode):
     groups: ietf_netconf_acm__nacm__groups_subs
     rule_list: ietf_netconf_acm__nacm__rule_list_subs
 
-    def __init__(self, path: ?SubscriptionPath=None):
+    def __init__(self, path: ?SubscriptionPath=None) -> None:
         SubscriptionNode.__init__(self, path)
         self.enable_nacm = SubscriptionNode(SubscriptionPath(yang.gdata.Id(NS_ietf_netconf_acm, 'enable-nacm'), parent=path))
         self.read_default = SubscriptionNode(SubscriptionPath(yang.gdata.Id(NS_ietf_netconf_acm, 'read-default'), parent=path))
@@ -11567,7 +11567,7 @@ class ietf_system__system__clock_subs(SubscriptionNode):
     timezone_name: SubscriptionNode
     timezone_utc_offset: SubscriptionNode
 
-    def __init__(self, path: ?SubscriptionPath=None):
+    def __init__(self, path: ?SubscriptionPath=None) -> None:
         SubscriptionNode.__init__(self, path)
         self.timezone_name = SubscriptionNode(SubscriptionPath(yang.gdata.Id(NS_ietf_system, 'timezone-name'), parent=path))
         self.timezone_utc_offset = SubscriptionNode(SubscriptionPath(yang.gdata.Id(NS_ietf_system, 'timezone-utc-offset'), parent=path))
@@ -11580,7 +11580,7 @@ class ietf_system__system__ntp__server__udp_subs(SubscriptionNode):
     address: SubscriptionNode
     port: SubscriptionNode
 
-    def __init__(self, path: ?SubscriptionPath=None):
+    def __init__(self, path: ?SubscriptionPath=None) -> None:
         SubscriptionNode.__init__(self, path)
         self.address = SubscriptionNode(SubscriptionPath(yang.gdata.Id(NS_ietf_system, 'address'), parent=path))
         self.port = SubscriptionNode(SubscriptionPath(yang.gdata.Id(NS_ietf_system, 'port'), parent=path))
@@ -11595,7 +11595,7 @@ class ietf_system__system__ntp__server_subs(SubscriptionNode):
     association_type: SubscriptionNode
     iburst: SubscriptionNode
     prefer: SubscriptionNode
-    def __init__(self, path: ?SubscriptionPath=None):
+    def __init__(self, path: ?SubscriptionPath=None) -> None:
         SubscriptionNode.__init__(self, path)
         self.name = SubscriptionNode(SubscriptionPath(yang.gdata.Id(NS_ietf_system, 'name'), parent=path))
         self.udp = ietf_system__system__ntp__server__udp_subs(SubscriptionPath(yang.gdata.Id(NS_ietf_system, 'udp'), parent=path))
@@ -11621,7 +11621,7 @@ class ietf_system__system__ntp__server_entry_subs(SubscriptionNode):
     iburst: SubscriptionNode
     prefer: SubscriptionNode
 
-    def __init__(self, path: ?SubscriptionPath=None):
+    def __init__(self, path: ?SubscriptionPath=None) -> None:
         SubscriptionNode.__init__(self, path)
         self.name = SubscriptionNode(SubscriptionPath(yang.gdata.Id(NS_ietf_system, 'name'), parent=path))
         self.udp = ietf_system__system__ntp__server__udp_subs(SubscriptionPath(yang.gdata.Id(NS_ietf_system, 'udp'), parent=path))
@@ -11637,7 +11637,7 @@ class ietf_system__system__ntp_subs(SubscriptionNode):
     enabled: SubscriptionNode
     server: ietf_system__system__ntp__server_subs
 
-    def __init__(self, path: ?SubscriptionPath=None):
+    def __init__(self, path: ?SubscriptionPath=None) -> None:
         SubscriptionNode.__init__(self, path)
         self.enabled = SubscriptionNode(SubscriptionPath(yang.gdata.Id(NS_ietf_system, 'enabled'), parent=path))
         self.server = ietf_system__system__ntp__server_subs(SubscriptionPath(yang.gdata.Id(NS_ietf_system, 'server'), parent=path))
@@ -11650,7 +11650,7 @@ class ietf_system__system__dns_resolver__server__udp_and_tcp_subs(SubscriptionNo
     address: SubscriptionNode
     port: SubscriptionNode
 
-    def __init__(self, path: ?SubscriptionPath=None):
+    def __init__(self, path: ?SubscriptionPath=None) -> None:
         SubscriptionNode.__init__(self, path)
         self.address = SubscriptionNode(SubscriptionPath(yang.gdata.Id(NS_ietf_system, 'address'), parent=path))
         self.port = SubscriptionNode(SubscriptionPath(yang.gdata.Id(NS_ietf_system, 'port'), parent=path))
@@ -11662,7 +11662,7 @@ class ietf_system__system__dns_resolver__server__udp_and_tcp_subs(SubscriptionNo
 class ietf_system__system__dns_resolver__server_subs(SubscriptionNode):
     name: SubscriptionNode
     udp_and_tcp: ietf_system__system__dns_resolver__server__udp_and_tcp_subs
-    def __init__(self, path: ?SubscriptionPath=None):
+    def __init__(self, path: ?SubscriptionPath=None) -> None:
         SubscriptionNode.__init__(self, path)
         self.name = SubscriptionNode(SubscriptionPath(yang.gdata.Id(NS_ietf_system, 'name'), parent=path))
         self.udp_and_tcp = ietf_system__system__dns_resolver__server__udp_and_tcp_subs(SubscriptionPath(yang.gdata.Id(NS_ietf_system, 'udp-and-tcp'), parent=path))
@@ -11682,7 +11682,7 @@ class ietf_system__system__dns_resolver__server_entry_subs(SubscriptionNode):
     name: SubscriptionNode
     udp_and_tcp: ietf_system__system__dns_resolver__server__udp_and_tcp_subs
 
-    def __init__(self, path: ?SubscriptionPath=None):
+    def __init__(self, path: ?SubscriptionPath=None) -> None:
         SubscriptionNode.__init__(self, path)
         self.name = SubscriptionNode(SubscriptionPath(yang.gdata.Id(NS_ietf_system, 'name'), parent=path))
         self.udp_and_tcp = ietf_system__system__dns_resolver__server__udp_and_tcp_subs(SubscriptionPath(yang.gdata.Id(NS_ietf_system, 'udp-and-tcp'), parent=path))
@@ -11695,7 +11695,7 @@ class ietf_system__system__dns_resolver__options_subs(SubscriptionNode):
     timeout: SubscriptionNode
     attempts: SubscriptionNode
 
-    def __init__(self, path: ?SubscriptionPath=None):
+    def __init__(self, path: ?SubscriptionPath=None) -> None:
         SubscriptionNode.__init__(self, path)
         self.timeout = SubscriptionNode(SubscriptionPath(yang.gdata.Id(NS_ietf_system, 'timeout'), parent=path))
         self.attempts = SubscriptionNode(SubscriptionPath(yang.gdata.Id(NS_ietf_system, 'attempts'), parent=path))
@@ -11709,7 +11709,7 @@ class ietf_system__system__dns_resolver_subs(SubscriptionNode):
     server: ietf_system__system__dns_resolver__server_subs
     options: ietf_system__system__dns_resolver__options_subs
 
-    def __init__(self, path: ?SubscriptionPath=None):
+    def __init__(self, path: ?SubscriptionPath=None) -> None:
         SubscriptionNode.__init__(self, path)
         self.search = SubscriptionNode(SubscriptionPath(yang.gdata.Id(NS_ietf_system, 'search'), parent=path))
         self.server = ietf_system__system__dns_resolver__server_subs(SubscriptionPath(yang.gdata.Id(NS_ietf_system, 'server'), parent=path))
@@ -11724,7 +11724,7 @@ class ietf_system__system__radius__server__udp_subs(SubscriptionNode):
     authentication_port: SubscriptionNode
     shared_secret: SubscriptionNode
 
-    def __init__(self, path: ?SubscriptionPath=None):
+    def __init__(self, path: ?SubscriptionPath=None) -> None:
         SubscriptionNode.__init__(self, path)
         self.address = SubscriptionNode(SubscriptionPath(yang.gdata.Id(NS_ietf_system, 'address'), parent=path))
         self.authentication_port = SubscriptionNode(SubscriptionPath(yang.gdata.Id(NS_ietf_system, 'authentication-port'), parent=path))
@@ -11738,7 +11738,7 @@ class ietf_system__system__radius__server_subs(SubscriptionNode):
     name: SubscriptionNode
     udp: ietf_system__system__radius__server__udp_subs
     authentication_type: SubscriptionNode
-    def __init__(self, path: ?SubscriptionPath=None):
+    def __init__(self, path: ?SubscriptionPath=None) -> None:
         SubscriptionNode.__init__(self, path)
         self.name = SubscriptionNode(SubscriptionPath(yang.gdata.Id(NS_ietf_system, 'name'), parent=path))
         self.udp = ietf_system__system__radius__server__udp_subs(SubscriptionPath(yang.gdata.Id(NS_ietf_system, 'udp'), parent=path))
@@ -11760,7 +11760,7 @@ class ietf_system__system__radius__server_entry_subs(SubscriptionNode):
     udp: ietf_system__system__radius__server__udp_subs
     authentication_type: SubscriptionNode
 
-    def __init__(self, path: ?SubscriptionPath=None):
+    def __init__(self, path: ?SubscriptionPath=None) -> None:
         SubscriptionNode.__init__(self, path)
         self.name = SubscriptionNode(SubscriptionPath(yang.gdata.Id(NS_ietf_system, 'name'), parent=path))
         self.udp = ietf_system__system__radius__server__udp_subs(SubscriptionPath(yang.gdata.Id(NS_ietf_system, 'udp'), parent=path))
@@ -11774,7 +11774,7 @@ class ietf_system__system__radius__options_subs(SubscriptionNode):
     timeout: SubscriptionNode
     attempts: SubscriptionNode
 
-    def __init__(self, path: ?SubscriptionPath=None):
+    def __init__(self, path: ?SubscriptionPath=None) -> None:
         SubscriptionNode.__init__(self, path)
         self.timeout = SubscriptionNode(SubscriptionPath(yang.gdata.Id(NS_ietf_system, 'timeout'), parent=path))
         self.attempts = SubscriptionNode(SubscriptionPath(yang.gdata.Id(NS_ietf_system, 'attempts'), parent=path))
@@ -11787,7 +11787,7 @@ class ietf_system__system__radius_subs(SubscriptionNode):
     server: ietf_system__system__radius__server_subs
     options: ietf_system__system__radius__options_subs
 
-    def __init__(self, path: ?SubscriptionPath=None):
+    def __init__(self, path: ?SubscriptionPath=None) -> None:
         SubscriptionNode.__init__(self, path)
         self.server = ietf_system__system__radius__server_subs(SubscriptionPath(yang.gdata.Id(NS_ietf_system, 'server'), parent=path))
         self.options = ietf_system__system__radius__options_subs(SubscriptionPath(yang.gdata.Id(NS_ietf_system, 'options'), parent=path))
@@ -11800,7 +11800,7 @@ class ietf_system__system__authentication__user__authorized_key_subs(Subscriptio
     name: SubscriptionNode
     algorithm: SubscriptionNode
     key_data: SubscriptionNode
-    def __init__(self, path: ?SubscriptionPath=None):
+    def __init__(self, path: ?SubscriptionPath=None) -> None:
         SubscriptionNode.__init__(self, path)
         self.name = SubscriptionNode(SubscriptionPath(yang.gdata.Id(NS_ietf_system, 'name'), parent=path))
         self.algorithm = SubscriptionNode(SubscriptionPath(yang.gdata.Id(NS_ietf_system, 'algorithm'), parent=path))
@@ -11822,7 +11822,7 @@ class ietf_system__system__authentication__user__authorized_key_entry_subs(Subsc
     algorithm: SubscriptionNode
     key_data: SubscriptionNode
 
-    def __init__(self, path: ?SubscriptionPath=None):
+    def __init__(self, path: ?SubscriptionPath=None) -> None:
         SubscriptionNode.__init__(self, path)
         self.name = SubscriptionNode(SubscriptionPath(yang.gdata.Id(NS_ietf_system, 'name'), parent=path))
         self.algorithm = SubscriptionNode(SubscriptionPath(yang.gdata.Id(NS_ietf_system, 'algorithm'), parent=path))
@@ -11836,7 +11836,7 @@ class ietf_system__system__authentication__user_subs(SubscriptionNode):
     name: SubscriptionNode
     password: SubscriptionNode
     authorized_key: ietf_system__system__authentication__user__authorized_key_subs
-    def __init__(self, path: ?SubscriptionPath=None):
+    def __init__(self, path: ?SubscriptionPath=None) -> None:
         SubscriptionNode.__init__(self, path)
         self.name = SubscriptionNode(SubscriptionPath(yang.gdata.Id(NS_ietf_system, 'name'), parent=path))
         self.password = SubscriptionNode(SubscriptionPath(yang.gdata.Id(NS_ietf_system, 'password'), parent=path))
@@ -11858,7 +11858,7 @@ class ietf_system__system__authentication__user_entry_subs(SubscriptionNode):
     password: SubscriptionNode
     authorized_key: ietf_system__system__authentication__user__authorized_key_subs
 
-    def __init__(self, path: ?SubscriptionPath=None):
+    def __init__(self, path: ?SubscriptionPath=None) -> None:
         SubscriptionNode.__init__(self, path)
         self.name = SubscriptionNode(SubscriptionPath(yang.gdata.Id(NS_ietf_system, 'name'), parent=path))
         self.password = SubscriptionNode(SubscriptionPath(yang.gdata.Id(NS_ietf_system, 'password'), parent=path))
@@ -11872,7 +11872,7 @@ class ietf_system__system__authentication_subs(SubscriptionNode):
     user_authentication_order: SubscriptionNode
     user: ietf_system__system__authentication__user_subs
 
-    def __init__(self, path: ?SubscriptionPath=None):
+    def __init__(self, path: ?SubscriptionPath=None) -> None:
         SubscriptionNode.__init__(self, path)
         self.user_authentication_order = SubscriptionNode(SubscriptionPath(yang.gdata.Id(NS_ietf_system, 'user-authentication-order'), parent=path))
         self.user = ietf_system__system__authentication__user_subs(SubscriptionPath(yang.gdata.Id(NS_ietf_system, 'user'), parent=path))
@@ -11891,7 +11891,7 @@ class ietf_system__system_subs(SubscriptionNode):
     radius: ietf_system__system__radius_subs
     authentication: ietf_system__system__authentication_subs
 
-    def __init__(self, path: ?SubscriptionPath=None):
+    def __init__(self, path: ?SubscriptionPath=None) -> None:
         SubscriptionNode.__init__(self, path)
         self.contact = SubscriptionNode(SubscriptionPath(yang.gdata.Id(NS_ietf_system, 'contact'), parent=path))
         self.hostname = SubscriptionNode(SubscriptionPath(yang.gdata.Id(NS_ietf_system, 'hostname'), parent=path))
@@ -11912,7 +11912,7 @@ class ietf_system__system_state__platform_subs(SubscriptionNode):
     os_version: SubscriptionNode
     machine: SubscriptionNode
 
-    def __init__(self, path: ?SubscriptionPath=None):
+    def __init__(self, path: ?SubscriptionPath=None) -> None:
         SubscriptionNode.__init__(self, path)
         self.os_name = SubscriptionNode(SubscriptionPath(yang.gdata.Id(NS_ietf_system, 'os-name'), parent=path))
         self.os_release = SubscriptionNode(SubscriptionPath(yang.gdata.Id(NS_ietf_system, 'os-release'), parent=path))
@@ -11927,7 +11927,7 @@ class ietf_system__system_state__clock_subs(SubscriptionNode):
     current_datetime: SubscriptionNode
     boot_datetime: SubscriptionNode
 
-    def __init__(self, path: ?SubscriptionPath=None):
+    def __init__(self, path: ?SubscriptionPath=None) -> None:
         SubscriptionNode.__init__(self, path)
         self.current_datetime = SubscriptionNode(SubscriptionPath(yang.gdata.Id(NS_ietf_system, 'current-datetime'), parent=path))
         self.boot_datetime = SubscriptionNode(SubscriptionPath(yang.gdata.Id(NS_ietf_system, 'boot-datetime'), parent=path))
@@ -11940,7 +11940,7 @@ class ietf_system__system_state_subs(SubscriptionNode):
     platform: ietf_system__system_state__platform_subs
     clock: ietf_system__system_state__clock_subs
 
-    def __init__(self, path: ?SubscriptionPath=None):
+    def __init__(self, path: ?SubscriptionPath=None) -> None:
         SubscriptionNode.__init__(self, path)
         self.platform = ietf_system__system_state__platform_subs(SubscriptionPath(yang.gdata.Id(NS_ietf_system, 'platform'), parent=path))
         self.clock = ietf_system__system_state__clock_subs(SubscriptionPath(yang.gdata.Id(NS_ietf_system, 'clock'), parent=path))
@@ -11965,7 +11965,7 @@ class ietf_interfaces__interfaces__interface__statistics_subs(SubscriptionNode):
     out_discards: SubscriptionNode
     out_errors: SubscriptionNode
 
-    def __init__(self, path: ?SubscriptionPath=None):
+    def __init__(self, path: ?SubscriptionPath=None) -> None:
         SubscriptionNode.__init__(self, path)
         self.discontinuity_time = SubscriptionNode(SubscriptionPath(yang.gdata.Id(NS_ietf_interfaces, 'discontinuity-time'), parent=path))
         self.in_octets = SubscriptionNode(SubscriptionPath(yang.gdata.Id(NS_ietf_interfaces, 'in-octets'), parent=path))
@@ -11991,7 +11991,7 @@ class ietf_interfaces__interfaces__interface__ipv4__address_subs(SubscriptionNod
     prefix_length: SubscriptionNode
     netmask: SubscriptionNode
     origin: SubscriptionNode
-    def __init__(self, path: ?SubscriptionPath=None):
+    def __init__(self, path: ?SubscriptionPath=None) -> None:
         SubscriptionNode.__init__(self, path)
         self.ip = SubscriptionNode(SubscriptionPath(yang.gdata.Id(NS_ietf_ip, 'ip'), parent=path))
         self.prefix_length = SubscriptionNode(SubscriptionPath(yang.gdata.Id(NS_ietf_ip, 'prefix-length'), parent=path))
@@ -12015,7 +12015,7 @@ class ietf_interfaces__interfaces__interface__ipv4__address_entry_subs(Subscript
     netmask: SubscriptionNode
     origin: SubscriptionNode
 
-    def __init__(self, path: ?SubscriptionPath=None):
+    def __init__(self, path: ?SubscriptionPath=None) -> None:
         SubscriptionNode.__init__(self, path)
         self.ip = SubscriptionNode(SubscriptionPath(yang.gdata.Id(NS_ietf_ip, 'ip'), parent=path))
         self.prefix_length = SubscriptionNode(SubscriptionPath(yang.gdata.Id(NS_ietf_ip, 'prefix-length'), parent=path))
@@ -12030,7 +12030,7 @@ class ietf_interfaces__interfaces__interface__ipv4__neighbor_subs(SubscriptionNo
     ip: SubscriptionNode
     link_layer_address: SubscriptionNode
     origin: SubscriptionNode
-    def __init__(self, path: ?SubscriptionPath=None):
+    def __init__(self, path: ?SubscriptionPath=None) -> None:
         SubscriptionNode.__init__(self, path)
         self.ip = SubscriptionNode(SubscriptionPath(yang.gdata.Id(NS_ietf_ip, 'ip'), parent=path))
         self.link_layer_address = SubscriptionNode(SubscriptionPath(yang.gdata.Id(NS_ietf_ip, 'link-layer-address'), parent=path))
@@ -12052,7 +12052,7 @@ class ietf_interfaces__interfaces__interface__ipv4__neighbor_entry_subs(Subscrip
     link_layer_address: SubscriptionNode
     origin: SubscriptionNode
 
-    def __init__(self, path: ?SubscriptionPath=None):
+    def __init__(self, path: ?SubscriptionPath=None) -> None:
         SubscriptionNode.__init__(self, path)
         self.ip = SubscriptionNode(SubscriptionPath(yang.gdata.Id(NS_ietf_ip, 'ip'), parent=path))
         self.link_layer_address = SubscriptionNode(SubscriptionPath(yang.gdata.Id(NS_ietf_ip, 'link-layer-address'), parent=path))
@@ -12069,7 +12069,7 @@ class ietf_interfaces__interfaces__interface__ipv4_subs(SubscriptionNode):
     address: ietf_interfaces__interfaces__interface__ipv4__address_subs
     neighbor: ietf_interfaces__interfaces__interface__ipv4__neighbor_subs
 
-    def __init__(self, path: ?SubscriptionPath=None):
+    def __init__(self, path: ?SubscriptionPath=None) -> None:
         SubscriptionNode.__init__(self, path)
         self.enabled = SubscriptionNode(SubscriptionPath(yang.gdata.Id(NS_ietf_ip, 'enabled'), parent=path))
         self.forwarding = SubscriptionNode(SubscriptionPath(yang.gdata.Id(NS_ietf_ip, 'forwarding'), parent=path))
@@ -12086,7 +12086,7 @@ class ietf_interfaces__interfaces__interface__ipv6__address_subs(SubscriptionNod
     prefix_length: SubscriptionNode
     origin: SubscriptionNode
     status: SubscriptionNode
-    def __init__(self, path: ?SubscriptionPath=None):
+    def __init__(self, path: ?SubscriptionPath=None) -> None:
         SubscriptionNode.__init__(self, path)
         self.ip = SubscriptionNode(SubscriptionPath(yang.gdata.Id(NS_ietf_ip, 'ip'), parent=path))
         self.prefix_length = SubscriptionNode(SubscriptionPath(yang.gdata.Id(NS_ietf_ip, 'prefix-length'), parent=path))
@@ -12110,7 +12110,7 @@ class ietf_interfaces__interfaces__interface__ipv6__address_entry_subs(Subscript
     origin: SubscriptionNode
     status: SubscriptionNode
 
-    def __init__(self, path: ?SubscriptionPath=None):
+    def __init__(self, path: ?SubscriptionPath=None) -> None:
         SubscriptionNode.__init__(self, path)
         self.ip = SubscriptionNode(SubscriptionPath(yang.gdata.Id(NS_ietf_ip, 'ip'), parent=path))
         self.prefix_length = SubscriptionNode(SubscriptionPath(yang.gdata.Id(NS_ietf_ip, 'prefix-length'), parent=path))
@@ -12127,7 +12127,7 @@ class ietf_interfaces__interfaces__interface__ipv6__neighbor_subs(SubscriptionNo
     origin: SubscriptionNode
     is_router: SubscriptionNode
     state: SubscriptionNode
-    def __init__(self, path: ?SubscriptionPath=None):
+    def __init__(self, path: ?SubscriptionPath=None) -> None:
         SubscriptionNode.__init__(self, path)
         self.ip = SubscriptionNode(SubscriptionPath(yang.gdata.Id(NS_ietf_ip, 'ip'), parent=path))
         self.link_layer_address = SubscriptionNode(SubscriptionPath(yang.gdata.Id(NS_ietf_ip, 'link-layer-address'), parent=path))
@@ -12153,7 +12153,7 @@ class ietf_interfaces__interfaces__interface__ipv6__neighbor_entry_subs(Subscrip
     is_router: SubscriptionNode
     state: SubscriptionNode
 
-    def __init__(self, path: ?SubscriptionPath=None):
+    def __init__(self, path: ?SubscriptionPath=None) -> None:
         SubscriptionNode.__init__(self, path)
         self.ip = SubscriptionNode(SubscriptionPath(yang.gdata.Id(NS_ietf_ip, 'ip'), parent=path))
         self.link_layer_address = SubscriptionNode(SubscriptionPath(yang.gdata.Id(NS_ietf_ip, 'link-layer-address'), parent=path))
@@ -12171,7 +12171,7 @@ class ietf_interfaces__interfaces__interface__ipv6__autoconf_subs(SubscriptionNo
     temporary_valid_lifetime: SubscriptionNode
     temporary_preferred_lifetime: SubscriptionNode
 
-    def __init__(self, path: ?SubscriptionPath=None):
+    def __init__(self, path: ?SubscriptionPath=None) -> None:
         SubscriptionNode.__init__(self, path)
         self.create_global_addresses = SubscriptionNode(SubscriptionPath(yang.gdata.Id(NS_ietf_ip, 'create-global-addresses'), parent=path))
         self.create_temporary_addresses = SubscriptionNode(SubscriptionPath(yang.gdata.Id(NS_ietf_ip, 'create-temporary-addresses'), parent=path))
@@ -12191,7 +12191,7 @@ class ietf_interfaces__interfaces__interface__ipv6_subs(SubscriptionNode):
     dup_addr_detect_transmits: SubscriptionNode
     autoconf: ietf_interfaces__interfaces__interface__ipv6__autoconf_subs
 
-    def __init__(self, path: ?SubscriptionPath=None):
+    def __init__(self, path: ?SubscriptionPath=None) -> None:
         SubscriptionNode.__init__(self, path)
         self.enabled = SubscriptionNode(SubscriptionPath(yang.gdata.Id(NS_ietf_ip, 'enabled'), parent=path))
         self.forwarding = SubscriptionNode(SubscriptionPath(yang.gdata.Id(NS_ietf_ip, 'forwarding'), parent=path))
@@ -12222,7 +12222,7 @@ class ietf_interfaces__interfaces__interface_subs(SubscriptionNode):
     statistics: ietf_interfaces__interfaces__interface__statistics_subs
     ipv4: ietf_interfaces__interfaces__interface__ipv4_subs
     ipv6: ietf_interfaces__interfaces__interface__ipv6_subs
-    def __init__(self, path: ?SubscriptionPath=None):
+    def __init__(self, path: ?SubscriptionPath=None) -> None:
         SubscriptionNode.__init__(self, path)
         self.name = SubscriptionNode(SubscriptionPath(yang.gdata.Id(NS_ietf_interfaces, 'name'), parent=path))
         self.description = SubscriptionNode(SubscriptionPath(yang.gdata.Id(NS_ietf_interfaces, 'description'), parent=path))
@@ -12270,7 +12270,7 @@ class ietf_interfaces__interfaces__interface_entry_subs(SubscriptionNode):
     ipv4: ietf_interfaces__interfaces__interface__ipv4_subs
     ipv6: ietf_interfaces__interfaces__interface__ipv6_subs
 
-    def __init__(self, path: ?SubscriptionPath=None):
+    def __init__(self, path: ?SubscriptionPath=None) -> None:
         SubscriptionNode.__init__(self, path)
         self.name = SubscriptionNode(SubscriptionPath(yang.gdata.Id(NS_ietf_interfaces, 'name'), parent=path))
         self.description = SubscriptionNode(SubscriptionPath(yang.gdata.Id(NS_ietf_interfaces, 'description'), parent=path))
@@ -12296,7 +12296,7 @@ class ietf_interfaces__interfaces__interface_entry_subs(SubscriptionNode):
 class ietf_interfaces__interfaces_subs(SubscriptionNode):
     interface: ietf_interfaces__interfaces__interface_subs
 
-    def __init__(self, path: ?SubscriptionPath=None):
+    def __init__(self, path: ?SubscriptionPath=None) -> None:
         SubscriptionNode.__init__(self, path)
         self.interface = ietf_interfaces__interfaces__interface_subs(SubscriptionPath(yang.gdata.Id(NS_ietf_interfaces, 'interface'), parent=path))
 
@@ -12320,7 +12320,7 @@ class ietf_interfaces__interfaces_state__interface__statistics_subs(Subscription
     out_discards: SubscriptionNode
     out_errors: SubscriptionNode
 
-    def __init__(self, path: ?SubscriptionPath=None):
+    def __init__(self, path: ?SubscriptionPath=None) -> None:
         SubscriptionNode.__init__(self, path)
         self.discontinuity_time = SubscriptionNode(SubscriptionPath(yang.gdata.Id(NS_ietf_interfaces, 'discontinuity-time'), parent=path))
         self.in_octets = SubscriptionNode(SubscriptionPath(yang.gdata.Id(NS_ietf_interfaces, 'in-octets'), parent=path))
@@ -12346,7 +12346,7 @@ class ietf_interfaces__interfaces_state__interface__ipv4__address_subs(Subscript
     prefix_length: SubscriptionNode
     netmask: SubscriptionNode
     origin: SubscriptionNode
-    def __init__(self, path: ?SubscriptionPath=None):
+    def __init__(self, path: ?SubscriptionPath=None) -> None:
         SubscriptionNode.__init__(self, path)
         self.ip = SubscriptionNode(SubscriptionPath(yang.gdata.Id(NS_ietf_ip, 'ip'), parent=path))
         self.prefix_length = SubscriptionNode(SubscriptionPath(yang.gdata.Id(NS_ietf_ip, 'prefix-length'), parent=path))
@@ -12370,7 +12370,7 @@ class ietf_interfaces__interfaces_state__interface__ipv4__address_entry_subs(Sub
     netmask: SubscriptionNode
     origin: SubscriptionNode
 
-    def __init__(self, path: ?SubscriptionPath=None):
+    def __init__(self, path: ?SubscriptionPath=None) -> None:
         SubscriptionNode.__init__(self, path)
         self.ip = SubscriptionNode(SubscriptionPath(yang.gdata.Id(NS_ietf_ip, 'ip'), parent=path))
         self.prefix_length = SubscriptionNode(SubscriptionPath(yang.gdata.Id(NS_ietf_ip, 'prefix-length'), parent=path))
@@ -12385,7 +12385,7 @@ class ietf_interfaces__interfaces_state__interface__ipv4__neighbor_subs(Subscrip
     ip: SubscriptionNode
     link_layer_address: SubscriptionNode
     origin: SubscriptionNode
-    def __init__(self, path: ?SubscriptionPath=None):
+    def __init__(self, path: ?SubscriptionPath=None) -> None:
         SubscriptionNode.__init__(self, path)
         self.ip = SubscriptionNode(SubscriptionPath(yang.gdata.Id(NS_ietf_ip, 'ip'), parent=path))
         self.link_layer_address = SubscriptionNode(SubscriptionPath(yang.gdata.Id(NS_ietf_ip, 'link-layer-address'), parent=path))
@@ -12407,7 +12407,7 @@ class ietf_interfaces__interfaces_state__interface__ipv4__neighbor_entry_subs(Su
     link_layer_address: SubscriptionNode
     origin: SubscriptionNode
 
-    def __init__(self, path: ?SubscriptionPath=None):
+    def __init__(self, path: ?SubscriptionPath=None) -> None:
         SubscriptionNode.__init__(self, path)
         self.ip = SubscriptionNode(SubscriptionPath(yang.gdata.Id(NS_ietf_ip, 'ip'), parent=path))
         self.link_layer_address = SubscriptionNode(SubscriptionPath(yang.gdata.Id(NS_ietf_ip, 'link-layer-address'), parent=path))
@@ -12423,7 +12423,7 @@ class ietf_interfaces__interfaces_state__interface__ipv4_subs(SubscriptionNode):
     address: ietf_interfaces__interfaces_state__interface__ipv4__address_subs
     neighbor: ietf_interfaces__interfaces_state__interface__ipv4__neighbor_subs
 
-    def __init__(self, path: ?SubscriptionPath=None):
+    def __init__(self, path: ?SubscriptionPath=None) -> None:
         SubscriptionNode.__init__(self, path)
         self.forwarding = SubscriptionNode(SubscriptionPath(yang.gdata.Id(NS_ietf_ip, 'forwarding'), parent=path))
         self.mtu = SubscriptionNode(SubscriptionPath(yang.gdata.Id(NS_ietf_ip, 'mtu'), parent=path))
@@ -12439,7 +12439,7 @@ class ietf_interfaces__interfaces_state__interface__ipv6__address_subs(Subscript
     prefix_length: SubscriptionNode
     origin: SubscriptionNode
     status: SubscriptionNode
-    def __init__(self, path: ?SubscriptionPath=None):
+    def __init__(self, path: ?SubscriptionPath=None) -> None:
         SubscriptionNode.__init__(self, path)
         self.ip = SubscriptionNode(SubscriptionPath(yang.gdata.Id(NS_ietf_ip, 'ip'), parent=path))
         self.prefix_length = SubscriptionNode(SubscriptionPath(yang.gdata.Id(NS_ietf_ip, 'prefix-length'), parent=path))
@@ -12463,7 +12463,7 @@ class ietf_interfaces__interfaces_state__interface__ipv6__address_entry_subs(Sub
     origin: SubscriptionNode
     status: SubscriptionNode
 
-    def __init__(self, path: ?SubscriptionPath=None):
+    def __init__(self, path: ?SubscriptionPath=None) -> None:
         SubscriptionNode.__init__(self, path)
         self.ip = SubscriptionNode(SubscriptionPath(yang.gdata.Id(NS_ietf_ip, 'ip'), parent=path))
         self.prefix_length = SubscriptionNode(SubscriptionPath(yang.gdata.Id(NS_ietf_ip, 'prefix-length'), parent=path))
@@ -12480,7 +12480,7 @@ class ietf_interfaces__interfaces_state__interface__ipv6__neighbor_subs(Subscrip
     origin: SubscriptionNode
     is_router: SubscriptionNode
     state: SubscriptionNode
-    def __init__(self, path: ?SubscriptionPath=None):
+    def __init__(self, path: ?SubscriptionPath=None) -> None:
         SubscriptionNode.__init__(self, path)
         self.ip = SubscriptionNode(SubscriptionPath(yang.gdata.Id(NS_ietf_ip, 'ip'), parent=path))
         self.link_layer_address = SubscriptionNode(SubscriptionPath(yang.gdata.Id(NS_ietf_ip, 'link-layer-address'), parent=path))
@@ -12506,7 +12506,7 @@ class ietf_interfaces__interfaces_state__interface__ipv6__neighbor_entry_subs(Su
     is_router: SubscriptionNode
     state: SubscriptionNode
 
-    def __init__(self, path: ?SubscriptionPath=None):
+    def __init__(self, path: ?SubscriptionPath=None) -> None:
         SubscriptionNode.__init__(self, path)
         self.ip = SubscriptionNode(SubscriptionPath(yang.gdata.Id(NS_ietf_ip, 'ip'), parent=path))
         self.link_layer_address = SubscriptionNode(SubscriptionPath(yang.gdata.Id(NS_ietf_ip, 'link-layer-address'), parent=path))
@@ -12524,7 +12524,7 @@ class ietf_interfaces__interfaces_state__interface__ipv6_subs(SubscriptionNode):
     address: ietf_interfaces__interfaces_state__interface__ipv6__address_subs
     neighbor: ietf_interfaces__interfaces_state__interface__ipv6__neighbor_subs
 
-    def __init__(self, path: ?SubscriptionPath=None):
+    def __init__(self, path: ?SubscriptionPath=None) -> None:
         SubscriptionNode.__init__(self, path)
         self.forwarding = SubscriptionNode(SubscriptionPath(yang.gdata.Id(NS_ietf_ip, 'forwarding'), parent=path))
         self.mtu = SubscriptionNode(SubscriptionPath(yang.gdata.Id(NS_ietf_ip, 'mtu'), parent=path))
@@ -12549,7 +12549,7 @@ class ietf_interfaces__interfaces_state__interface_subs(SubscriptionNode):
     statistics: ietf_interfaces__interfaces_state__interface__statistics_subs
     ipv4: ietf_interfaces__interfaces_state__interface__ipv4_subs
     ipv6: ietf_interfaces__interfaces_state__interface__ipv6_subs
-    def __init__(self, path: ?SubscriptionPath=None):
+    def __init__(self, path: ?SubscriptionPath=None) -> None:
         SubscriptionNode.__init__(self, path)
         self.name = SubscriptionNode(SubscriptionPath(yang.gdata.Id(NS_ietf_interfaces, 'name'), parent=path))
         self.type = SubscriptionNode(SubscriptionPath(yang.gdata.Id(NS_ietf_interfaces, 'type'), parent=path))
@@ -12591,7 +12591,7 @@ class ietf_interfaces__interfaces_state__interface_entry_subs(SubscriptionNode):
     ipv4: ietf_interfaces__interfaces_state__interface__ipv4_subs
     ipv6: ietf_interfaces__interfaces_state__interface__ipv6_subs
 
-    def __init__(self, path: ?SubscriptionPath=None):
+    def __init__(self, path: ?SubscriptionPath=None) -> None:
         SubscriptionNode.__init__(self, path)
         self.name = SubscriptionNode(SubscriptionPath(yang.gdata.Id(NS_ietf_interfaces, 'name'), parent=path))
         self.type = SubscriptionNode(SubscriptionPath(yang.gdata.Id(NS_ietf_interfaces, 'type'), parent=path))
@@ -12614,7 +12614,7 @@ class ietf_interfaces__interfaces_state__interface_entry_subs(SubscriptionNode):
 class ietf_interfaces__interfaces_state_subs(SubscriptionNode):
     interface: ietf_interfaces__interfaces_state__interface_subs
 
-    def __init__(self, path: ?SubscriptionPath=None):
+    def __init__(self, path: ?SubscriptionPath=None) -> None:
         SubscriptionNode.__init__(self, path)
         self.interface = ietf_interfaces__interfaces_state__interface_subs(SubscriptionPath(yang.gdata.Id(NS_ietf_interfaces, 'interface'), parent=path))
 
@@ -12629,7 +12629,7 @@ class root_subs(SubscriptionNode):
     interfaces: ietf_interfaces__interfaces_subs
     interfaces_state: ietf_interfaces__interfaces_state_subs
 
-    def __init__(self, path: ?SubscriptionPath=None):
+    def __init__(self, path: ?SubscriptionPath=None) -> None:
         SubscriptionNode.__init__(self, path)
         self.nacm = ietf_netconf_acm__nacm_subs(SubscriptionPath(yang.gdata.Id(NS_ietf_netconf_acm, 'nacm'), parent=path))
         self.system = ietf_system__system_subs(SubscriptionPath(yang.gdata.Id(NS_ietf_system, 'system'), parent=path))

--- a/minisys/src/mini/layers/y_0.act
+++ b/minisys/src/mini/layers/y_0.act
@@ -781,7 +781,7 @@ _breaker1 = None
 class netinfra__netinfra__global_settings(yang.adata.MNode):
     asn: ?u64
 
-    mut def __init__(self, asn: ?u64):
+    mut def __init__(self, asn: ?u64) -> None:
         self._ns = 'http://example.com/netinfra'
         self.asn = asn
 
@@ -798,7 +798,7 @@ class netinfra__netinfra__global_settings(yang.adata.MNode):
             return netinfra__netinfra__global_settings(asn=n.get_opt_u64(yang.gdata.Id(NS_netinfra, 'asn')))
         return netinfra__netinfra__global_settings()
 
-    def copy(self):
+    def copy(self) -> netinfra__netinfra__global_settings:
         """Create a deep copy of this adata object"""
         return netinfra__netinfra__global_settings.from_gdata(self.to_gdata())
 
@@ -807,7 +807,7 @@ _breaker2 = None
 class netinfra__netinfra__router__dynstate(yang.adata.MNode):
     current_datetime: ?str
 
-    mut def __init__(self, current_datetime: ?str):
+    mut def __init__(self, current_datetime: ?str) -> None:
         self._ns = 'http://example.com/netinfra'
         self.current_datetime = current_datetime
 
@@ -824,7 +824,7 @@ class netinfra__netinfra__router__dynstate(yang.adata.MNode):
             return netinfra__netinfra__router__dynstate(current_datetime=n.get_opt_str(yang.gdata.Id(NS_netinfra, 'current-datetime')))
         return netinfra__netinfra__router__dynstate()
 
-    def copy(self):
+    def copy(self) -> netinfra__netinfra__router__dynstate:
         """Create a deep copy of this adata object"""
         return netinfra__netinfra__router__dynstate.from_gdata(self.to_gdata())
 
@@ -836,7 +836,7 @@ class netinfra__netinfra__router_entry(yang.adata.MNode):
     type: str
     mock: bool
 
-    mut def __init__(self, name: str, id: u64, type: str, mock: ?bool=None):
+    mut def __init__(self, name: str, id: u64, type: str, mock: ?bool=None) -> None:
         self._ns = 'http://example.com/netinfra'
         self.name = name
         self.id = id
@@ -860,19 +860,19 @@ class netinfra__netinfra__router_entry(yang.adata.MNode):
     mut def from_gdata(n: yang.gdata.Node) -> netinfra__netinfra__router_entry:
         return netinfra__netinfra__router_entry(name=n.get_str(yang.gdata.Id(NS_netinfra, 'name')), id=n.get_u64(yang.gdata.Id(NS_netinfra, 'id')), type=n.get_str(yang.gdata.Id(NS_netinfra, 'type')), mock=n.get_opt_bool(yang.gdata.Id(NS_netinfra, 'mock')))
 
-    def copy(self):
+    def copy(self) -> netinfra__netinfra__router_entry:
         """Create a deep copy of this adata object"""
         return netinfra__netinfra__router_entry.from_gdata(self.to_gdata())
 
 _breaker4 = None
 class netinfra__netinfra__router(yang.adata.MNode):
     elements: list[netinfra__netinfra__router_entry]
-    mut def __init__(self, elements=[]):
+    mut def __init__(self, elements: list[netinfra__netinfra__router_entry]=[]) -> None:
         self._ns = 'http://example.com/netinfra'
         self._name = 'router'
         self.elements = elements
 
-    mut def create(self, name, id, type, mock=None):
+    mut def create(self, name: str, id: u64, type: str, mock: ?bool=None) -> netinfra__netinfra__router_entry:
         for e in self:
             match = True
             if e.name != name:
@@ -895,7 +895,7 @@ class netinfra__netinfra__router(yang.adata.MNode):
             return [netinfra__netinfra__router_entry.from_gdata(e) for e in n.elements]
         return []
 
-    def copy(self):
+    def copy(self) -> netinfra__netinfra__router:
         """Create a deep copy of this list object"""
         # Copy each element in the list
         copied_elements = []
@@ -914,7 +914,7 @@ class netinfra__netinfra(yang.adata.MNode):
     global_settings: netinfra__netinfra__global_settings
     router: netinfra__netinfra__router
 
-    mut def __init__(self, global_settings: ?netinfra__netinfra__global_settings=None, router: list[netinfra__netinfra__router_entry]=[]):
+    mut def __init__(self, global_settings: ?netinfra__netinfra__global_settings=None, router: list[netinfra__netinfra__router_entry]=[]) -> None:
         self._ns = 'http://example.com/netinfra'
         self.global_settings = global_settings if global_settings is not None else netinfra__netinfra__global_settings()
         self.router = netinfra__netinfra__router(elements=router)
@@ -934,7 +934,7 @@ class netinfra__netinfra(yang.adata.MNode):
             return netinfra__netinfra(global_settings=netinfra__netinfra__global_settings.from_gdata(n.get_opt_cnt(yang.gdata.Id(NS_netinfra, 'global-settings'))), router=netinfra__netinfra__router.from_gdata(n.get_opt_list(yang.gdata.Id(NS_netinfra, 'router'))))
         return netinfra__netinfra()
 
-    def copy(self):
+    def copy(self) -> netinfra__netinfra:
         """Create a deep copy of this adata object"""
         return netinfra__netinfra.from_gdata(self.to_gdata())
 
@@ -951,7 +951,7 @@ class l3vpn__l3vpn__endpoint_entry(yang.adata.MNode):
     site_code: ?str
     description: ?str
 
-    mut def __init__(self, device: str, interface_name: str, ipv4_address: str, prefix_length: u64, mtu: ?u64, vlan_id: ?u64, enabled: ?bool=None, site_code: ?str, description: ?str):
+    mut def __init__(self, device: str, interface_name: str, ipv4_address: str, prefix_length: u64, mtu: ?u64, vlan_id: ?u64, enabled: ?bool=None, site_code: ?str, description: ?str) -> None:
         self._ns = 'http://example.com/l3vpn'
         self.device = device
         self.interface_name = interface_name
@@ -990,19 +990,19 @@ class l3vpn__l3vpn__endpoint_entry(yang.adata.MNode):
     mut def from_gdata(n: yang.gdata.Node) -> l3vpn__l3vpn__endpoint_entry:
         return l3vpn__l3vpn__endpoint_entry(device=n.get_str(yang.gdata.Id(NS_l3vpn, 'device')), interface_name=n.get_str(yang.gdata.Id(NS_l3vpn, 'interface-name')), ipv4_address=n.get_str(yang.gdata.Id(NS_l3vpn, 'ipv4-address')), prefix_length=n.get_u64(yang.gdata.Id(NS_l3vpn, 'prefix-length')), mtu=n.get_opt_u64(yang.gdata.Id(NS_l3vpn, 'mtu')), vlan_id=n.get_opt_u64(yang.gdata.Id(NS_l3vpn, 'vlan-id')), enabled=n.get_opt_bool(yang.gdata.Id(NS_l3vpn, 'enabled')), site_code=n.get_opt_str(yang.gdata.Id(NS_l3vpn, 'site-code')), description=n.get_opt_str(yang.gdata.Id(NS_l3vpn, 'description')))
 
-    def copy(self):
+    def copy(self) -> l3vpn__l3vpn__endpoint_entry:
         """Create a deep copy of this adata object"""
         return l3vpn__l3vpn__endpoint_entry.from_gdata(self.to_gdata())
 
 _breaker7 = None
 class l3vpn__l3vpn__endpoint(yang.adata.MNode):
     elements: list[l3vpn__l3vpn__endpoint_entry]
-    mut def __init__(self, elements=[]):
+    mut def __init__(self, elements: list[l3vpn__l3vpn__endpoint_entry]=[]) -> None:
         self._ns = 'http://example.com/l3vpn'
         self._name = 'endpoint'
         self.elements = elements
 
-    mut def create(self, device, interface_name, ipv4_address, prefix_length, mtu=None, vlan_id=None, enabled=None, site_code=None, description=None):
+    mut def create(self, device: str, interface_name: str, ipv4_address: str, prefix_length: u64, mtu: ?u64=None, vlan_id: ?u64=None, enabled: ?bool=None, site_code: ?str=None, description: ?str=None) -> l3vpn__l3vpn__endpoint_entry:
         for e in self:
             match = True
             if e.device != device:
@@ -1036,7 +1036,7 @@ class l3vpn__l3vpn__endpoint(yang.adata.MNode):
             return [l3vpn__l3vpn__endpoint_entry.from_gdata(e) for e in n.elements]
         return []
 
-    def copy(self):
+    def copy(self) -> l3vpn__l3vpn__endpoint:
         """Create a deep copy of this list object"""
         # Copy each element in the list
         copied_elements = []
@@ -1060,7 +1060,7 @@ class l3vpn__l3vpn_entry(yang.adata.MNode):
     description: ?str
     endpoint: l3vpn__l3vpn__endpoint
 
-    mut def __init__(self, name: str, customer_name: str, vpn_id: u64, service_mtu: ?u64=None, enabled: ?bool=None, description: ?str, endpoint: list[l3vpn__l3vpn__endpoint_entry]=[]):
+    mut def __init__(self, name: str, customer_name: str, vpn_id: u64, service_mtu: ?u64=None, enabled: ?bool=None, description: ?str, endpoint: list[l3vpn__l3vpn__endpoint_entry]=[]) -> None:
         self._ns = 'http://example.com/l3vpn'
         self.name = name
         self.customer_name = customer_name
@@ -1093,19 +1093,19 @@ class l3vpn__l3vpn_entry(yang.adata.MNode):
     mut def from_gdata(n: yang.gdata.Node) -> l3vpn__l3vpn_entry:
         return l3vpn__l3vpn_entry(name=n.get_str(yang.gdata.Id(NS_l3vpn, 'name')), customer_name=n.get_str(yang.gdata.Id(NS_l3vpn, 'customer-name')), vpn_id=n.get_u64(yang.gdata.Id(NS_l3vpn, 'vpn-id')), service_mtu=n.get_opt_u64(yang.gdata.Id(NS_l3vpn, 'service-mtu')), enabled=n.get_opt_bool(yang.gdata.Id(NS_l3vpn, 'enabled')), description=n.get_opt_str(yang.gdata.Id(NS_l3vpn, 'description')), endpoint=l3vpn__l3vpn__endpoint.from_gdata(n.get_opt_list(yang.gdata.Id(NS_l3vpn, 'endpoint'))))
 
-    def copy(self):
+    def copy(self) -> l3vpn__l3vpn_entry:
         """Create a deep copy of this adata object"""
         return l3vpn__l3vpn_entry.from_gdata(self.to_gdata())
 
 _breaker9 = None
 class l3vpn__l3vpn(yang.adata.MNode):
     elements: list[l3vpn__l3vpn_entry]
-    mut def __init__(self, elements=[]):
+    mut def __init__(self, elements: list[l3vpn__l3vpn_entry]=[]) -> None:
         self._ns = 'http://example.com/l3vpn'
         self._name = 'l3vpn'
         self.elements = elements
 
-    mut def create(self, name, customer_name, vpn_id, service_mtu=None, enabled=None, description=None):
+    mut def create(self, name: str, customer_name: str, vpn_id: u64, service_mtu: ?u64=None, enabled: ?bool=None, description: ?str=None) -> l3vpn__l3vpn_entry:
         for e in self:
             match = True
             if e.name != name:
@@ -1132,7 +1132,7 @@ class l3vpn__l3vpn(yang.adata.MNode):
             return [l3vpn__l3vpn_entry.from_gdata(e) for e in n.elements]
         return []
 
-    def copy(self):
+    def copy(self) -> l3vpn__l3vpn:
         """Create a deep copy of this list object"""
         # Copy each element in the list
         copied_elements = []
@@ -1151,7 +1151,7 @@ class root(yang.adata.MNode):
     netinfra: netinfra__netinfra
     l3vpn: l3vpn__l3vpn
 
-    mut def __init__(self, netinfra: ?netinfra__netinfra=None, l3vpn: list[l3vpn__l3vpn_entry]=[]):
+    mut def __init__(self, netinfra: ?netinfra__netinfra=None, l3vpn: list[l3vpn__l3vpn_entry]=[]) -> None:
         self._ns = ''
         self.netinfra = netinfra if netinfra is not None else netinfra__netinfra()
         self.l3vpn = l3vpn__l3vpn(elements=l3vpn)
@@ -1171,7 +1171,7 @@ class root(yang.adata.MNode):
             return root(netinfra=netinfra__netinfra.from_gdata(n.get_opt_cnt(yang.gdata.Id(NS_netinfra, 'netinfra'))), l3vpn=l3vpn__l3vpn.from_gdata(n.get_opt_list(yang.gdata.Id(NS_l3vpn, 'l3vpn'))))
         return root()
 
-    def copy(self):
+    def copy(self) -> root:
         """Create a deep copy of this adata object"""
         return root.from_gdata(self.to_gdata())
 

--- a/minisys/src/mini/layers/y_0_loose.act
+++ b/minisys/src/mini/layers/y_0_loose.act
@@ -781,7 +781,7 @@ _breaker1 = None
 class netinfra__netinfra__global_settings(yang.adata.MNode):
     asn: ?u64
 
-    mut def __init__(self, asn: ?u64):
+    mut def __init__(self, asn: ?u64) -> None:
         self._ns = 'http://example.com/netinfra'
         self.asn = asn
 
@@ -798,7 +798,7 @@ class netinfra__netinfra__global_settings(yang.adata.MNode):
             return netinfra__netinfra__global_settings(asn=n.get_opt_u64(yang.gdata.Id(NS_netinfra, 'asn')))
         return netinfra__netinfra__global_settings()
 
-    def copy(self):
+    def copy(self) -> netinfra__netinfra__global_settings:
         """Create a deep copy of this adata object"""
         return netinfra__netinfra__global_settings.from_gdata(self.to_gdata())
 
@@ -807,7 +807,7 @@ _breaker2 = None
 class netinfra__netinfra__router__dynstate(yang.adata.MNode):
     current_datetime: ?str
 
-    mut def __init__(self, current_datetime: ?str):
+    mut def __init__(self, current_datetime: ?str) -> None:
         self._ns = 'http://example.com/netinfra'
         self.current_datetime = current_datetime
 
@@ -824,7 +824,7 @@ class netinfra__netinfra__router__dynstate(yang.adata.MNode):
             return netinfra__netinfra__router__dynstate(current_datetime=n.get_opt_str(yang.gdata.Id(NS_netinfra, 'current-datetime')))
         return netinfra__netinfra__router__dynstate()
 
-    def copy(self):
+    def copy(self) -> netinfra__netinfra__router__dynstate:
         """Create a deep copy of this adata object"""
         return netinfra__netinfra__router__dynstate.from_gdata(self.to_gdata())
 
@@ -836,7 +836,7 @@ class netinfra__netinfra__router_entry(yang.adata.MNode):
     type: ?str
     mock: ?bool
 
-    mut def __init__(self, name: str, id: ?u64, type: ?str, mock: ?bool):
+    mut def __init__(self, name: str, id: ?u64, type: ?str, mock: ?bool) -> None:
         self._ns = 'http://example.com/netinfra'
         self.name = name
         self.id = id
@@ -860,19 +860,19 @@ class netinfra__netinfra__router_entry(yang.adata.MNode):
     mut def from_gdata(n: yang.gdata.Node) -> netinfra__netinfra__router_entry:
         return netinfra__netinfra__router_entry(name=n.get_str(yang.gdata.Id(NS_netinfra, 'name')), id=n.get_opt_u64(yang.gdata.Id(NS_netinfra, 'id')), type=n.get_opt_str(yang.gdata.Id(NS_netinfra, 'type')), mock=n.get_opt_bool(yang.gdata.Id(NS_netinfra, 'mock')))
 
-    def copy(self):
+    def copy(self) -> netinfra__netinfra__router_entry:
         """Create a deep copy of this adata object"""
         return netinfra__netinfra__router_entry.from_gdata(self.to_gdata())
 
 _breaker4 = None
 class netinfra__netinfra__router(yang.adata.MNode):
     elements: list[netinfra__netinfra__router_entry]
-    mut def __init__(self, elements=[]):
+    mut def __init__(self, elements: list[netinfra__netinfra__router_entry]=[]) -> None:
         self._ns = 'http://example.com/netinfra'
         self._name = 'router'
         self.elements = elements
 
-    mut def create(self, name, id=None, type=None, mock=None):
+    mut def create(self, name: str, id: ?u64=None, type: ?str=None, mock: ?bool=None) -> netinfra__netinfra__router_entry:
         for e in self:
             match = True
             if e.name != name:
@@ -897,7 +897,7 @@ class netinfra__netinfra__router(yang.adata.MNode):
             return [netinfra__netinfra__router_entry.from_gdata(e) for e in n.elements]
         return []
 
-    def copy(self):
+    def copy(self) -> netinfra__netinfra__router:
         """Create a deep copy of this list object"""
         # Copy each element in the list
         copied_elements = []
@@ -916,7 +916,7 @@ class netinfra__netinfra(yang.adata.MNode):
     global_settings: netinfra__netinfra__global_settings
     router: netinfra__netinfra__router
 
-    mut def __init__(self, global_settings: ?netinfra__netinfra__global_settings=None, router: list[netinfra__netinfra__router_entry]=[]):
+    mut def __init__(self, global_settings: ?netinfra__netinfra__global_settings=None, router: list[netinfra__netinfra__router_entry]=[]) -> None:
         self._ns = 'http://example.com/netinfra'
         self.global_settings = global_settings if global_settings is not None else netinfra__netinfra__global_settings()
         self.router = netinfra__netinfra__router(elements=router)
@@ -936,7 +936,7 @@ class netinfra__netinfra(yang.adata.MNode):
             return netinfra__netinfra(global_settings=netinfra__netinfra__global_settings.from_gdata(n.get_opt_cnt(yang.gdata.Id(NS_netinfra, 'global-settings'))), router=netinfra__netinfra__router.from_gdata(n.get_opt_list(yang.gdata.Id(NS_netinfra, 'router'))))
         return netinfra__netinfra()
 
-    def copy(self):
+    def copy(self) -> netinfra__netinfra:
         """Create a deep copy of this adata object"""
         return netinfra__netinfra.from_gdata(self.to_gdata())
 
@@ -953,7 +953,7 @@ class l3vpn__l3vpn__endpoint_entry(yang.adata.MNode):
     site_code: ?str
     description: ?str
 
-    mut def __init__(self, device: str, interface_name: str, ipv4_address: ?str, prefix_length: ?u64, mtu: ?u64, vlan_id: ?u64, enabled: ?bool, site_code: ?str, description: ?str):
+    mut def __init__(self, device: str, interface_name: str, ipv4_address: ?str, prefix_length: ?u64, mtu: ?u64, vlan_id: ?u64, enabled: ?bool, site_code: ?str, description: ?str) -> None:
         self._ns = 'http://example.com/l3vpn'
         self.device = device
         self.interface_name = interface_name
@@ -992,19 +992,19 @@ class l3vpn__l3vpn__endpoint_entry(yang.adata.MNode):
     mut def from_gdata(n: yang.gdata.Node) -> l3vpn__l3vpn__endpoint_entry:
         return l3vpn__l3vpn__endpoint_entry(device=n.get_str(yang.gdata.Id(NS_l3vpn, 'device')), interface_name=n.get_str(yang.gdata.Id(NS_l3vpn, 'interface-name')), ipv4_address=n.get_opt_str(yang.gdata.Id(NS_l3vpn, 'ipv4-address')), prefix_length=n.get_opt_u64(yang.gdata.Id(NS_l3vpn, 'prefix-length')), mtu=n.get_opt_u64(yang.gdata.Id(NS_l3vpn, 'mtu')), vlan_id=n.get_opt_u64(yang.gdata.Id(NS_l3vpn, 'vlan-id')), enabled=n.get_opt_bool(yang.gdata.Id(NS_l3vpn, 'enabled')), site_code=n.get_opt_str(yang.gdata.Id(NS_l3vpn, 'site-code')), description=n.get_opt_str(yang.gdata.Id(NS_l3vpn, 'description')))
 
-    def copy(self):
+    def copy(self) -> l3vpn__l3vpn__endpoint_entry:
         """Create a deep copy of this adata object"""
         return l3vpn__l3vpn__endpoint_entry.from_gdata(self.to_gdata())
 
 _breaker7 = None
 class l3vpn__l3vpn__endpoint(yang.adata.MNode):
     elements: list[l3vpn__l3vpn__endpoint_entry]
-    mut def __init__(self, elements=[]):
+    mut def __init__(self, elements: list[l3vpn__l3vpn__endpoint_entry]=[]) -> None:
         self._ns = 'http://example.com/l3vpn'
         self._name = 'endpoint'
         self.elements = elements
 
-    mut def create(self, device, interface_name, ipv4_address=None, prefix_length=None, mtu=None, vlan_id=None, enabled=None, site_code=None, description=None):
+    mut def create(self, device: str, interface_name: str, ipv4_address: ?str=None, prefix_length: ?u64=None, mtu: ?u64=None, vlan_id: ?u64=None, enabled: ?bool=None, site_code: ?str=None, description: ?str=None) -> l3vpn__l3vpn__endpoint_entry:
         for e in self:
             match = True
             if e.device != device:
@@ -1040,7 +1040,7 @@ class l3vpn__l3vpn__endpoint(yang.adata.MNode):
             return [l3vpn__l3vpn__endpoint_entry.from_gdata(e) for e in n.elements]
         return []
 
-    def copy(self):
+    def copy(self) -> l3vpn__l3vpn__endpoint:
         """Create a deep copy of this list object"""
         # Copy each element in the list
         copied_elements = []
@@ -1064,7 +1064,7 @@ class l3vpn__l3vpn_entry(yang.adata.MNode):
     description: ?str
     endpoint: l3vpn__l3vpn__endpoint
 
-    mut def __init__(self, name: str, customer_name: ?str, vpn_id: ?u64, service_mtu: ?u64, enabled: ?bool, description: ?str, endpoint: list[l3vpn__l3vpn__endpoint_entry]=[]):
+    mut def __init__(self, name: str, customer_name: ?str, vpn_id: ?u64, service_mtu: ?u64, enabled: ?bool, description: ?str, endpoint: list[l3vpn__l3vpn__endpoint_entry]=[]) -> None:
         self._ns = 'http://example.com/l3vpn'
         self.name = name
         self.customer_name = customer_name
@@ -1097,19 +1097,19 @@ class l3vpn__l3vpn_entry(yang.adata.MNode):
     mut def from_gdata(n: yang.gdata.Node) -> l3vpn__l3vpn_entry:
         return l3vpn__l3vpn_entry(name=n.get_str(yang.gdata.Id(NS_l3vpn, 'name')), customer_name=n.get_opt_str(yang.gdata.Id(NS_l3vpn, 'customer-name')), vpn_id=n.get_opt_u64(yang.gdata.Id(NS_l3vpn, 'vpn-id')), service_mtu=n.get_opt_u64(yang.gdata.Id(NS_l3vpn, 'service-mtu')), enabled=n.get_opt_bool(yang.gdata.Id(NS_l3vpn, 'enabled')), description=n.get_opt_str(yang.gdata.Id(NS_l3vpn, 'description')), endpoint=l3vpn__l3vpn__endpoint.from_gdata(n.get_opt_list(yang.gdata.Id(NS_l3vpn, 'endpoint'))))
 
-    def copy(self):
+    def copy(self) -> l3vpn__l3vpn_entry:
         """Create a deep copy of this adata object"""
         return l3vpn__l3vpn_entry.from_gdata(self.to_gdata())
 
 _breaker9 = None
 class l3vpn__l3vpn(yang.adata.MNode):
     elements: list[l3vpn__l3vpn_entry]
-    mut def __init__(self, elements=[]):
+    mut def __init__(self, elements: list[l3vpn__l3vpn_entry]=[]) -> None:
         self._ns = 'http://example.com/l3vpn'
         self._name = 'l3vpn'
         self.elements = elements
 
-    mut def create(self, name, customer_name=None, vpn_id=None, service_mtu=None, enabled=None, description=None):
+    mut def create(self, name: str, customer_name: ?str=None, vpn_id: ?u64=None, service_mtu: ?u64=None, enabled: ?bool=None, description: ?str=None) -> l3vpn__l3vpn_entry:
         for e in self:
             match = True
             if e.name != name:
@@ -1138,7 +1138,7 @@ class l3vpn__l3vpn(yang.adata.MNode):
             return [l3vpn__l3vpn_entry.from_gdata(e) for e in n.elements]
         return []
 
-    def copy(self):
+    def copy(self) -> l3vpn__l3vpn:
         """Create a deep copy of this list object"""
         # Copy each element in the list
         copied_elements = []
@@ -1157,7 +1157,7 @@ class root(yang.adata.MNode):
     netinfra: netinfra__netinfra
     l3vpn: l3vpn__l3vpn
 
-    mut def __init__(self, netinfra: ?netinfra__netinfra=None, l3vpn: list[l3vpn__l3vpn_entry]=[]):
+    mut def __init__(self, netinfra: ?netinfra__netinfra=None, l3vpn: list[l3vpn__l3vpn_entry]=[]) -> None:
         self._ns = ''
         self.netinfra = netinfra if netinfra is not None else netinfra__netinfra()
         self.l3vpn = l3vpn__l3vpn(elements=l3vpn)
@@ -1177,7 +1177,7 @@ class root(yang.adata.MNode):
             return root(netinfra=netinfra__netinfra.from_gdata(n.get_opt_cnt(yang.gdata.Id(NS_netinfra, 'netinfra'))), l3vpn=l3vpn__l3vpn.from_gdata(n.get_opt_list(yang.gdata.Id(NS_l3vpn, 'l3vpn'))))
         return root()
 
-    def copy(self):
+    def copy(self) -> root:
         """Create a deep copy of this adata object"""
         return root.from_gdata(self.to_gdata())
 

--- a/minisys/src/mini/layers/y_0_oper.act
+++ b/minisys/src/mini/layers/y_0_oper.act
@@ -784,7 +784,7 @@ _breaker1 = None
 class netinfra__netinfra__global_settings(yang.adata.MNode):
     asn: ?u64
 
-    mut def __init__(self, asn: ?u64):
+    mut def __init__(self, asn: ?u64) -> None:
         self._ns = 'http://example.com/netinfra'
         self.asn = asn
 
@@ -801,7 +801,7 @@ class netinfra__netinfra__global_settings(yang.adata.MNode):
             return netinfra__netinfra__global_settings(asn=n.get_opt_u64(yang.gdata.Id(NS_netinfra, 'asn')))
         return netinfra__netinfra__global_settings()
 
-    def copy(self):
+    def copy(self) -> netinfra__netinfra__global_settings:
         """Create a deep copy of this adata object"""
         return netinfra__netinfra__global_settings.from_gdata(self.to_gdata())
 
@@ -810,7 +810,7 @@ _breaker2 = None
 class netinfra__netinfra__router__dynstate(yang.adata.MNode):
     current_datetime: ?str
 
-    mut def __init__(self, current_datetime: ?str):
+    mut def __init__(self, current_datetime: ?str) -> None:
         self._ns = 'http://example.com/netinfra'
         self.current_datetime = current_datetime
 
@@ -827,7 +827,7 @@ class netinfra__netinfra__router__dynstate(yang.adata.MNode):
             return netinfra__netinfra__router__dynstate(current_datetime=n.get_opt_str(yang.gdata.Id(NS_netinfra, 'current-datetime')))
         return netinfra__netinfra__router__dynstate()
 
-    def copy(self):
+    def copy(self) -> netinfra__netinfra__router__dynstate:
         """Create a deep copy of this adata object"""
         return netinfra__netinfra__router__dynstate.from_gdata(self.to_gdata())
 
@@ -836,7 +836,7 @@ _breaker3 = None
 class netinfra__netinfra__router__state(yang.adata.MNode):
     current_datetime: ?str
 
-    mut def __init__(self, current_datetime: ?str):
+    mut def __init__(self, current_datetime: ?str) -> None:
         self._ns = 'http://example.com/netinfra'
         self.current_datetime = current_datetime
 
@@ -853,7 +853,7 @@ class netinfra__netinfra__router__state(yang.adata.MNode):
             return netinfra__netinfra__router__state(current_datetime=n.get_opt_str(yang.gdata.Id(NS_netinfra, 'current-datetime')))
         return netinfra__netinfra__router__state()
 
-    def copy(self):
+    def copy(self) -> netinfra__netinfra__router__state:
         """Create a deep copy of this adata object"""
         return netinfra__netinfra__router__state.from_gdata(self.to_gdata())
 
@@ -866,7 +866,7 @@ class netinfra__netinfra__router_entry(yang.adata.MNode):
     mock: ?bool
     state: netinfra__netinfra__router__state
 
-    mut def __init__(self, name: str, id: ?u64, type: ?str, mock: ?bool, state: ?netinfra__netinfra__router__state=None):
+    mut def __init__(self, name: str, id: ?u64, type: ?str, mock: ?bool, state: ?netinfra__netinfra__router__state=None) -> None:
         self._ns = 'http://example.com/netinfra'
         self.name = name
         self.id = id
@@ -893,19 +893,19 @@ class netinfra__netinfra__router_entry(yang.adata.MNode):
     mut def from_gdata(n: yang.gdata.Node) -> netinfra__netinfra__router_entry:
         return netinfra__netinfra__router_entry(name=n.get_str(yang.gdata.Id(NS_netinfra, 'name')), id=n.get_opt_u64(yang.gdata.Id(NS_netinfra, 'id')), type=n.get_opt_str(yang.gdata.Id(NS_netinfra, 'type')), mock=n.get_opt_bool(yang.gdata.Id(NS_netinfra, 'mock')), state=netinfra__netinfra__router__state.from_gdata(n.get_opt_cnt(yang.gdata.Id(NS_netinfra, 'state'))))
 
-    def copy(self):
+    def copy(self) -> netinfra__netinfra__router_entry:
         """Create a deep copy of this adata object"""
         return netinfra__netinfra__router_entry.from_gdata(self.to_gdata())
 
 _breaker5 = None
 class netinfra__netinfra__router(yang.adata.MNode):
     elements: list[netinfra__netinfra__router_entry]
-    mut def __init__(self, elements=[]):
+    mut def __init__(self, elements: list[netinfra__netinfra__router_entry]=[]) -> None:
         self._ns = 'http://example.com/netinfra'
         self._name = 'router'
         self.elements = elements
 
-    mut def create(self, name, id=None, type=None, mock=None):
+    mut def create(self, name: str, id: ?u64=None, type: ?str=None, mock: ?bool=None) -> netinfra__netinfra__router_entry:
         for e in self:
             match = True
             if e.name != name:
@@ -930,7 +930,7 @@ class netinfra__netinfra__router(yang.adata.MNode):
             return [netinfra__netinfra__router_entry.from_gdata(e) for e in n.elements]
         return []
 
-    def copy(self):
+    def copy(self) -> netinfra__netinfra__router:
         """Create a deep copy of this list object"""
         # Copy each element in the list
         copied_elements = []
@@ -949,7 +949,7 @@ class netinfra__netinfra(yang.adata.MNode):
     global_settings: netinfra__netinfra__global_settings
     router: netinfra__netinfra__router
 
-    mut def __init__(self, global_settings: ?netinfra__netinfra__global_settings=None, router: list[netinfra__netinfra__router_entry]=[]):
+    mut def __init__(self, global_settings: ?netinfra__netinfra__global_settings=None, router: list[netinfra__netinfra__router_entry]=[]) -> None:
         self._ns = 'http://example.com/netinfra'
         self.global_settings = global_settings if global_settings is not None else netinfra__netinfra__global_settings()
         self.router = netinfra__netinfra__router(elements=router)
@@ -969,7 +969,7 @@ class netinfra__netinfra(yang.adata.MNode):
             return netinfra__netinfra(global_settings=netinfra__netinfra__global_settings.from_gdata(n.get_opt_cnt(yang.gdata.Id(NS_netinfra, 'global-settings'))), router=netinfra__netinfra__router.from_gdata(n.get_opt_list(yang.gdata.Id(NS_netinfra, 'router'))))
         return netinfra__netinfra()
 
-    def copy(self):
+    def copy(self) -> netinfra__netinfra:
         """Create a deep copy of this adata object"""
         return netinfra__netinfra.from_gdata(self.to_gdata())
 
@@ -986,7 +986,7 @@ class l3vpn__l3vpn__endpoint_entry(yang.adata.MNode):
     site_code: ?str
     description: ?str
 
-    mut def __init__(self, device: str, interface_name: str, ipv4_address: ?str, prefix_length: ?u64, mtu: ?u64, vlan_id: ?u64, enabled: ?bool, site_code: ?str, description: ?str):
+    mut def __init__(self, device: str, interface_name: str, ipv4_address: ?str, prefix_length: ?u64, mtu: ?u64, vlan_id: ?u64, enabled: ?bool, site_code: ?str, description: ?str) -> None:
         self._ns = 'http://example.com/l3vpn'
         self.device = device
         self.interface_name = interface_name
@@ -1025,19 +1025,19 @@ class l3vpn__l3vpn__endpoint_entry(yang.adata.MNode):
     mut def from_gdata(n: yang.gdata.Node) -> l3vpn__l3vpn__endpoint_entry:
         return l3vpn__l3vpn__endpoint_entry(device=n.get_str(yang.gdata.Id(NS_l3vpn, 'device')), interface_name=n.get_str(yang.gdata.Id(NS_l3vpn, 'interface-name')), ipv4_address=n.get_opt_str(yang.gdata.Id(NS_l3vpn, 'ipv4-address')), prefix_length=n.get_opt_u64(yang.gdata.Id(NS_l3vpn, 'prefix-length')), mtu=n.get_opt_u64(yang.gdata.Id(NS_l3vpn, 'mtu')), vlan_id=n.get_opt_u64(yang.gdata.Id(NS_l3vpn, 'vlan-id')), enabled=n.get_opt_bool(yang.gdata.Id(NS_l3vpn, 'enabled')), site_code=n.get_opt_str(yang.gdata.Id(NS_l3vpn, 'site-code')), description=n.get_opt_str(yang.gdata.Id(NS_l3vpn, 'description')))
 
-    def copy(self):
+    def copy(self) -> l3vpn__l3vpn__endpoint_entry:
         """Create a deep copy of this adata object"""
         return l3vpn__l3vpn__endpoint_entry.from_gdata(self.to_gdata())
 
 _breaker8 = None
 class l3vpn__l3vpn__endpoint(yang.adata.MNode):
     elements: list[l3vpn__l3vpn__endpoint_entry]
-    mut def __init__(self, elements=[]):
+    mut def __init__(self, elements: list[l3vpn__l3vpn__endpoint_entry]=[]) -> None:
         self._ns = 'http://example.com/l3vpn'
         self._name = 'endpoint'
         self.elements = elements
 
-    mut def create(self, device, interface_name, ipv4_address=None, prefix_length=None, mtu=None, vlan_id=None, enabled=None, site_code=None, description=None):
+    mut def create(self, device: str, interface_name: str, ipv4_address: ?str=None, prefix_length: ?u64=None, mtu: ?u64=None, vlan_id: ?u64=None, enabled: ?bool=None, site_code: ?str=None, description: ?str=None) -> l3vpn__l3vpn__endpoint_entry:
         for e in self:
             match = True
             if e.device != device:
@@ -1073,7 +1073,7 @@ class l3vpn__l3vpn__endpoint(yang.adata.MNode):
             return [l3vpn__l3vpn__endpoint_entry.from_gdata(e) for e in n.elements]
         return []
 
-    def copy(self):
+    def copy(self) -> l3vpn__l3vpn__endpoint:
         """Create a deep copy of this list object"""
         # Copy each element in the list
         copied_elements = []
@@ -1097,7 +1097,7 @@ class l3vpn__l3vpn_entry(yang.adata.MNode):
     description: ?str
     endpoint: l3vpn__l3vpn__endpoint
 
-    mut def __init__(self, name: str, customer_name: ?str, vpn_id: ?u64, service_mtu: ?u64, enabled: ?bool, description: ?str, endpoint: list[l3vpn__l3vpn__endpoint_entry]=[]):
+    mut def __init__(self, name: str, customer_name: ?str, vpn_id: ?u64, service_mtu: ?u64, enabled: ?bool, description: ?str, endpoint: list[l3vpn__l3vpn__endpoint_entry]=[]) -> None:
         self._ns = 'http://example.com/l3vpn'
         self.name = name
         self.customer_name = customer_name
@@ -1130,19 +1130,19 @@ class l3vpn__l3vpn_entry(yang.adata.MNode):
     mut def from_gdata(n: yang.gdata.Node) -> l3vpn__l3vpn_entry:
         return l3vpn__l3vpn_entry(name=n.get_str(yang.gdata.Id(NS_l3vpn, 'name')), customer_name=n.get_opt_str(yang.gdata.Id(NS_l3vpn, 'customer-name')), vpn_id=n.get_opt_u64(yang.gdata.Id(NS_l3vpn, 'vpn-id')), service_mtu=n.get_opt_u64(yang.gdata.Id(NS_l3vpn, 'service-mtu')), enabled=n.get_opt_bool(yang.gdata.Id(NS_l3vpn, 'enabled')), description=n.get_opt_str(yang.gdata.Id(NS_l3vpn, 'description')), endpoint=l3vpn__l3vpn__endpoint.from_gdata(n.get_opt_list(yang.gdata.Id(NS_l3vpn, 'endpoint'))))
 
-    def copy(self):
+    def copy(self) -> l3vpn__l3vpn_entry:
         """Create a deep copy of this adata object"""
         return l3vpn__l3vpn_entry.from_gdata(self.to_gdata())
 
 _breaker10 = None
 class l3vpn__l3vpn(yang.adata.MNode):
     elements: list[l3vpn__l3vpn_entry]
-    mut def __init__(self, elements=[]):
+    mut def __init__(self, elements: list[l3vpn__l3vpn_entry]=[]) -> None:
         self._ns = 'http://example.com/l3vpn'
         self._name = 'l3vpn'
         self.elements = elements
 
-    mut def create(self, name, customer_name=None, vpn_id=None, service_mtu=None, enabled=None, description=None):
+    mut def create(self, name: str, customer_name: ?str=None, vpn_id: ?u64=None, service_mtu: ?u64=None, enabled: ?bool=None, description: ?str=None) -> l3vpn__l3vpn_entry:
         for e in self:
             match = True
             if e.name != name:
@@ -1171,7 +1171,7 @@ class l3vpn__l3vpn(yang.adata.MNode):
             return [l3vpn__l3vpn_entry.from_gdata(e) for e in n.elements]
         return []
 
-    def copy(self):
+    def copy(self) -> l3vpn__l3vpn:
         """Create a deep copy of this list object"""
         # Copy each element in the list
         copied_elements = []
@@ -1190,7 +1190,7 @@ class root(yang.adata.MNode):
     netinfra: netinfra__netinfra
     l3vpn: l3vpn__l3vpn
 
-    mut def __init__(self, netinfra: ?netinfra__netinfra=None, l3vpn: list[l3vpn__l3vpn_entry]=[]):
+    mut def __init__(self, netinfra: ?netinfra__netinfra=None, l3vpn: list[l3vpn__l3vpn_entry]=[]) -> None:
         self._ns = ''
         self.netinfra = netinfra if netinfra is not None else netinfra__netinfra()
         self.l3vpn = l3vpn__l3vpn(elements=l3vpn)
@@ -1210,7 +1210,7 @@ class root(yang.adata.MNode):
             return root(netinfra=netinfra__netinfra.from_gdata(n.get_opt_cnt(yang.gdata.Id(NS_netinfra, 'netinfra'))), l3vpn=l3vpn__l3vpn.from_gdata(n.get_opt_list(yang.gdata.Id(NS_l3vpn, 'l3vpn'))))
         return root()
 
-    def copy(self):
+    def copy(self) -> root:
         """Create a deep copy of this adata object"""
         return root.from_gdata(self.to_gdata())
 

--- a/minisys/src/mini/layers/y_1.act
+++ b/minisys/src/mini/layers/y_1.act
@@ -935,7 +935,7 @@ class stratoweave_rfs__device__address__initial_credentials_entry(yang.adata.MNo
     password: str
     key: str
 
-    mut def __init__(self, username: str, password: str, key: str):
+    mut def __init__(self, username: str, password: str, key: str) -> None:
         self._ns = 'http://stratoweave.org/yang/stratoweave-rfs.yang'
         self.username = username
         self.password = password
@@ -956,19 +956,19 @@ class stratoweave_rfs__device__address__initial_credentials_entry(yang.adata.MNo
     mut def from_gdata(n: yang.gdata.Node) -> stratoweave_rfs__device__address__initial_credentials_entry:
         return stratoweave_rfs__device__address__initial_credentials_entry(username=n.get_str(yang.gdata.Id(NS_stratoweave_rfs, 'username')), password=n.get_str(yang.gdata.Id(NS_stratoweave_rfs, 'password')), key=n.get_str(yang.gdata.Id(NS_stratoweave_rfs, 'key')))
 
-    def copy(self):
+    def copy(self) -> stratoweave_rfs__device__address__initial_credentials_entry:
         """Create a deep copy of this adata object"""
         return stratoweave_rfs__device__address__initial_credentials_entry.from_gdata(self.to_gdata())
 
 _breaker2 = None
 class stratoweave_rfs__device__address__initial_credentials(yang.adata.MNode):
     elements: list[stratoweave_rfs__device__address__initial_credentials_entry]
-    mut def __init__(self, elements=[]):
+    mut def __init__(self, elements: list[stratoweave_rfs__device__address__initial_credentials_entry]=[]) -> None:
         self._ns = 'http://stratoweave.org/yang/stratoweave-rfs.yang'
         self._name = 'initial-credentials'
         self.elements = elements
 
-    mut def create(self, username, password, key):
+    mut def create(self, username: str, password: str, key: str) -> stratoweave_rfs__device__address__initial_credentials_entry:
         for e in self:
             match = True
             if e.username != username:
@@ -993,7 +993,7 @@ class stratoweave_rfs__device__address__initial_credentials(yang.adata.MNode):
             return [stratoweave_rfs__device__address__initial_credentials_entry.from_gdata(e) for e in n.elements]
         return []
 
-    def copy(self):
+    def copy(self) -> stratoweave_rfs__device__address__initial_credentials:
         """Create a deep copy of this list object"""
         # Copy each element in the list
         copied_elements = []
@@ -1014,7 +1014,7 @@ class stratoweave_rfs__device__address_entry(yang.adata.MNode):
     port: ?u64
     initial_credentials: stratoweave_rfs__device__address__initial_credentials
 
-    mut def __init__(self, name: str, address: str, port: ?u64, initial_credentials: list[stratoweave_rfs__device__address__initial_credentials_entry]=[]):
+    mut def __init__(self, name: str, address: str, port: ?u64, initial_credentials: list[stratoweave_rfs__device__address__initial_credentials_entry]=[]) -> None:
         self._ns = 'http://stratoweave.org/yang/stratoweave-rfs.yang'
         self.name = name
         self.address = address
@@ -1038,19 +1038,19 @@ class stratoweave_rfs__device__address_entry(yang.adata.MNode):
     mut def from_gdata(n: yang.gdata.Node) -> stratoweave_rfs__device__address_entry:
         return stratoweave_rfs__device__address_entry(name=n.get_str(yang.gdata.Id(NS_stratoweave_rfs, 'name')), address=n.get_str(yang.gdata.Id(NS_stratoweave_rfs, 'address')), port=n.get_opt_u64(yang.gdata.Id(NS_stratoweave_rfs, 'port')), initial_credentials=stratoweave_rfs__device__address__initial_credentials.from_gdata(n.get_opt_list(yang.gdata.Id(NS_stratoweave_rfs, 'initial-credentials'))))
 
-    def copy(self):
+    def copy(self) -> stratoweave_rfs__device__address_entry:
         """Create a deep copy of this adata object"""
         return stratoweave_rfs__device__address_entry.from_gdata(self.to_gdata())
 
 _breaker4 = None
 class stratoweave_rfs__device__address(yang.adata.MNode):
     elements: list[stratoweave_rfs__device__address_entry]
-    mut def __init__(self, elements=[]):
+    mut def __init__(self, elements: list[stratoweave_rfs__device__address_entry]=[]) -> None:
         self._ns = 'http://stratoweave.org/yang/stratoweave-rfs.yang'
         self._name = 'address'
         self.elements = elements
 
-    mut def create(self, name, address, port=None):
+    mut def create(self, name: str, address: str, port: ?u64=None) -> stratoweave_rfs__device__address_entry:
         for e in self:
             match = True
             if e.name != name:
@@ -1072,7 +1072,7 @@ class stratoweave_rfs__device__address(yang.adata.MNode):
             return [stratoweave_rfs__device__address_entry.from_gdata(e) for e in n.elements]
         return []
 
-    def copy(self):
+    def copy(self) -> stratoweave_rfs__device__address:
         """Create a deep copy of this list object"""
         # Copy each element in the list
         copied_elements = []
@@ -1091,7 +1091,7 @@ class stratoweave_rfs__device__credentials__key_entry(yang.adata.MNode):
     key: str
     private_key: ?str
 
-    mut def __init__(self, key: str, private_key: ?str):
+    mut def __init__(self, key: str, private_key: ?str) -> None:
         self._ns = 'http://stratoweave.org/yang/stratoweave-rfs.yang'
         self.key = key
         self.private_key = private_key
@@ -1109,19 +1109,19 @@ class stratoweave_rfs__device__credentials__key_entry(yang.adata.MNode):
     mut def from_gdata(n: yang.gdata.Node) -> stratoweave_rfs__device__credentials__key_entry:
         return stratoweave_rfs__device__credentials__key_entry(key=n.get_str(yang.gdata.Id(NS_stratoweave_rfs, 'key')), private_key=n.get_opt_str(yang.gdata.Id(NS_stratoweave_rfs, 'private-key')))
 
-    def copy(self):
+    def copy(self) -> stratoweave_rfs__device__credentials__key_entry:
         """Create a deep copy of this adata object"""
         return stratoweave_rfs__device__credentials__key_entry.from_gdata(self.to_gdata())
 
 _breaker6 = None
 class stratoweave_rfs__device__credentials__key(yang.adata.MNode):
     elements: list[stratoweave_rfs__device__credentials__key_entry]
-    mut def __init__(self, elements=[]):
+    mut def __init__(self, elements: list[stratoweave_rfs__device__credentials__key_entry]=[]) -> None:
         self._ns = 'http://stratoweave.org/yang/stratoweave-rfs.yang'
         self._name = 'key'
         self.elements = elements
 
-    mut def create(self, key, private_key=None):
+    mut def create(self, key: str, private_key: ?str=None) -> stratoweave_rfs__device__credentials__key_entry:
         for e in self:
             match = True
             if e.key != key:
@@ -1142,7 +1142,7 @@ class stratoweave_rfs__device__credentials__key(yang.adata.MNode):
             return [stratoweave_rfs__device__credentials__key_entry.from_gdata(e) for e in n.elements]
         return []
 
-    def copy(self):
+    def copy(self) -> stratoweave_rfs__device__credentials__key:
         """Create a deep copy of this list object"""
         # Copy each element in the list
         copied_elements = []
@@ -1162,7 +1162,7 @@ class stratoweave_rfs__device__credentials(yang.adata.MNode):
     password: ?str
     key: stratoweave_rfs__device__credentials__key
 
-    mut def __init__(self, username: str, password: ?str, key: list[stratoweave_rfs__device__credentials__key_entry]=[]):
+    mut def __init__(self, username: str, password: ?str, key: list[stratoweave_rfs__device__credentials__key_entry]=[]) -> None:
         self._ns = 'http://stratoweave.org/yang/stratoweave-rfs.yang'
         self.username = username
         self.password = password
@@ -1185,7 +1185,7 @@ class stratoweave_rfs__device__credentials(yang.adata.MNode):
             return stratoweave_rfs__device__credentials(username=n.get_str(yang.gdata.Id(NS_stratoweave_rfs, 'username')), password=n.get_opt_str(yang.gdata.Id(NS_stratoweave_rfs, 'password')), key=stratoweave_rfs__device__credentials__key.from_gdata(n.get_opt_list(yang.gdata.Id(NS_stratoweave_rfs, 'key'))))
         raise ValueError('Missing required subtree stratoweave_rfs__device__credentials')
 
-    def copy(self):
+    def copy(self) -> stratoweave_rfs__device__credentials:
         """Create a deep copy of this adata object"""
         return stratoweave_rfs__device__credentials.from_gdata(self.to_gdata())
 
@@ -1196,7 +1196,7 @@ class stratoweave_rfs__device__initial_credentials_entry(yang.adata.MNode):
     password: str
     key: str
 
-    mut def __init__(self, username: str, password: str, key: str):
+    mut def __init__(self, username: str, password: str, key: str) -> None:
         self._ns = 'http://stratoweave.org/yang/stratoweave-rfs.yang'
         self.username = username
         self.password = password
@@ -1217,19 +1217,19 @@ class stratoweave_rfs__device__initial_credentials_entry(yang.adata.MNode):
     mut def from_gdata(n: yang.gdata.Node) -> stratoweave_rfs__device__initial_credentials_entry:
         return stratoweave_rfs__device__initial_credentials_entry(username=n.get_str(yang.gdata.Id(NS_stratoweave_rfs, 'username')), password=n.get_str(yang.gdata.Id(NS_stratoweave_rfs, 'password')), key=n.get_str(yang.gdata.Id(NS_stratoweave_rfs, 'key')))
 
-    def copy(self):
+    def copy(self) -> stratoweave_rfs__device__initial_credentials_entry:
         """Create a deep copy of this adata object"""
         return stratoweave_rfs__device__initial_credentials_entry.from_gdata(self.to_gdata())
 
 _breaker9 = None
 class stratoweave_rfs__device__initial_credentials(yang.adata.MNode):
     elements: list[stratoweave_rfs__device__initial_credentials_entry]
-    mut def __init__(self, elements=[]):
+    mut def __init__(self, elements: list[stratoweave_rfs__device__initial_credentials_entry]=[]) -> None:
         self._ns = 'http://stratoweave.org/yang/stratoweave-rfs.yang'
         self._name = 'initial-credentials'
         self.elements = elements
 
-    mut def create(self, username, password, key):
+    mut def create(self, username: str, password: str, key: str) -> stratoweave_rfs__device__initial_credentials_entry:
         for e in self:
             match = True
             if e.username != username:
@@ -1254,7 +1254,7 @@ class stratoweave_rfs__device__initial_credentials(yang.adata.MNode):
             return [stratoweave_rfs__device__initial_credentials_entry.from_gdata(e) for e in n.elements]
         return []
 
-    def copy(self):
+    def copy(self) -> stratoweave_rfs__device__initial_credentials:
         """Create a deep copy of this list object"""
         # Copy each element in the list
         copied_elements = []
@@ -1275,7 +1275,7 @@ class stratoweave_rfs__device__mock__module_entry(yang.adata.MNode):
     revision: ?str
     feature: list[str]
 
-    mut def __init__(self, name: str, namespace: str, revision: ?str, feature: ?list[str]=None):
+    mut def __init__(self, name: str, namespace: str, revision: ?str, feature: ?list[str]=None) -> None:
         self._ns = 'http://stratoweave.org/yang/stratoweave-rfs.yang'
         self.name = name
         self.namespace = namespace
@@ -1299,19 +1299,19 @@ class stratoweave_rfs__device__mock__module_entry(yang.adata.MNode):
     mut def from_gdata(n: yang.gdata.Node) -> stratoweave_rfs__device__mock__module_entry:
         return stratoweave_rfs__device__mock__module_entry(name=n.get_str(yang.gdata.Id(NS_stratoweave_rfs, 'name')), namespace=n.get_str(yang.gdata.Id(NS_stratoweave_rfs, 'namespace')), revision=n.get_opt_str(yang.gdata.Id(NS_stratoweave_rfs, 'revision')), feature=n.get_opt_strs(yang.gdata.Id(NS_stratoweave_rfs, 'feature')))
 
-    def copy(self):
+    def copy(self) -> stratoweave_rfs__device__mock__module_entry:
         """Create a deep copy of this adata object"""
         return stratoweave_rfs__device__mock__module_entry.from_gdata(self.to_gdata())
 
 _breaker11 = None
 class stratoweave_rfs__device__mock__module(yang.adata.MNode):
     elements: list[stratoweave_rfs__device__mock__module_entry]
-    mut def __init__(self, elements=[]):
+    mut def __init__(self, elements: list[stratoweave_rfs__device__mock__module_entry]=[]) -> None:
         self._ns = 'http://stratoweave.org/yang/stratoweave-rfs.yang'
         self._name = 'module'
         self.elements = elements
 
-    mut def create(self, name, namespace, revision=None):
+    mut def create(self, name: str, namespace: str, revision: ?str=None) -> stratoweave_rfs__device__mock__module_entry:
         for e in self:
             match = True
             if e.name != name:
@@ -1333,7 +1333,7 @@ class stratoweave_rfs__device__mock__module(yang.adata.MNode):
             return [stratoweave_rfs__device__mock__module_entry.from_gdata(e) for e in n.elements]
         return []
 
-    def copy(self):
+    def copy(self) -> stratoweave_rfs__device__mock__module:
         """Create a deep copy of this list object"""
         # Copy each element in the list
         copied_elements = []
@@ -1353,7 +1353,7 @@ class stratoweave_rfs__device__mock(yang.adata.MNode):
     preset: list[str]
     module: stratoweave_rfs__device__mock__module
 
-    mut def __init__(self, enabled: ?bool=None, preset: ?list[str]=None, module: list[stratoweave_rfs__device__mock__module_entry]=[]):
+    mut def __init__(self, enabled: ?bool=None, preset: ?list[str]=None, module: list[stratoweave_rfs__device__mock__module_entry]=[]) -> None:
         self._ns = 'http://stratoweave.org/yang/stratoweave-rfs.yang'
         self.enabled = enabled if enabled is not None else False
         self.preset = preset if preset is not None else []
@@ -1376,7 +1376,7 @@ class stratoweave_rfs__device__mock(yang.adata.MNode):
             return stratoweave_rfs__device__mock(enabled=n.get_opt_bool(yang.gdata.Id(NS_stratoweave_rfs, 'enabled')), preset=n.get_opt_strs(yang.gdata.Id(NS_stratoweave_rfs, 'preset')), module=stratoweave_rfs__device__mock__module.from_gdata(n.get_opt_list(yang.gdata.Id(NS_stratoweave_rfs, 'module'))))
         return stratoweave_rfs__device__mock()
 
-    def copy(self):
+    def copy(self) -> stratoweave_rfs__device__mock:
         """Create a deep copy of this adata object"""
         return stratoweave_rfs__device__mock.from_gdata(self.to_gdata())
 
@@ -1385,7 +1385,7 @@ _breaker13 = None
 class stratoweave_rfs__device__debug(yang.adata.MNode):
     connection: bool
 
-    mut def __init__(self, connection: ?bool=None):
+    mut def __init__(self, connection: ?bool=None) -> None:
         self._ns = 'http://stratoweave.org/yang/stratoweave-rfs.yang'
         self.connection = connection if connection is not None else False
 
@@ -1402,7 +1402,7 @@ class stratoweave_rfs__device__debug(yang.adata.MNode):
             return stratoweave_rfs__device__debug(connection=n.get_opt_bool(yang.gdata.Id(NS_stratoweave_rfs, 'connection')))
         return stratoweave_rfs__device__debug()
 
-    def copy(self):
+    def copy(self) -> stratoweave_rfs__device__debug:
         """Create a deep copy of this adata object"""
         return stratoweave_rfs__device__debug.from_gdata(self.to_gdata())
 
@@ -1411,7 +1411,7 @@ _breaker14 = None
 class stratoweave_rfs__device__feature_flags(yang.adata.MNode):
     runtime_schema_fetch: bool
 
-    mut def __init__(self, runtime_schema_fetch: ?bool=None):
+    mut def __init__(self, runtime_schema_fetch: ?bool=None) -> None:
         self._ns = 'http://stratoweave.org/yang/stratoweave-rfs.yang'
         self.runtime_schema_fetch = runtime_schema_fetch if runtime_schema_fetch is not None else False
 
@@ -1428,7 +1428,7 @@ class stratoweave_rfs__device__feature_flags(yang.adata.MNode):
             return stratoweave_rfs__device__feature_flags(runtime_schema_fetch=n.get_opt_bool(yang.gdata.Id(NS_stratoweave_rfs, 'runtime-schema-fetch')))
         return stratoweave_rfs__device__feature_flags()
 
-    def copy(self):
+    def copy(self) -> stratoweave_rfs__device__feature_flags:
         """Create a deep copy of this adata object"""
         return stratoweave_rfs__device__feature_flags.from_gdata(self.to_gdata())
 
@@ -1446,7 +1446,7 @@ class stratoweave_rfs__device_entry(yang.adata.MNode):
     debug: stratoweave_rfs__device__debug
     feature_flags: stratoweave_rfs__device__feature_flags
 
-    mut def __init__(self, name: str, credentials: stratoweave_rfs__device__credentials, description: ?str, type: ?str, address: list[stratoweave_rfs__device__address_entry]=[], initial_credentials: list[stratoweave_rfs__device__initial_credentials_entry]=[], approval_required: ?bool=None, mock: ?stratoweave_rfs__device__mock=None, debug: ?stratoweave_rfs__device__debug=None, feature_flags: ?stratoweave_rfs__device__feature_flags=None):
+    mut def __init__(self, name: str, credentials: stratoweave_rfs__device__credentials, description: ?str, type: ?str, address: list[stratoweave_rfs__device__address_entry]=[], initial_credentials: list[stratoweave_rfs__device__initial_credentials_entry]=[], approval_required: ?bool=None, mock: ?stratoweave_rfs__device__mock=None, debug: ?stratoweave_rfs__device__debug=None, feature_flags: ?stratoweave_rfs__device__feature_flags=None) -> None:
         self._ns = 'http://stratoweave.org/yang/stratoweave-rfs.yang'
         self.name = name
         self.description = description
@@ -1488,19 +1488,19 @@ class stratoweave_rfs__device_entry(yang.adata.MNode):
     mut def from_gdata(n: yang.gdata.Node) -> stratoweave_rfs__device_entry:
         return stratoweave_rfs__device_entry(name=n.get_str(yang.gdata.Id(NS_stratoweave_rfs, 'name')), description=n.get_opt_str(yang.gdata.Id(NS_stratoweave_rfs, 'description')), type=n.get_opt_str(yang.gdata.Id(NS_stratoweave_rfs, 'type')), address=stratoweave_rfs__device__address.from_gdata(n.get_opt_list(yang.gdata.Id(NS_stratoweave_rfs, 'address'))), credentials=stratoweave_rfs__device__credentials.from_gdata(n.get_cnt(yang.gdata.Id(NS_stratoweave_rfs, 'credentials'))), initial_credentials=stratoweave_rfs__device__initial_credentials.from_gdata(n.get_opt_list(yang.gdata.Id(NS_stratoweave_rfs, 'initial-credentials'))), approval_required=n.get_opt_bool(yang.gdata.Id(NS_stratoweave_rfs, 'approval-required')), mock=stratoweave_rfs__device__mock.from_gdata(n.get_opt_cnt(yang.gdata.Id(NS_stratoweave_rfs, 'mock'))), debug=stratoweave_rfs__device__debug.from_gdata(n.get_opt_cnt(yang.gdata.Id(NS_stratoweave_rfs, 'debug'))), feature_flags=stratoweave_rfs__device__feature_flags.from_gdata(n.get_opt_cnt(yang.gdata.Id(NS_stratoweave_rfs, 'feature-flags'))))
 
-    def copy(self):
+    def copy(self) -> stratoweave_rfs__device_entry:
         """Create a deep copy of this adata object"""
         return stratoweave_rfs__device_entry.from_gdata(self.to_gdata())
 
 _breaker16 = None
 class stratoweave_rfs__device(yang.adata.MNode):
     elements: list[stratoweave_rfs__device_entry]
-    mut def __init__(self, elements=[]):
+    mut def __init__(self, elements: list[stratoweave_rfs__device_entry]=[]) -> None:
         self._ns = 'http://stratoweave.org/yang/stratoweave-rfs.yang'
         self._name = 'device'
         self.elements = elements
 
-    mut def create(self, name, credentials, description=None, type=None, approval_required=None):
+    mut def create(self, name: str, credentials: stratoweave_rfs__device__credentials, description: ?str=None, type: ?str=None, approval_required: ?bool=None) -> stratoweave_rfs__device_entry:
         for e in self:
             match = True
             if e.name != name:
@@ -1526,7 +1526,7 @@ class stratoweave_rfs__device(yang.adata.MNode):
             return [stratoweave_rfs__device_entry.from_gdata(e) for e in n.elements]
         return []
 
-    def copy(self):
+    def copy(self) -> stratoweave_rfs__device:
         """Create a deep copy of this list object"""
         # Copy each element in the list
         copied_elements = []
@@ -1544,7 +1544,7 @@ _breaker17 = None
 class stratoweave_rfs__rfs__base_config__dynstate(yang.adata.MNode):
     current_datetime: ?str
 
-    mut def __init__(self, current_datetime: ?str):
+    mut def __init__(self, current_datetime: ?str) -> None:
         self._ns = 'http://example.com/mini-rfs'
         self.current_datetime = current_datetime
 
@@ -1561,7 +1561,7 @@ class stratoweave_rfs__rfs__base_config__dynstate(yang.adata.MNode):
             return stratoweave_rfs__rfs__base_config__dynstate(current_datetime=n.get_opt_str(yang.gdata.Id(NS_mini_rfs, 'current-datetime')))
         return stratoweave_rfs__rfs__base_config__dynstate()
 
-    def copy(self):
+    def copy(self) -> stratoweave_rfs__rfs__base_config__dynstate:
         """Create a deep copy of this adata object"""
         return stratoweave_rfs__rfs__base_config__dynstate.from_gdata(self.to_gdata())
 
@@ -1571,7 +1571,7 @@ class stratoweave_rfs__rfs__base_config(yang.adata.MNode):
     name: str
     ipv4_address: str
 
-    mut def __init__(self, name: str, ipv4_address: str):
+    mut def __init__(self, name: str, ipv4_address: str) -> None:
         self._ns = 'http://example.com/mini-rfs'
         self.name = name
         self.ipv4_address = ipv4_address
@@ -1591,7 +1591,7 @@ class stratoweave_rfs__rfs__base_config(yang.adata.MNode):
             return stratoweave_rfs__rfs__base_config(name=n.get_str(yang.gdata.Id(NS_mini_rfs, 'name')), ipv4_address=n.get_str(yang.gdata.Id(NS_mini_rfs, 'ipv4-address')))
         raise ValueError('Missing required subtree stratoweave_rfs__rfs__base_config')
 
-    def copy(self):
+    def copy(self) -> stratoweave_rfs__rfs__base_config:
         """Create a deep copy of this adata object"""
         return stratoweave_rfs__rfs__base_config.from_gdata(self.to_gdata())
 
@@ -1612,7 +1612,7 @@ class stratoweave_rfs__rfs__l3vpn_endpoint_entry(yang.adata.MNode):
     site_code: ?str
     description: ?str
 
-    mut def __init__(self, interface_name: str, vpn_name: str, customer_name: str, route_distinguisher: str, import_rt: str, export_rt: str, ipv4_address: str, prefix_length: u64, mtu: u64, enabled: bool, vlan_id: ?u64, site_code: ?str, description: ?str):
+    mut def __init__(self, interface_name: str, vpn_name: str, customer_name: str, route_distinguisher: str, import_rt: str, export_rt: str, ipv4_address: str, prefix_length: u64, mtu: u64, enabled: bool, vlan_id: ?u64, site_code: ?str, description: ?str) -> None:
         self._ns = 'http://example.com/mini-rfs'
         self.interface_name = interface_name
         self.vpn_name = vpn_name
@@ -1663,19 +1663,19 @@ class stratoweave_rfs__rfs__l3vpn_endpoint_entry(yang.adata.MNode):
     mut def from_gdata(n: yang.gdata.Node) -> stratoweave_rfs__rfs__l3vpn_endpoint_entry:
         return stratoweave_rfs__rfs__l3vpn_endpoint_entry(interface_name=n.get_str(yang.gdata.Id(NS_mini_rfs, 'interface-name')), vpn_name=n.get_str(yang.gdata.Id(NS_mini_rfs, 'vpn-name')), customer_name=n.get_str(yang.gdata.Id(NS_mini_rfs, 'customer-name')), route_distinguisher=n.get_str(yang.gdata.Id(NS_mini_rfs, 'route-distinguisher')), import_rt=n.get_str(yang.gdata.Id(NS_mini_rfs, 'import-rt')), export_rt=n.get_str(yang.gdata.Id(NS_mini_rfs, 'export-rt')), ipv4_address=n.get_str(yang.gdata.Id(NS_mini_rfs, 'ipv4-address')), prefix_length=n.get_u64(yang.gdata.Id(NS_mini_rfs, 'prefix-length')), mtu=n.get_u64(yang.gdata.Id(NS_mini_rfs, 'mtu')), vlan_id=n.get_opt_u64(yang.gdata.Id(NS_mini_rfs, 'vlan-id')), enabled=n.get_bool(yang.gdata.Id(NS_mini_rfs, 'enabled')), site_code=n.get_opt_str(yang.gdata.Id(NS_mini_rfs, 'site-code')), description=n.get_opt_str(yang.gdata.Id(NS_mini_rfs, 'description')))
 
-    def copy(self):
+    def copy(self) -> stratoweave_rfs__rfs__l3vpn_endpoint_entry:
         """Create a deep copy of this adata object"""
         return stratoweave_rfs__rfs__l3vpn_endpoint_entry.from_gdata(self.to_gdata())
 
 _breaker20 = None
 class stratoweave_rfs__rfs__l3vpn_endpoint(yang.adata.MNode):
     elements: list[stratoweave_rfs__rfs__l3vpn_endpoint_entry]
-    mut def __init__(self, elements=[]):
+    mut def __init__(self, elements: list[stratoweave_rfs__rfs__l3vpn_endpoint_entry]=[]) -> None:
         self._ns = 'http://example.com/mini-rfs'
         self._name = 'l3vpn-endpoint'
         self.elements = elements
 
-    mut def create(self, interface_name, vpn_name, customer_name, route_distinguisher, import_rt, export_rt, ipv4_address, prefix_length, mtu, enabled, vlan_id=None, site_code=None, description=None):
+    mut def create(self, interface_name: str, vpn_name: str, customer_name: str, route_distinguisher: str, import_rt: str, export_rt: str, ipv4_address: str, prefix_length: u64, mtu: u64, enabled: bool, vlan_id: ?u64=None, site_code: ?str=None, description: ?str=None) -> stratoweave_rfs__rfs__l3vpn_endpoint_entry:
         for e in self:
             match = True
             if e.interface_name != interface_name:
@@ -1709,7 +1709,7 @@ class stratoweave_rfs__rfs__l3vpn_endpoint(yang.adata.MNode):
             return [stratoweave_rfs__rfs__l3vpn_endpoint_entry.from_gdata(e) for e in n.elements]
         return []
 
-    def copy(self):
+    def copy(self) -> stratoweave_rfs__rfs__l3vpn_endpoint:
         """Create a deep copy of this list object"""
         # Copy each element in the list
         copied_elements = []
@@ -1729,7 +1729,7 @@ class stratoweave_rfs__rfs_entry(yang.adata.MNode):
     base_config: stratoweave_rfs__rfs__base_config
     l3vpn_endpoint: stratoweave_rfs__rfs__l3vpn_endpoint
 
-    mut def __init__(self, name: str, base_config: stratoweave_rfs__rfs__base_config, l3vpn_endpoint: list[stratoweave_rfs__rfs__l3vpn_endpoint_entry]=[]):
+    mut def __init__(self, name: str, base_config: stratoweave_rfs__rfs__base_config, l3vpn_endpoint: list[stratoweave_rfs__rfs__l3vpn_endpoint_entry]=[]) -> None:
         self._ns = 'http://stratoweave.org/yang/stratoweave-rfs.yang'
         self.name = name
         self.base_config = base_config
@@ -1750,19 +1750,19 @@ class stratoweave_rfs__rfs_entry(yang.adata.MNode):
     mut def from_gdata(n: yang.gdata.Node) -> stratoweave_rfs__rfs_entry:
         return stratoweave_rfs__rfs_entry(name=n.get_str(yang.gdata.Id(NS_stratoweave_rfs, 'name')), base_config=stratoweave_rfs__rfs__base_config.from_gdata(n.get_cnt(yang.gdata.Id(NS_mini_rfs, 'base-config'))), l3vpn_endpoint=stratoweave_rfs__rfs__l3vpn_endpoint.from_gdata(n.get_opt_list(yang.gdata.Id(NS_mini_rfs, 'l3vpn-endpoint'))))
 
-    def copy(self):
+    def copy(self) -> stratoweave_rfs__rfs_entry:
         """Create a deep copy of this adata object"""
         return stratoweave_rfs__rfs_entry.from_gdata(self.to_gdata())
 
 _breaker22 = None
 class stratoweave_rfs__rfs(yang.adata.MNode):
     elements: list[stratoweave_rfs__rfs_entry]
-    mut def __init__(self, elements=[]):
+    mut def __init__(self, elements: list[stratoweave_rfs__rfs_entry]=[]) -> None:
         self._ns = 'http://stratoweave.org/yang/stratoweave-rfs.yang'
         self._name = 'rfs'
         self.elements = elements
 
-    mut def create(self, name, base_config):
+    mut def create(self, name: str, base_config: stratoweave_rfs__rfs__base_config) -> stratoweave_rfs__rfs_entry:
         for e in self:
             match = True
             if e.name != name:
@@ -1782,7 +1782,7 @@ class stratoweave_rfs__rfs(yang.adata.MNode):
             return [stratoweave_rfs__rfs_entry.from_gdata(e) for e in n.elements]
         return []
 
-    def copy(self):
+    def copy(self) -> stratoweave_rfs__rfs:
         """Create a deep copy of this list object"""
         # Copy each element in the list
         copied_elements = []
@@ -1801,7 +1801,7 @@ class root(yang.adata.MNode):
     device: stratoweave_rfs__device
     rfs: stratoweave_rfs__rfs
 
-    mut def __init__(self, device: list[stratoweave_rfs__device_entry]=[], rfs: list[stratoweave_rfs__rfs_entry]=[]):
+    mut def __init__(self, device: list[stratoweave_rfs__device_entry]=[], rfs: list[stratoweave_rfs__rfs_entry]=[]) -> None:
         self._ns = ''
         self.device = stratoweave_rfs__device(elements=device)
         self.rfs = stratoweave_rfs__rfs(elements=rfs)
@@ -1821,7 +1821,7 @@ class root(yang.adata.MNode):
             return root(device=stratoweave_rfs__device.from_gdata(n.get_opt_list(yang.gdata.Id(NS_stratoweave_rfs, 'device'))), rfs=stratoweave_rfs__rfs.from_gdata(n.get_opt_list(yang.gdata.Id(NS_stratoweave_rfs, 'rfs'))))
         return root()
 
-    def copy(self):
+    def copy(self) -> root:
         """Create a deep copy of this adata object"""
         return root.from_gdata(self.to_gdata())
 

--- a/minisys/src/mini/layers/y_1_loose.act
+++ b/minisys/src/mini/layers/y_1_loose.act
@@ -935,7 +935,7 @@ class stratoweave_rfs__device__address__initial_credentials_entry(yang.adata.MNo
     password: str
     key: str
 
-    mut def __init__(self, username: str, password: str, key: str):
+    mut def __init__(self, username: str, password: str, key: str) -> None:
         self._ns = 'http://stratoweave.org/yang/stratoweave-rfs.yang'
         self.username = username
         self.password = password
@@ -956,19 +956,19 @@ class stratoweave_rfs__device__address__initial_credentials_entry(yang.adata.MNo
     mut def from_gdata(n: yang.gdata.Node) -> stratoweave_rfs__device__address__initial_credentials_entry:
         return stratoweave_rfs__device__address__initial_credentials_entry(username=n.get_str(yang.gdata.Id(NS_stratoweave_rfs, 'username')), password=n.get_str(yang.gdata.Id(NS_stratoweave_rfs, 'password')), key=n.get_str(yang.gdata.Id(NS_stratoweave_rfs, 'key')))
 
-    def copy(self):
+    def copy(self) -> stratoweave_rfs__device__address__initial_credentials_entry:
         """Create a deep copy of this adata object"""
         return stratoweave_rfs__device__address__initial_credentials_entry.from_gdata(self.to_gdata())
 
 _breaker2 = None
 class stratoweave_rfs__device__address__initial_credentials(yang.adata.MNode):
     elements: list[stratoweave_rfs__device__address__initial_credentials_entry]
-    mut def __init__(self, elements=[]):
+    mut def __init__(self, elements: list[stratoweave_rfs__device__address__initial_credentials_entry]=[]) -> None:
         self._ns = 'http://stratoweave.org/yang/stratoweave-rfs.yang'
         self._name = 'initial-credentials'
         self.elements = elements
 
-    mut def create(self, username, password, key):
+    mut def create(self, username: str, password: str, key: str) -> stratoweave_rfs__device__address__initial_credentials_entry:
         for e in self:
             match = True
             if e.username != username:
@@ -993,7 +993,7 @@ class stratoweave_rfs__device__address__initial_credentials(yang.adata.MNode):
             return [stratoweave_rfs__device__address__initial_credentials_entry.from_gdata(e) for e in n.elements]
         return []
 
-    def copy(self):
+    def copy(self) -> stratoweave_rfs__device__address__initial_credentials:
         """Create a deep copy of this list object"""
         # Copy each element in the list
         copied_elements = []
@@ -1014,7 +1014,7 @@ class stratoweave_rfs__device__address_entry(yang.adata.MNode):
     port: ?u64
     initial_credentials: stratoweave_rfs__device__address__initial_credentials
 
-    mut def __init__(self, name: str, address: ?str, port: ?u64, initial_credentials: list[stratoweave_rfs__device__address__initial_credentials_entry]=[]):
+    mut def __init__(self, name: str, address: ?str, port: ?u64, initial_credentials: list[stratoweave_rfs__device__address__initial_credentials_entry]=[]) -> None:
         self._ns = 'http://stratoweave.org/yang/stratoweave-rfs.yang'
         self.name = name
         self.address = address
@@ -1038,19 +1038,19 @@ class stratoweave_rfs__device__address_entry(yang.adata.MNode):
     mut def from_gdata(n: yang.gdata.Node) -> stratoweave_rfs__device__address_entry:
         return stratoweave_rfs__device__address_entry(name=n.get_str(yang.gdata.Id(NS_stratoweave_rfs, 'name')), address=n.get_opt_str(yang.gdata.Id(NS_stratoweave_rfs, 'address')), port=n.get_opt_u64(yang.gdata.Id(NS_stratoweave_rfs, 'port')), initial_credentials=stratoweave_rfs__device__address__initial_credentials.from_gdata(n.get_opt_list(yang.gdata.Id(NS_stratoweave_rfs, 'initial-credentials'))))
 
-    def copy(self):
+    def copy(self) -> stratoweave_rfs__device__address_entry:
         """Create a deep copy of this adata object"""
         return stratoweave_rfs__device__address_entry.from_gdata(self.to_gdata())
 
 _breaker4 = None
 class stratoweave_rfs__device__address(yang.adata.MNode):
     elements: list[stratoweave_rfs__device__address_entry]
-    mut def __init__(self, elements=[]):
+    mut def __init__(self, elements: list[stratoweave_rfs__device__address_entry]=[]) -> None:
         self._ns = 'http://stratoweave.org/yang/stratoweave-rfs.yang'
         self._name = 'address'
         self.elements = elements
 
-    mut def create(self, name, address=None, port=None):
+    mut def create(self, name: str, address: ?str=None, port: ?u64=None) -> stratoweave_rfs__device__address_entry:
         for e in self:
             match = True
             if e.name != name:
@@ -1073,7 +1073,7 @@ class stratoweave_rfs__device__address(yang.adata.MNode):
             return [stratoweave_rfs__device__address_entry.from_gdata(e) for e in n.elements]
         return []
 
-    def copy(self):
+    def copy(self) -> stratoweave_rfs__device__address:
         """Create a deep copy of this list object"""
         # Copy each element in the list
         copied_elements = []
@@ -1092,7 +1092,7 @@ class stratoweave_rfs__device__credentials__key_entry(yang.adata.MNode):
     key: str
     private_key: ?str
 
-    mut def __init__(self, key: str, private_key: ?str):
+    mut def __init__(self, key: str, private_key: ?str) -> None:
         self._ns = 'http://stratoweave.org/yang/stratoweave-rfs.yang'
         self.key = key
         self.private_key = private_key
@@ -1110,19 +1110,19 @@ class stratoweave_rfs__device__credentials__key_entry(yang.adata.MNode):
     mut def from_gdata(n: yang.gdata.Node) -> stratoweave_rfs__device__credentials__key_entry:
         return stratoweave_rfs__device__credentials__key_entry(key=n.get_str(yang.gdata.Id(NS_stratoweave_rfs, 'key')), private_key=n.get_opt_str(yang.gdata.Id(NS_stratoweave_rfs, 'private-key')))
 
-    def copy(self):
+    def copy(self) -> stratoweave_rfs__device__credentials__key_entry:
         """Create a deep copy of this adata object"""
         return stratoweave_rfs__device__credentials__key_entry.from_gdata(self.to_gdata())
 
 _breaker6 = None
 class stratoweave_rfs__device__credentials__key(yang.adata.MNode):
     elements: list[stratoweave_rfs__device__credentials__key_entry]
-    mut def __init__(self, elements=[]):
+    mut def __init__(self, elements: list[stratoweave_rfs__device__credentials__key_entry]=[]) -> None:
         self._ns = 'http://stratoweave.org/yang/stratoweave-rfs.yang'
         self._name = 'key'
         self.elements = elements
 
-    mut def create(self, key, private_key=None):
+    mut def create(self, key: str, private_key: ?str=None) -> stratoweave_rfs__device__credentials__key_entry:
         for e in self:
             match = True
             if e.key != key:
@@ -1143,7 +1143,7 @@ class stratoweave_rfs__device__credentials__key(yang.adata.MNode):
             return [stratoweave_rfs__device__credentials__key_entry.from_gdata(e) for e in n.elements]
         return []
 
-    def copy(self):
+    def copy(self) -> stratoweave_rfs__device__credentials__key:
         """Create a deep copy of this list object"""
         # Copy each element in the list
         copied_elements = []
@@ -1163,7 +1163,7 @@ class stratoweave_rfs__device__credentials(yang.adata.MNode):
     password: ?str
     key: stratoweave_rfs__device__credentials__key
 
-    mut def __init__(self, username: ?str, password: ?str, key: list[stratoweave_rfs__device__credentials__key_entry]=[]):
+    mut def __init__(self, username: ?str, password: ?str, key: list[stratoweave_rfs__device__credentials__key_entry]=[]) -> None:
         self._ns = 'http://stratoweave.org/yang/stratoweave-rfs.yang'
         self.username = username
         self.password = password
@@ -1186,7 +1186,7 @@ class stratoweave_rfs__device__credentials(yang.adata.MNode):
             return stratoweave_rfs__device__credentials(username=n.get_opt_str(yang.gdata.Id(NS_stratoweave_rfs, 'username')), password=n.get_opt_str(yang.gdata.Id(NS_stratoweave_rfs, 'password')), key=stratoweave_rfs__device__credentials__key.from_gdata(n.get_opt_list(yang.gdata.Id(NS_stratoweave_rfs, 'key'))))
         return stratoweave_rfs__device__credentials()
 
-    def copy(self):
+    def copy(self) -> stratoweave_rfs__device__credentials:
         """Create a deep copy of this adata object"""
         return stratoweave_rfs__device__credentials.from_gdata(self.to_gdata())
 
@@ -1197,7 +1197,7 @@ class stratoweave_rfs__device__initial_credentials_entry(yang.adata.MNode):
     password: str
     key: str
 
-    mut def __init__(self, username: str, password: str, key: str):
+    mut def __init__(self, username: str, password: str, key: str) -> None:
         self._ns = 'http://stratoweave.org/yang/stratoweave-rfs.yang'
         self.username = username
         self.password = password
@@ -1218,19 +1218,19 @@ class stratoweave_rfs__device__initial_credentials_entry(yang.adata.MNode):
     mut def from_gdata(n: yang.gdata.Node) -> stratoweave_rfs__device__initial_credentials_entry:
         return stratoweave_rfs__device__initial_credentials_entry(username=n.get_str(yang.gdata.Id(NS_stratoweave_rfs, 'username')), password=n.get_str(yang.gdata.Id(NS_stratoweave_rfs, 'password')), key=n.get_str(yang.gdata.Id(NS_stratoweave_rfs, 'key')))
 
-    def copy(self):
+    def copy(self) -> stratoweave_rfs__device__initial_credentials_entry:
         """Create a deep copy of this adata object"""
         return stratoweave_rfs__device__initial_credentials_entry.from_gdata(self.to_gdata())
 
 _breaker9 = None
 class stratoweave_rfs__device__initial_credentials(yang.adata.MNode):
     elements: list[stratoweave_rfs__device__initial_credentials_entry]
-    mut def __init__(self, elements=[]):
+    mut def __init__(self, elements: list[stratoweave_rfs__device__initial_credentials_entry]=[]) -> None:
         self._ns = 'http://stratoweave.org/yang/stratoweave-rfs.yang'
         self._name = 'initial-credentials'
         self.elements = elements
 
-    mut def create(self, username, password, key):
+    mut def create(self, username: str, password: str, key: str) -> stratoweave_rfs__device__initial_credentials_entry:
         for e in self:
             match = True
             if e.username != username:
@@ -1255,7 +1255,7 @@ class stratoweave_rfs__device__initial_credentials(yang.adata.MNode):
             return [stratoweave_rfs__device__initial_credentials_entry.from_gdata(e) for e in n.elements]
         return []
 
-    def copy(self):
+    def copy(self) -> stratoweave_rfs__device__initial_credentials:
         """Create a deep copy of this list object"""
         # Copy each element in the list
         copied_elements = []
@@ -1276,7 +1276,7 @@ class stratoweave_rfs__device__mock__module_entry(yang.adata.MNode):
     revision: ?str
     feature: list[str]
 
-    mut def __init__(self, name: str, namespace: ?str, revision: ?str, feature: ?list[str]=None):
+    mut def __init__(self, name: str, namespace: ?str, revision: ?str, feature: ?list[str]=None) -> None:
         self._ns = 'http://stratoweave.org/yang/stratoweave-rfs.yang'
         self.name = name
         self.namespace = namespace
@@ -1300,19 +1300,19 @@ class stratoweave_rfs__device__mock__module_entry(yang.adata.MNode):
     mut def from_gdata(n: yang.gdata.Node) -> stratoweave_rfs__device__mock__module_entry:
         return stratoweave_rfs__device__mock__module_entry(name=n.get_str(yang.gdata.Id(NS_stratoweave_rfs, 'name')), namespace=n.get_opt_str(yang.gdata.Id(NS_stratoweave_rfs, 'namespace')), revision=n.get_opt_str(yang.gdata.Id(NS_stratoweave_rfs, 'revision')), feature=n.get_opt_strs(yang.gdata.Id(NS_stratoweave_rfs, 'feature')))
 
-    def copy(self):
+    def copy(self) -> stratoweave_rfs__device__mock__module_entry:
         """Create a deep copy of this adata object"""
         return stratoweave_rfs__device__mock__module_entry.from_gdata(self.to_gdata())
 
 _breaker11 = None
 class stratoweave_rfs__device__mock__module(yang.adata.MNode):
     elements: list[stratoweave_rfs__device__mock__module_entry]
-    mut def __init__(self, elements=[]):
+    mut def __init__(self, elements: list[stratoweave_rfs__device__mock__module_entry]=[]) -> None:
         self._ns = 'http://stratoweave.org/yang/stratoweave-rfs.yang'
         self._name = 'module'
         self.elements = elements
 
-    mut def create(self, name, namespace=None, revision=None):
+    mut def create(self, name: str, namespace: ?str=None, revision: ?str=None) -> stratoweave_rfs__device__mock__module_entry:
         for e in self:
             match = True
             if e.name != name:
@@ -1335,7 +1335,7 @@ class stratoweave_rfs__device__mock__module(yang.adata.MNode):
             return [stratoweave_rfs__device__mock__module_entry.from_gdata(e) for e in n.elements]
         return []
 
-    def copy(self):
+    def copy(self) -> stratoweave_rfs__device__mock__module:
         """Create a deep copy of this list object"""
         # Copy each element in the list
         copied_elements = []
@@ -1355,7 +1355,7 @@ class stratoweave_rfs__device__mock(yang.adata.MNode):
     preset: list[str]
     module: stratoweave_rfs__device__mock__module
 
-    mut def __init__(self, enabled: ?bool, preset: ?list[str]=None, module: list[stratoweave_rfs__device__mock__module_entry]=[]):
+    mut def __init__(self, enabled: ?bool, preset: ?list[str]=None, module: list[stratoweave_rfs__device__mock__module_entry]=[]) -> None:
         self._ns = 'http://stratoweave.org/yang/stratoweave-rfs.yang'
         self.enabled = enabled
         self.preset = preset if preset is not None else []
@@ -1378,7 +1378,7 @@ class stratoweave_rfs__device__mock(yang.adata.MNode):
             return stratoweave_rfs__device__mock(enabled=n.get_opt_bool(yang.gdata.Id(NS_stratoweave_rfs, 'enabled')), preset=n.get_opt_strs(yang.gdata.Id(NS_stratoweave_rfs, 'preset')), module=stratoweave_rfs__device__mock__module.from_gdata(n.get_opt_list(yang.gdata.Id(NS_stratoweave_rfs, 'module'))))
         return stratoweave_rfs__device__mock()
 
-    def copy(self):
+    def copy(self) -> stratoweave_rfs__device__mock:
         """Create a deep copy of this adata object"""
         return stratoweave_rfs__device__mock.from_gdata(self.to_gdata())
 
@@ -1387,7 +1387,7 @@ _breaker13 = None
 class stratoweave_rfs__device__debug(yang.adata.MNode):
     connection: ?bool
 
-    mut def __init__(self, connection: ?bool):
+    mut def __init__(self, connection: ?bool) -> None:
         self._ns = 'http://stratoweave.org/yang/stratoweave-rfs.yang'
         self.connection = connection
 
@@ -1404,7 +1404,7 @@ class stratoweave_rfs__device__debug(yang.adata.MNode):
             return stratoweave_rfs__device__debug(connection=n.get_opt_bool(yang.gdata.Id(NS_stratoweave_rfs, 'connection')))
         return stratoweave_rfs__device__debug()
 
-    def copy(self):
+    def copy(self) -> stratoweave_rfs__device__debug:
         """Create a deep copy of this adata object"""
         return stratoweave_rfs__device__debug.from_gdata(self.to_gdata())
 
@@ -1413,7 +1413,7 @@ _breaker14 = None
 class stratoweave_rfs__device__feature_flags(yang.adata.MNode):
     runtime_schema_fetch: ?bool
 
-    mut def __init__(self, runtime_schema_fetch: ?bool):
+    mut def __init__(self, runtime_schema_fetch: ?bool) -> None:
         self._ns = 'http://stratoweave.org/yang/stratoweave-rfs.yang'
         self.runtime_schema_fetch = runtime_schema_fetch
 
@@ -1430,7 +1430,7 @@ class stratoweave_rfs__device__feature_flags(yang.adata.MNode):
             return stratoweave_rfs__device__feature_flags(runtime_schema_fetch=n.get_opt_bool(yang.gdata.Id(NS_stratoweave_rfs, 'runtime-schema-fetch')))
         return stratoweave_rfs__device__feature_flags()
 
-    def copy(self):
+    def copy(self) -> stratoweave_rfs__device__feature_flags:
         """Create a deep copy of this adata object"""
         return stratoweave_rfs__device__feature_flags.from_gdata(self.to_gdata())
 
@@ -1448,7 +1448,7 @@ class stratoweave_rfs__device_entry(yang.adata.MNode):
     debug: stratoweave_rfs__device__debug
     feature_flags: stratoweave_rfs__device__feature_flags
 
-    mut def __init__(self, name: str, description: ?str, type: ?str, address: list[stratoweave_rfs__device__address_entry]=[], credentials: ?stratoweave_rfs__device__credentials=None, initial_credentials: list[stratoweave_rfs__device__initial_credentials_entry]=[], approval_required: ?bool, mock: ?stratoweave_rfs__device__mock=None, debug: ?stratoweave_rfs__device__debug=None, feature_flags: ?stratoweave_rfs__device__feature_flags=None):
+    mut def __init__(self, name: str, description: ?str, type: ?str, address: list[stratoweave_rfs__device__address_entry]=[], credentials: ?stratoweave_rfs__device__credentials=None, initial_credentials: list[stratoweave_rfs__device__initial_credentials_entry]=[], approval_required: ?bool, mock: ?stratoweave_rfs__device__mock=None, debug: ?stratoweave_rfs__device__debug=None, feature_flags: ?stratoweave_rfs__device__feature_flags=None) -> None:
         self._ns = 'http://stratoweave.org/yang/stratoweave-rfs.yang'
         self.name = name
         self.description = description
@@ -1490,19 +1490,19 @@ class stratoweave_rfs__device_entry(yang.adata.MNode):
     mut def from_gdata(n: yang.gdata.Node) -> stratoweave_rfs__device_entry:
         return stratoweave_rfs__device_entry(name=n.get_str(yang.gdata.Id(NS_stratoweave_rfs, 'name')), description=n.get_opt_str(yang.gdata.Id(NS_stratoweave_rfs, 'description')), type=n.get_opt_str(yang.gdata.Id(NS_stratoweave_rfs, 'type')), address=stratoweave_rfs__device__address.from_gdata(n.get_opt_list(yang.gdata.Id(NS_stratoweave_rfs, 'address'))), credentials=stratoweave_rfs__device__credentials.from_gdata(n.get_opt_cnt(yang.gdata.Id(NS_stratoweave_rfs, 'credentials'))), initial_credentials=stratoweave_rfs__device__initial_credentials.from_gdata(n.get_opt_list(yang.gdata.Id(NS_stratoweave_rfs, 'initial-credentials'))), approval_required=n.get_opt_bool(yang.gdata.Id(NS_stratoweave_rfs, 'approval-required')), mock=stratoweave_rfs__device__mock.from_gdata(n.get_opt_cnt(yang.gdata.Id(NS_stratoweave_rfs, 'mock'))), debug=stratoweave_rfs__device__debug.from_gdata(n.get_opt_cnt(yang.gdata.Id(NS_stratoweave_rfs, 'debug'))), feature_flags=stratoweave_rfs__device__feature_flags.from_gdata(n.get_opt_cnt(yang.gdata.Id(NS_stratoweave_rfs, 'feature-flags'))))
 
-    def copy(self):
+    def copy(self) -> stratoweave_rfs__device_entry:
         """Create a deep copy of this adata object"""
         return stratoweave_rfs__device_entry.from_gdata(self.to_gdata())
 
 _breaker16 = None
 class stratoweave_rfs__device(yang.adata.MNode):
     elements: list[stratoweave_rfs__device_entry]
-    mut def __init__(self, elements=[]):
+    mut def __init__(self, elements: list[stratoweave_rfs__device_entry]=[]) -> None:
         self._ns = 'http://stratoweave.org/yang/stratoweave-rfs.yang'
         self._name = 'device'
         self.elements = elements
 
-    mut def create(self, name, description=None, type=None, approval_required=None):
+    mut def create(self, name: str, description: ?str=None, type: ?str=None, approval_required: ?bool=None) -> stratoweave_rfs__device_entry:
         for e in self:
             match = True
             if e.name != name:
@@ -1527,7 +1527,7 @@ class stratoweave_rfs__device(yang.adata.MNode):
             return [stratoweave_rfs__device_entry.from_gdata(e) for e in n.elements]
         return []
 
-    def copy(self):
+    def copy(self) -> stratoweave_rfs__device:
         """Create a deep copy of this list object"""
         # Copy each element in the list
         copied_elements = []
@@ -1545,7 +1545,7 @@ _breaker17 = None
 class stratoweave_rfs__rfs__base_config__dynstate(yang.adata.MNode):
     current_datetime: ?str
 
-    mut def __init__(self, current_datetime: ?str):
+    mut def __init__(self, current_datetime: ?str) -> None:
         self._ns = 'http://example.com/mini-rfs'
         self.current_datetime = current_datetime
 
@@ -1562,7 +1562,7 @@ class stratoweave_rfs__rfs__base_config__dynstate(yang.adata.MNode):
             return stratoweave_rfs__rfs__base_config__dynstate(current_datetime=n.get_opt_str(yang.gdata.Id(NS_mini_rfs, 'current-datetime')))
         return stratoweave_rfs__rfs__base_config__dynstate()
 
-    def copy(self):
+    def copy(self) -> stratoweave_rfs__rfs__base_config__dynstate:
         """Create a deep copy of this adata object"""
         return stratoweave_rfs__rfs__base_config__dynstate.from_gdata(self.to_gdata())
 
@@ -1572,7 +1572,7 @@ class stratoweave_rfs__rfs__base_config(yang.adata.MNode):
     name: ?str
     ipv4_address: ?str
 
-    mut def __init__(self, name: ?str, ipv4_address: ?str):
+    mut def __init__(self, name: ?str, ipv4_address: ?str) -> None:
         self._ns = 'http://example.com/mini-rfs'
         self.name = name
         self.ipv4_address = ipv4_address
@@ -1592,7 +1592,7 @@ class stratoweave_rfs__rfs__base_config(yang.adata.MNode):
             return stratoweave_rfs__rfs__base_config(name=n.get_opt_str(yang.gdata.Id(NS_mini_rfs, 'name')), ipv4_address=n.get_opt_str(yang.gdata.Id(NS_mini_rfs, 'ipv4-address')))
         return stratoweave_rfs__rfs__base_config()
 
-    def copy(self):
+    def copy(self) -> stratoweave_rfs__rfs__base_config:
         """Create a deep copy of this adata object"""
         return stratoweave_rfs__rfs__base_config.from_gdata(self.to_gdata())
 
@@ -1613,7 +1613,7 @@ class stratoweave_rfs__rfs__l3vpn_endpoint_entry(yang.adata.MNode):
     site_code: ?str
     description: ?str
 
-    mut def __init__(self, interface_name: str, vpn_name: ?str, customer_name: ?str, route_distinguisher: ?str, import_rt: ?str, export_rt: ?str, ipv4_address: ?str, prefix_length: ?u64, mtu: ?u64, vlan_id: ?u64, enabled: ?bool, site_code: ?str, description: ?str):
+    mut def __init__(self, interface_name: str, vpn_name: ?str, customer_name: ?str, route_distinguisher: ?str, import_rt: ?str, export_rt: ?str, ipv4_address: ?str, prefix_length: ?u64, mtu: ?u64, vlan_id: ?u64, enabled: ?bool, site_code: ?str, description: ?str) -> None:
         self._ns = 'http://example.com/mini-rfs'
         self.interface_name = interface_name
         self.vpn_name = vpn_name
@@ -1664,19 +1664,19 @@ class stratoweave_rfs__rfs__l3vpn_endpoint_entry(yang.adata.MNode):
     mut def from_gdata(n: yang.gdata.Node) -> stratoweave_rfs__rfs__l3vpn_endpoint_entry:
         return stratoweave_rfs__rfs__l3vpn_endpoint_entry(interface_name=n.get_str(yang.gdata.Id(NS_mini_rfs, 'interface-name')), vpn_name=n.get_opt_str(yang.gdata.Id(NS_mini_rfs, 'vpn-name')), customer_name=n.get_opt_str(yang.gdata.Id(NS_mini_rfs, 'customer-name')), route_distinguisher=n.get_opt_str(yang.gdata.Id(NS_mini_rfs, 'route-distinguisher')), import_rt=n.get_opt_str(yang.gdata.Id(NS_mini_rfs, 'import-rt')), export_rt=n.get_opt_str(yang.gdata.Id(NS_mini_rfs, 'export-rt')), ipv4_address=n.get_opt_str(yang.gdata.Id(NS_mini_rfs, 'ipv4-address')), prefix_length=n.get_opt_u64(yang.gdata.Id(NS_mini_rfs, 'prefix-length')), mtu=n.get_opt_u64(yang.gdata.Id(NS_mini_rfs, 'mtu')), vlan_id=n.get_opt_u64(yang.gdata.Id(NS_mini_rfs, 'vlan-id')), enabled=n.get_opt_bool(yang.gdata.Id(NS_mini_rfs, 'enabled')), site_code=n.get_opt_str(yang.gdata.Id(NS_mini_rfs, 'site-code')), description=n.get_opt_str(yang.gdata.Id(NS_mini_rfs, 'description')))
 
-    def copy(self):
+    def copy(self) -> stratoweave_rfs__rfs__l3vpn_endpoint_entry:
         """Create a deep copy of this adata object"""
         return stratoweave_rfs__rfs__l3vpn_endpoint_entry.from_gdata(self.to_gdata())
 
 _breaker20 = None
 class stratoweave_rfs__rfs__l3vpn_endpoint(yang.adata.MNode):
     elements: list[stratoweave_rfs__rfs__l3vpn_endpoint_entry]
-    mut def __init__(self, elements=[]):
+    mut def __init__(self, elements: list[stratoweave_rfs__rfs__l3vpn_endpoint_entry]=[]) -> None:
         self._ns = 'http://example.com/mini-rfs'
         self._name = 'l3vpn-endpoint'
         self.elements = elements
 
-    mut def create(self, interface_name, vpn_name=None, customer_name=None, route_distinguisher=None, import_rt=None, export_rt=None, ipv4_address=None, prefix_length=None, mtu=None, vlan_id=None, enabled=None, site_code=None, description=None):
+    mut def create(self, interface_name: str, vpn_name: ?str=None, customer_name: ?str=None, route_distinguisher: ?str=None, import_rt: ?str=None, export_rt: ?str=None, ipv4_address: ?str=None, prefix_length: ?u64=None, mtu: ?u64=None, vlan_id: ?u64=None, enabled: ?bool=None, site_code: ?str=None, description: ?str=None) -> stratoweave_rfs__rfs__l3vpn_endpoint_entry:
         for e in self:
             match = True
             if e.interface_name != interface_name:
@@ -1719,7 +1719,7 @@ class stratoweave_rfs__rfs__l3vpn_endpoint(yang.adata.MNode):
             return [stratoweave_rfs__rfs__l3vpn_endpoint_entry.from_gdata(e) for e in n.elements]
         return []
 
-    def copy(self):
+    def copy(self) -> stratoweave_rfs__rfs__l3vpn_endpoint:
         """Create a deep copy of this list object"""
         # Copy each element in the list
         copied_elements = []
@@ -1739,7 +1739,7 @@ class stratoweave_rfs__rfs_entry(yang.adata.MNode):
     base_config: stratoweave_rfs__rfs__base_config
     l3vpn_endpoint: stratoweave_rfs__rfs__l3vpn_endpoint
 
-    mut def __init__(self, name: str, base_config: ?stratoweave_rfs__rfs__base_config=None, l3vpn_endpoint: list[stratoweave_rfs__rfs__l3vpn_endpoint_entry]=[]):
+    mut def __init__(self, name: str, base_config: ?stratoweave_rfs__rfs__base_config=None, l3vpn_endpoint: list[stratoweave_rfs__rfs__l3vpn_endpoint_entry]=[]) -> None:
         self._ns = 'http://stratoweave.org/yang/stratoweave-rfs.yang'
         self.name = name
         self.base_config = base_config if base_config is not None else stratoweave_rfs__rfs__base_config()
@@ -1760,19 +1760,19 @@ class stratoweave_rfs__rfs_entry(yang.adata.MNode):
     mut def from_gdata(n: yang.gdata.Node) -> stratoweave_rfs__rfs_entry:
         return stratoweave_rfs__rfs_entry(name=n.get_str(yang.gdata.Id(NS_stratoweave_rfs, 'name')), base_config=stratoweave_rfs__rfs__base_config.from_gdata(n.get_opt_cnt(yang.gdata.Id(NS_mini_rfs, 'base-config'))), l3vpn_endpoint=stratoweave_rfs__rfs__l3vpn_endpoint.from_gdata(n.get_opt_list(yang.gdata.Id(NS_mini_rfs, 'l3vpn-endpoint'))))
 
-    def copy(self):
+    def copy(self) -> stratoweave_rfs__rfs_entry:
         """Create a deep copy of this adata object"""
         return stratoweave_rfs__rfs_entry.from_gdata(self.to_gdata())
 
 _breaker22 = None
 class stratoweave_rfs__rfs(yang.adata.MNode):
     elements: list[stratoweave_rfs__rfs_entry]
-    mut def __init__(self, elements=[]):
+    mut def __init__(self, elements: list[stratoweave_rfs__rfs_entry]=[]) -> None:
         self._ns = 'http://stratoweave.org/yang/stratoweave-rfs.yang'
         self._name = 'rfs'
         self.elements = elements
 
-    mut def create(self, name):
+    mut def create(self, name: str) -> stratoweave_rfs__rfs_entry:
         for e in self:
             match = True
             if e.name != name:
@@ -1791,7 +1791,7 @@ class stratoweave_rfs__rfs(yang.adata.MNode):
             return [stratoweave_rfs__rfs_entry.from_gdata(e) for e in n.elements]
         return []
 
-    def copy(self):
+    def copy(self) -> stratoweave_rfs__rfs:
         """Create a deep copy of this list object"""
         # Copy each element in the list
         copied_elements = []
@@ -1810,7 +1810,7 @@ class root(yang.adata.MNode):
     device: stratoweave_rfs__device
     rfs: stratoweave_rfs__rfs
 
-    mut def __init__(self, device: list[stratoweave_rfs__device_entry]=[], rfs: list[stratoweave_rfs__rfs_entry]=[]):
+    mut def __init__(self, device: list[stratoweave_rfs__device_entry]=[], rfs: list[stratoweave_rfs__rfs_entry]=[]) -> None:
         self._ns = ''
         self.device = stratoweave_rfs__device(elements=device)
         self.rfs = stratoweave_rfs__rfs(elements=rfs)
@@ -1830,7 +1830,7 @@ class root(yang.adata.MNode):
             return root(device=stratoweave_rfs__device.from_gdata(n.get_opt_list(yang.gdata.Id(NS_stratoweave_rfs, 'device'))), rfs=stratoweave_rfs__rfs.from_gdata(n.get_opt_list(yang.gdata.Id(NS_stratoweave_rfs, 'rfs'))))
         return root()
 
-    def copy(self):
+    def copy(self) -> root:
         """Create a deep copy of this adata object"""
         return root.from_gdata(self.to_gdata())
 

--- a/minisys/src/mini/layers/y_1_oper.act
+++ b/minisys/src/mini/layers/y_1_oper.act
@@ -940,7 +940,7 @@ class stratoweave_rfs__device__address__initial_credentials_entry(yang.adata.MNo
     password: str
     key: str
 
-    mut def __init__(self, username: str, password: str, key: str):
+    mut def __init__(self, username: str, password: str, key: str) -> None:
         self._ns = 'http://stratoweave.org/yang/stratoweave-rfs.yang'
         self.username = username
         self.password = password
@@ -961,19 +961,19 @@ class stratoweave_rfs__device__address__initial_credentials_entry(yang.adata.MNo
     mut def from_gdata(n: yang.gdata.Node) -> stratoweave_rfs__device__address__initial_credentials_entry:
         return stratoweave_rfs__device__address__initial_credentials_entry(username=n.get_str(yang.gdata.Id(NS_stratoweave_rfs, 'username')), password=n.get_str(yang.gdata.Id(NS_stratoweave_rfs, 'password')), key=n.get_str(yang.gdata.Id(NS_stratoweave_rfs, 'key')))
 
-    def copy(self):
+    def copy(self) -> stratoweave_rfs__device__address__initial_credentials_entry:
         """Create a deep copy of this adata object"""
         return stratoweave_rfs__device__address__initial_credentials_entry.from_gdata(self.to_gdata())
 
 _breaker2 = None
 class stratoweave_rfs__device__address__initial_credentials(yang.adata.MNode):
     elements: list[stratoweave_rfs__device__address__initial_credentials_entry]
-    mut def __init__(self, elements=[]):
+    mut def __init__(self, elements: list[stratoweave_rfs__device__address__initial_credentials_entry]=[]) -> None:
         self._ns = 'http://stratoweave.org/yang/stratoweave-rfs.yang'
         self._name = 'initial-credentials'
         self.elements = elements
 
-    mut def create(self, username, password, key):
+    mut def create(self, username: str, password: str, key: str) -> stratoweave_rfs__device__address__initial_credentials_entry:
         for e in self:
             match = True
             if e.username != username:
@@ -998,7 +998,7 @@ class stratoweave_rfs__device__address__initial_credentials(yang.adata.MNode):
             return [stratoweave_rfs__device__address__initial_credentials_entry.from_gdata(e) for e in n.elements]
         return []
 
-    def copy(self):
+    def copy(self) -> stratoweave_rfs__device__address__initial_credentials:
         """Create a deep copy of this list object"""
         # Copy each element in the list
         copied_elements = []
@@ -1019,7 +1019,7 @@ class stratoweave_rfs__device__address_entry(yang.adata.MNode):
     port: ?u64
     initial_credentials: stratoweave_rfs__device__address__initial_credentials
 
-    mut def __init__(self, name: str, address: ?str, port: ?u64, initial_credentials: list[stratoweave_rfs__device__address__initial_credentials_entry]=[]):
+    mut def __init__(self, name: str, address: ?str, port: ?u64, initial_credentials: list[stratoweave_rfs__device__address__initial_credentials_entry]=[]) -> None:
         self._ns = 'http://stratoweave.org/yang/stratoweave-rfs.yang'
         self.name = name
         self.address = address
@@ -1043,19 +1043,19 @@ class stratoweave_rfs__device__address_entry(yang.adata.MNode):
     mut def from_gdata(n: yang.gdata.Node) -> stratoweave_rfs__device__address_entry:
         return stratoweave_rfs__device__address_entry(name=n.get_str(yang.gdata.Id(NS_stratoweave_rfs, 'name')), address=n.get_opt_str(yang.gdata.Id(NS_stratoweave_rfs, 'address')), port=n.get_opt_u64(yang.gdata.Id(NS_stratoweave_rfs, 'port')), initial_credentials=stratoweave_rfs__device__address__initial_credentials.from_gdata(n.get_opt_list(yang.gdata.Id(NS_stratoweave_rfs, 'initial-credentials'))))
 
-    def copy(self):
+    def copy(self) -> stratoweave_rfs__device__address_entry:
         """Create a deep copy of this adata object"""
         return stratoweave_rfs__device__address_entry.from_gdata(self.to_gdata())
 
 _breaker4 = None
 class stratoweave_rfs__device__address(yang.adata.MNode):
     elements: list[stratoweave_rfs__device__address_entry]
-    mut def __init__(self, elements=[]):
+    mut def __init__(self, elements: list[stratoweave_rfs__device__address_entry]=[]) -> None:
         self._ns = 'http://stratoweave.org/yang/stratoweave-rfs.yang'
         self._name = 'address'
         self.elements = elements
 
-    mut def create(self, name, address=None, port=None):
+    mut def create(self, name: str, address: ?str=None, port: ?u64=None) -> stratoweave_rfs__device__address_entry:
         for e in self:
             match = True
             if e.name != name:
@@ -1078,7 +1078,7 @@ class stratoweave_rfs__device__address(yang.adata.MNode):
             return [stratoweave_rfs__device__address_entry.from_gdata(e) for e in n.elements]
         return []
 
-    def copy(self):
+    def copy(self) -> stratoweave_rfs__device__address:
         """Create a deep copy of this list object"""
         # Copy each element in the list
         copied_elements = []
@@ -1097,7 +1097,7 @@ class stratoweave_rfs__device__credentials__key_entry(yang.adata.MNode):
     key: str
     private_key: ?str
 
-    mut def __init__(self, key: str, private_key: ?str):
+    mut def __init__(self, key: str, private_key: ?str) -> None:
         self._ns = 'http://stratoweave.org/yang/stratoweave-rfs.yang'
         self.key = key
         self.private_key = private_key
@@ -1115,19 +1115,19 @@ class stratoweave_rfs__device__credentials__key_entry(yang.adata.MNode):
     mut def from_gdata(n: yang.gdata.Node) -> stratoweave_rfs__device__credentials__key_entry:
         return stratoweave_rfs__device__credentials__key_entry(key=n.get_str(yang.gdata.Id(NS_stratoweave_rfs, 'key')), private_key=n.get_opt_str(yang.gdata.Id(NS_stratoweave_rfs, 'private-key')))
 
-    def copy(self):
+    def copy(self) -> stratoweave_rfs__device__credentials__key_entry:
         """Create a deep copy of this adata object"""
         return stratoweave_rfs__device__credentials__key_entry.from_gdata(self.to_gdata())
 
 _breaker6 = None
 class stratoweave_rfs__device__credentials__key(yang.adata.MNode):
     elements: list[stratoweave_rfs__device__credentials__key_entry]
-    mut def __init__(self, elements=[]):
+    mut def __init__(self, elements: list[stratoweave_rfs__device__credentials__key_entry]=[]) -> None:
         self._ns = 'http://stratoweave.org/yang/stratoweave-rfs.yang'
         self._name = 'key'
         self.elements = elements
 
-    mut def create(self, key, private_key=None):
+    mut def create(self, key: str, private_key: ?str=None) -> stratoweave_rfs__device__credentials__key_entry:
         for e in self:
             match = True
             if e.key != key:
@@ -1148,7 +1148,7 @@ class stratoweave_rfs__device__credentials__key(yang.adata.MNode):
             return [stratoweave_rfs__device__credentials__key_entry.from_gdata(e) for e in n.elements]
         return []
 
-    def copy(self):
+    def copy(self) -> stratoweave_rfs__device__credentials__key:
         """Create a deep copy of this list object"""
         # Copy each element in the list
         copied_elements = []
@@ -1168,7 +1168,7 @@ class stratoweave_rfs__device__credentials(yang.adata.MNode):
     password: ?str
     key: stratoweave_rfs__device__credentials__key
 
-    mut def __init__(self, username: ?str, password: ?str, key: list[stratoweave_rfs__device__credentials__key_entry]=[]):
+    mut def __init__(self, username: ?str, password: ?str, key: list[stratoweave_rfs__device__credentials__key_entry]=[]) -> None:
         self._ns = 'http://stratoweave.org/yang/stratoweave-rfs.yang'
         self.username = username
         self.password = password
@@ -1191,7 +1191,7 @@ class stratoweave_rfs__device__credentials(yang.adata.MNode):
             return stratoweave_rfs__device__credentials(username=n.get_opt_str(yang.gdata.Id(NS_stratoweave_rfs, 'username')), password=n.get_opt_str(yang.gdata.Id(NS_stratoweave_rfs, 'password')), key=stratoweave_rfs__device__credentials__key.from_gdata(n.get_opt_list(yang.gdata.Id(NS_stratoweave_rfs, 'key'))))
         return stratoweave_rfs__device__credentials()
 
-    def copy(self):
+    def copy(self) -> stratoweave_rfs__device__credentials:
         """Create a deep copy of this adata object"""
         return stratoweave_rfs__device__credentials.from_gdata(self.to_gdata())
 
@@ -1202,7 +1202,7 @@ class stratoweave_rfs__device__initial_credentials_entry(yang.adata.MNode):
     password: str
     key: str
 
-    mut def __init__(self, username: str, password: str, key: str):
+    mut def __init__(self, username: str, password: str, key: str) -> None:
         self._ns = 'http://stratoweave.org/yang/stratoweave-rfs.yang'
         self.username = username
         self.password = password
@@ -1223,19 +1223,19 @@ class stratoweave_rfs__device__initial_credentials_entry(yang.adata.MNode):
     mut def from_gdata(n: yang.gdata.Node) -> stratoweave_rfs__device__initial_credentials_entry:
         return stratoweave_rfs__device__initial_credentials_entry(username=n.get_str(yang.gdata.Id(NS_stratoweave_rfs, 'username')), password=n.get_str(yang.gdata.Id(NS_stratoweave_rfs, 'password')), key=n.get_str(yang.gdata.Id(NS_stratoweave_rfs, 'key')))
 
-    def copy(self):
+    def copy(self) -> stratoweave_rfs__device__initial_credentials_entry:
         """Create a deep copy of this adata object"""
         return stratoweave_rfs__device__initial_credentials_entry.from_gdata(self.to_gdata())
 
 _breaker9 = None
 class stratoweave_rfs__device__initial_credentials(yang.adata.MNode):
     elements: list[stratoweave_rfs__device__initial_credentials_entry]
-    mut def __init__(self, elements=[]):
+    mut def __init__(self, elements: list[stratoweave_rfs__device__initial_credentials_entry]=[]) -> None:
         self._ns = 'http://stratoweave.org/yang/stratoweave-rfs.yang'
         self._name = 'initial-credentials'
         self.elements = elements
 
-    mut def create(self, username, password, key):
+    mut def create(self, username: str, password: str, key: str) -> stratoweave_rfs__device__initial_credentials_entry:
         for e in self:
             match = True
             if e.username != username:
@@ -1260,7 +1260,7 @@ class stratoweave_rfs__device__initial_credentials(yang.adata.MNode):
             return [stratoweave_rfs__device__initial_credentials_entry.from_gdata(e) for e in n.elements]
         return []
 
-    def copy(self):
+    def copy(self) -> stratoweave_rfs__device__initial_credentials:
         """Create a deep copy of this list object"""
         # Copy each element in the list
         copied_elements = []
@@ -1281,7 +1281,7 @@ class stratoweave_rfs__device__mock__module_entry(yang.adata.MNode):
     revision: ?str
     feature: list[str]
 
-    mut def __init__(self, name: str, namespace: ?str, revision: ?str, feature: ?list[str]=None):
+    mut def __init__(self, name: str, namespace: ?str, revision: ?str, feature: ?list[str]=None) -> None:
         self._ns = 'http://stratoweave.org/yang/stratoweave-rfs.yang'
         self.name = name
         self.namespace = namespace
@@ -1305,19 +1305,19 @@ class stratoweave_rfs__device__mock__module_entry(yang.adata.MNode):
     mut def from_gdata(n: yang.gdata.Node) -> stratoweave_rfs__device__mock__module_entry:
         return stratoweave_rfs__device__mock__module_entry(name=n.get_str(yang.gdata.Id(NS_stratoweave_rfs, 'name')), namespace=n.get_opt_str(yang.gdata.Id(NS_stratoweave_rfs, 'namespace')), revision=n.get_opt_str(yang.gdata.Id(NS_stratoweave_rfs, 'revision')), feature=n.get_opt_strs(yang.gdata.Id(NS_stratoweave_rfs, 'feature')))
 
-    def copy(self):
+    def copy(self) -> stratoweave_rfs__device__mock__module_entry:
         """Create a deep copy of this adata object"""
         return stratoweave_rfs__device__mock__module_entry.from_gdata(self.to_gdata())
 
 _breaker11 = None
 class stratoweave_rfs__device__mock__module(yang.adata.MNode):
     elements: list[stratoweave_rfs__device__mock__module_entry]
-    mut def __init__(self, elements=[]):
+    mut def __init__(self, elements: list[stratoweave_rfs__device__mock__module_entry]=[]) -> None:
         self._ns = 'http://stratoweave.org/yang/stratoweave-rfs.yang'
         self._name = 'module'
         self.elements = elements
 
-    mut def create(self, name, namespace=None, revision=None):
+    mut def create(self, name: str, namespace: ?str=None, revision: ?str=None) -> stratoweave_rfs__device__mock__module_entry:
         for e in self:
             match = True
             if e.name != name:
@@ -1340,7 +1340,7 @@ class stratoweave_rfs__device__mock__module(yang.adata.MNode):
             return [stratoweave_rfs__device__mock__module_entry.from_gdata(e) for e in n.elements]
         return []
 
-    def copy(self):
+    def copy(self) -> stratoweave_rfs__device__mock__module:
         """Create a deep copy of this list object"""
         # Copy each element in the list
         copied_elements = []
@@ -1360,7 +1360,7 @@ class stratoweave_rfs__device__mock(yang.adata.MNode):
     preset: list[str]
     module: stratoweave_rfs__device__mock__module
 
-    mut def __init__(self, enabled: ?bool, preset: ?list[str]=None, module: list[stratoweave_rfs__device__mock__module_entry]=[]):
+    mut def __init__(self, enabled: ?bool, preset: ?list[str]=None, module: list[stratoweave_rfs__device__mock__module_entry]=[]) -> None:
         self._ns = 'http://stratoweave.org/yang/stratoweave-rfs.yang'
         self.enabled = enabled
         self.preset = preset if preset is not None else []
@@ -1383,7 +1383,7 @@ class stratoweave_rfs__device__mock(yang.adata.MNode):
             return stratoweave_rfs__device__mock(enabled=n.get_opt_bool(yang.gdata.Id(NS_stratoweave_rfs, 'enabled')), preset=n.get_opt_strs(yang.gdata.Id(NS_stratoweave_rfs, 'preset')), module=stratoweave_rfs__device__mock__module.from_gdata(n.get_opt_list(yang.gdata.Id(NS_stratoweave_rfs, 'module'))))
         return stratoweave_rfs__device__mock()
 
-    def copy(self):
+    def copy(self) -> stratoweave_rfs__device__mock:
         """Create a deep copy of this adata object"""
         return stratoweave_rfs__device__mock.from_gdata(self.to_gdata())
 
@@ -1392,7 +1392,7 @@ _breaker13 = None
 class stratoweave_rfs__device__debug(yang.adata.MNode):
     connection: ?bool
 
-    mut def __init__(self, connection: ?bool):
+    mut def __init__(self, connection: ?bool) -> None:
         self._ns = 'http://stratoweave.org/yang/stratoweave-rfs.yang'
         self.connection = connection
 
@@ -1409,7 +1409,7 @@ class stratoweave_rfs__device__debug(yang.adata.MNode):
             return stratoweave_rfs__device__debug(connection=n.get_opt_bool(yang.gdata.Id(NS_stratoweave_rfs, 'connection')))
         return stratoweave_rfs__device__debug()
 
-    def copy(self):
+    def copy(self) -> stratoweave_rfs__device__debug:
         """Create a deep copy of this adata object"""
         return stratoweave_rfs__device__debug.from_gdata(self.to_gdata())
 
@@ -1418,7 +1418,7 @@ _breaker14 = None
 class stratoweave_rfs__device__feature_flags(yang.adata.MNode):
     runtime_schema_fetch: ?bool
 
-    mut def __init__(self, runtime_schema_fetch: ?bool):
+    mut def __init__(self, runtime_schema_fetch: ?bool) -> None:
         self._ns = 'http://stratoweave.org/yang/stratoweave-rfs.yang'
         self.runtime_schema_fetch = runtime_schema_fetch
 
@@ -1435,7 +1435,7 @@ class stratoweave_rfs__device__feature_flags(yang.adata.MNode):
             return stratoweave_rfs__device__feature_flags(runtime_schema_fetch=n.get_opt_bool(yang.gdata.Id(NS_stratoweave_rfs, 'runtime-schema-fetch')))
         return stratoweave_rfs__device__feature_flags()
 
-    def copy(self):
+    def copy(self) -> stratoweave_rfs__device__feature_flags:
         """Create a deep copy of this adata object"""
         return stratoweave_rfs__device__feature_flags.from_gdata(self.to_gdata())
 
@@ -1443,7 +1443,7 @@ class stratoweave_rfs__device__feature_flags(yang.adata.MNode):
 _breaker15 = None
 class stratoweave_rfs__device__state(yang.adata.MNode):
 
-    mut def __init__(self):
+    mut def __init__(self) -> None:
         self._ns = 'http://stratoweave.org/yang/stratoweave-rfs.yang'
         pass
 
@@ -1456,7 +1456,7 @@ class stratoweave_rfs__device__state(yang.adata.MNode):
             return stratoweave_rfs__device__state()
         return stratoweave_rfs__device__state()
 
-    def copy(self):
+    def copy(self) -> stratoweave_rfs__device__state:
         """Create a deep copy of this adata object"""
         return stratoweave_rfs__device__state.from_gdata(self.to_gdata())
 
@@ -1475,7 +1475,7 @@ class stratoweave_rfs__device_entry(yang.adata.MNode):
     feature_flags: stratoweave_rfs__device__feature_flags
     state: stratoweave_rfs__device__state
 
-    mut def __init__(self, name: str, description: ?str, type: ?str, address: list[stratoweave_rfs__device__address_entry]=[], credentials: ?stratoweave_rfs__device__credentials=None, initial_credentials: list[stratoweave_rfs__device__initial_credentials_entry]=[], approval_required: ?bool, mock: ?stratoweave_rfs__device__mock=None, debug: ?stratoweave_rfs__device__debug=None, feature_flags: ?stratoweave_rfs__device__feature_flags=None, state: ?stratoweave_rfs__device__state=None):
+    mut def __init__(self, name: str, description: ?str, type: ?str, address: list[stratoweave_rfs__device__address_entry]=[], credentials: ?stratoweave_rfs__device__credentials=None, initial_credentials: list[stratoweave_rfs__device__initial_credentials_entry]=[], approval_required: ?bool, mock: ?stratoweave_rfs__device__mock=None, debug: ?stratoweave_rfs__device__debug=None, feature_flags: ?stratoweave_rfs__device__feature_flags=None, state: ?stratoweave_rfs__device__state=None) -> None:
         self._ns = 'http://stratoweave.org/yang/stratoweave-rfs.yang'
         self.name = name
         self.description = description
@@ -1520,19 +1520,19 @@ class stratoweave_rfs__device_entry(yang.adata.MNode):
     mut def from_gdata(n: yang.gdata.Node) -> stratoweave_rfs__device_entry:
         return stratoweave_rfs__device_entry(name=n.get_str(yang.gdata.Id(NS_stratoweave_rfs, 'name')), description=n.get_opt_str(yang.gdata.Id(NS_stratoweave_rfs, 'description')), type=n.get_opt_str(yang.gdata.Id(NS_stratoweave_rfs, 'type')), address=stratoweave_rfs__device__address.from_gdata(n.get_opt_list(yang.gdata.Id(NS_stratoweave_rfs, 'address'))), credentials=stratoweave_rfs__device__credentials.from_gdata(n.get_opt_cnt(yang.gdata.Id(NS_stratoweave_rfs, 'credentials'))), initial_credentials=stratoweave_rfs__device__initial_credentials.from_gdata(n.get_opt_list(yang.gdata.Id(NS_stratoweave_rfs, 'initial-credentials'))), approval_required=n.get_opt_bool(yang.gdata.Id(NS_stratoweave_rfs, 'approval-required')), mock=stratoweave_rfs__device__mock.from_gdata(n.get_opt_cnt(yang.gdata.Id(NS_stratoweave_rfs, 'mock'))), debug=stratoweave_rfs__device__debug.from_gdata(n.get_opt_cnt(yang.gdata.Id(NS_stratoweave_rfs, 'debug'))), feature_flags=stratoweave_rfs__device__feature_flags.from_gdata(n.get_opt_cnt(yang.gdata.Id(NS_stratoweave_rfs, 'feature-flags'))), state=stratoweave_rfs__device__state.from_gdata(n.get_opt_cnt(yang.gdata.Id(NS_stratoweave_rfs, 'state'))))
 
-    def copy(self):
+    def copy(self) -> stratoweave_rfs__device_entry:
         """Create a deep copy of this adata object"""
         return stratoweave_rfs__device_entry.from_gdata(self.to_gdata())
 
 _breaker17 = None
 class stratoweave_rfs__device(yang.adata.MNode):
     elements: list[stratoweave_rfs__device_entry]
-    mut def __init__(self, elements=[]):
+    mut def __init__(self, elements: list[stratoweave_rfs__device_entry]=[]) -> None:
         self._ns = 'http://stratoweave.org/yang/stratoweave-rfs.yang'
         self._name = 'device'
         self.elements = elements
 
-    mut def create(self, name, description=None, type=None, approval_required=None):
+    mut def create(self, name: str, description: ?str=None, type: ?str=None, approval_required: ?bool=None) -> stratoweave_rfs__device_entry:
         for e in self:
             match = True
             if e.name != name:
@@ -1557,7 +1557,7 @@ class stratoweave_rfs__device(yang.adata.MNode):
             return [stratoweave_rfs__device_entry.from_gdata(e) for e in n.elements]
         return []
 
-    def copy(self):
+    def copy(self) -> stratoweave_rfs__device:
         """Create a deep copy of this list object"""
         # Copy each element in the list
         copied_elements = []
@@ -1575,7 +1575,7 @@ _breaker18 = None
 class stratoweave_rfs__rfs__base_config__dynstate(yang.adata.MNode):
     current_datetime: ?str
 
-    mut def __init__(self, current_datetime: ?str):
+    mut def __init__(self, current_datetime: ?str) -> None:
         self._ns = 'http://example.com/mini-rfs'
         self.current_datetime = current_datetime
 
@@ -1592,7 +1592,7 @@ class stratoweave_rfs__rfs__base_config__dynstate(yang.adata.MNode):
             return stratoweave_rfs__rfs__base_config__dynstate(current_datetime=n.get_opt_str(yang.gdata.Id(NS_mini_rfs, 'current-datetime')))
         return stratoweave_rfs__rfs__base_config__dynstate()
 
-    def copy(self):
+    def copy(self) -> stratoweave_rfs__rfs__base_config__dynstate:
         """Create a deep copy of this adata object"""
         return stratoweave_rfs__rfs__base_config__dynstate.from_gdata(self.to_gdata())
 
@@ -1601,7 +1601,7 @@ _breaker19 = None
 class stratoweave_rfs__rfs__base_config__state(yang.adata.MNode):
     current_datetime: ?str
 
-    mut def __init__(self, current_datetime: ?str):
+    mut def __init__(self, current_datetime: ?str) -> None:
         self._ns = 'http://example.com/mini-rfs'
         self.current_datetime = current_datetime
 
@@ -1618,7 +1618,7 @@ class stratoweave_rfs__rfs__base_config__state(yang.adata.MNode):
             return stratoweave_rfs__rfs__base_config__state(current_datetime=n.get_opt_str(yang.gdata.Id(NS_mini_rfs, 'current-datetime')))
         return stratoweave_rfs__rfs__base_config__state()
 
-    def copy(self):
+    def copy(self) -> stratoweave_rfs__rfs__base_config__state:
         """Create a deep copy of this adata object"""
         return stratoweave_rfs__rfs__base_config__state.from_gdata(self.to_gdata())
 
@@ -1629,7 +1629,7 @@ class stratoweave_rfs__rfs__base_config(yang.adata.MNode):
     ipv4_address: ?str
     state: stratoweave_rfs__rfs__base_config__state
 
-    mut def __init__(self, name: ?str, ipv4_address: ?str, state: ?stratoweave_rfs__rfs__base_config__state=None):
+    mut def __init__(self, name: ?str, ipv4_address: ?str, state: ?stratoweave_rfs__rfs__base_config__state=None) -> None:
         self._ns = 'http://example.com/mini-rfs'
         self.name = name
         self.ipv4_address = ipv4_address
@@ -1652,7 +1652,7 @@ class stratoweave_rfs__rfs__base_config(yang.adata.MNode):
             return stratoweave_rfs__rfs__base_config(name=n.get_opt_str(yang.gdata.Id(NS_mini_rfs, 'name')), ipv4_address=n.get_opt_str(yang.gdata.Id(NS_mini_rfs, 'ipv4-address')), state=stratoweave_rfs__rfs__base_config__state.from_gdata(n.get_opt_cnt(yang.gdata.Id(NS_mini_rfs, 'state'))))
         return stratoweave_rfs__rfs__base_config()
 
-    def copy(self):
+    def copy(self) -> stratoweave_rfs__rfs__base_config:
         """Create a deep copy of this adata object"""
         return stratoweave_rfs__rfs__base_config.from_gdata(self.to_gdata())
 
@@ -1673,7 +1673,7 @@ class stratoweave_rfs__rfs__l3vpn_endpoint_entry(yang.adata.MNode):
     site_code: ?str
     description: ?str
 
-    mut def __init__(self, interface_name: str, vpn_name: ?str, customer_name: ?str, route_distinguisher: ?str, import_rt: ?str, export_rt: ?str, ipv4_address: ?str, prefix_length: ?u64, mtu: ?u64, vlan_id: ?u64, enabled: ?bool, site_code: ?str, description: ?str):
+    mut def __init__(self, interface_name: str, vpn_name: ?str, customer_name: ?str, route_distinguisher: ?str, import_rt: ?str, export_rt: ?str, ipv4_address: ?str, prefix_length: ?u64, mtu: ?u64, vlan_id: ?u64, enabled: ?bool, site_code: ?str, description: ?str) -> None:
         self._ns = 'http://example.com/mini-rfs'
         self.interface_name = interface_name
         self.vpn_name = vpn_name
@@ -1724,19 +1724,19 @@ class stratoweave_rfs__rfs__l3vpn_endpoint_entry(yang.adata.MNode):
     mut def from_gdata(n: yang.gdata.Node) -> stratoweave_rfs__rfs__l3vpn_endpoint_entry:
         return stratoweave_rfs__rfs__l3vpn_endpoint_entry(interface_name=n.get_str(yang.gdata.Id(NS_mini_rfs, 'interface-name')), vpn_name=n.get_opt_str(yang.gdata.Id(NS_mini_rfs, 'vpn-name')), customer_name=n.get_opt_str(yang.gdata.Id(NS_mini_rfs, 'customer-name')), route_distinguisher=n.get_opt_str(yang.gdata.Id(NS_mini_rfs, 'route-distinguisher')), import_rt=n.get_opt_str(yang.gdata.Id(NS_mini_rfs, 'import-rt')), export_rt=n.get_opt_str(yang.gdata.Id(NS_mini_rfs, 'export-rt')), ipv4_address=n.get_opt_str(yang.gdata.Id(NS_mini_rfs, 'ipv4-address')), prefix_length=n.get_opt_u64(yang.gdata.Id(NS_mini_rfs, 'prefix-length')), mtu=n.get_opt_u64(yang.gdata.Id(NS_mini_rfs, 'mtu')), vlan_id=n.get_opt_u64(yang.gdata.Id(NS_mini_rfs, 'vlan-id')), enabled=n.get_opt_bool(yang.gdata.Id(NS_mini_rfs, 'enabled')), site_code=n.get_opt_str(yang.gdata.Id(NS_mini_rfs, 'site-code')), description=n.get_opt_str(yang.gdata.Id(NS_mini_rfs, 'description')))
 
-    def copy(self):
+    def copy(self) -> stratoweave_rfs__rfs__l3vpn_endpoint_entry:
         """Create a deep copy of this adata object"""
         return stratoweave_rfs__rfs__l3vpn_endpoint_entry.from_gdata(self.to_gdata())
 
 _breaker22 = None
 class stratoweave_rfs__rfs__l3vpn_endpoint(yang.adata.MNode):
     elements: list[stratoweave_rfs__rfs__l3vpn_endpoint_entry]
-    mut def __init__(self, elements=[]):
+    mut def __init__(self, elements: list[stratoweave_rfs__rfs__l3vpn_endpoint_entry]=[]) -> None:
         self._ns = 'http://example.com/mini-rfs'
         self._name = 'l3vpn-endpoint'
         self.elements = elements
 
-    mut def create(self, interface_name, vpn_name=None, customer_name=None, route_distinguisher=None, import_rt=None, export_rt=None, ipv4_address=None, prefix_length=None, mtu=None, vlan_id=None, enabled=None, site_code=None, description=None):
+    mut def create(self, interface_name: str, vpn_name: ?str=None, customer_name: ?str=None, route_distinguisher: ?str=None, import_rt: ?str=None, export_rt: ?str=None, ipv4_address: ?str=None, prefix_length: ?u64=None, mtu: ?u64=None, vlan_id: ?u64=None, enabled: ?bool=None, site_code: ?str=None, description: ?str=None) -> stratoweave_rfs__rfs__l3vpn_endpoint_entry:
         for e in self:
             match = True
             if e.interface_name != interface_name:
@@ -1779,7 +1779,7 @@ class stratoweave_rfs__rfs__l3vpn_endpoint(yang.adata.MNode):
             return [stratoweave_rfs__rfs__l3vpn_endpoint_entry.from_gdata(e) for e in n.elements]
         return []
 
-    def copy(self):
+    def copy(self) -> stratoweave_rfs__rfs__l3vpn_endpoint:
         """Create a deep copy of this list object"""
         # Copy each element in the list
         copied_elements = []
@@ -1799,7 +1799,7 @@ class stratoweave_rfs__rfs_entry(yang.adata.MNode):
     base_config: stratoweave_rfs__rfs__base_config
     l3vpn_endpoint: stratoweave_rfs__rfs__l3vpn_endpoint
 
-    mut def __init__(self, name: str, base_config: ?stratoweave_rfs__rfs__base_config=None, l3vpn_endpoint: list[stratoweave_rfs__rfs__l3vpn_endpoint_entry]=[]):
+    mut def __init__(self, name: str, base_config: ?stratoweave_rfs__rfs__base_config=None, l3vpn_endpoint: list[stratoweave_rfs__rfs__l3vpn_endpoint_entry]=[]) -> None:
         self._ns = 'http://stratoweave.org/yang/stratoweave-rfs.yang'
         self.name = name
         self.base_config = base_config if base_config is not None else stratoweave_rfs__rfs__base_config()
@@ -1820,19 +1820,19 @@ class stratoweave_rfs__rfs_entry(yang.adata.MNode):
     mut def from_gdata(n: yang.gdata.Node) -> stratoweave_rfs__rfs_entry:
         return stratoweave_rfs__rfs_entry(name=n.get_str(yang.gdata.Id(NS_stratoweave_rfs, 'name')), base_config=stratoweave_rfs__rfs__base_config.from_gdata(n.get_opt_cnt(yang.gdata.Id(NS_mini_rfs, 'base-config'))), l3vpn_endpoint=stratoweave_rfs__rfs__l3vpn_endpoint.from_gdata(n.get_opt_list(yang.gdata.Id(NS_mini_rfs, 'l3vpn-endpoint'))))
 
-    def copy(self):
+    def copy(self) -> stratoweave_rfs__rfs_entry:
         """Create a deep copy of this adata object"""
         return stratoweave_rfs__rfs_entry.from_gdata(self.to_gdata())
 
 _breaker24 = None
 class stratoweave_rfs__rfs(yang.adata.MNode):
     elements: list[stratoweave_rfs__rfs_entry]
-    mut def __init__(self, elements=[]):
+    mut def __init__(self, elements: list[stratoweave_rfs__rfs_entry]=[]) -> None:
         self._ns = 'http://stratoweave.org/yang/stratoweave-rfs.yang'
         self._name = 'rfs'
         self.elements = elements
 
-    mut def create(self, name):
+    mut def create(self, name: str) -> stratoweave_rfs__rfs_entry:
         for e in self:
             match = True
             if e.name != name:
@@ -1851,7 +1851,7 @@ class stratoweave_rfs__rfs(yang.adata.MNode):
             return [stratoweave_rfs__rfs_entry.from_gdata(e) for e in n.elements]
         return []
 
-    def copy(self):
+    def copy(self) -> stratoweave_rfs__rfs:
         """Create a deep copy of this list object"""
         # Copy each element in the list
         copied_elements = []
@@ -1870,7 +1870,7 @@ class root(yang.adata.MNode):
     device: stratoweave_rfs__device
     rfs: stratoweave_rfs__rfs
 
-    mut def __init__(self, device: list[stratoweave_rfs__device_entry]=[], rfs: list[stratoweave_rfs__rfs_entry]=[]):
+    mut def __init__(self, device: list[stratoweave_rfs__device_entry]=[], rfs: list[stratoweave_rfs__rfs_entry]=[]) -> None:
         self._ns = ''
         self.device = stratoweave_rfs__device(elements=device)
         self.rfs = stratoweave_rfs__rfs(elements=rfs)
@@ -1890,7 +1890,7 @@ class root(yang.adata.MNode):
             return root(device=stratoweave_rfs__device.from_gdata(n.get_opt_list(yang.gdata.Id(NS_stratoweave_rfs, 'device'))), rfs=stratoweave_rfs__rfs.from_gdata(n.get_opt_list(yang.gdata.Id(NS_stratoweave_rfs, 'rfs'))))
         return root()
 
-    def copy(self):
+    def copy(self) -> root:
         """Create a deep copy of this adata object"""
         return root.from_gdata(self.to_gdata())
 

--- a/minisys/src/mini/layers/y_2.act
+++ b/minisys/src/mini/layers/y_2.act
@@ -142,7 +142,7 @@ class stratoweave_device__devices__device_entry(yang.adata.MNode):
     name: str
     modset_id: ?str
 
-    mut def __init__(self, name: str, modset_id: ?str):
+    mut def __init__(self, name: str, modset_id: ?str) -> None:
         self._ns = 'http://stratoweave.org/yang/stratoweave-device.yang'
         self.name = name
         self.modset_id = modset_id
@@ -160,19 +160,19 @@ class stratoweave_device__devices__device_entry(yang.adata.MNode):
     mut def from_gdata(n: yang.gdata.Node) -> stratoweave_device__devices__device_entry:
         return stratoweave_device__devices__device_entry(name=n.get_str(yang.gdata.Id(NS_stratoweave_device, 'name')), modset_id=n.get_opt_str(yang.gdata.Id(NS_stratoweave_device, 'modset_id')))
 
-    def copy(self):
+    def copy(self) -> stratoweave_device__devices__device_entry:
         """Create a deep copy of this adata object"""
         return stratoweave_device__devices__device_entry.from_gdata(self.to_gdata())
 
 _breaker2 = None
 class stratoweave_device__devices__device(yang.adata.MNode):
     elements: list[stratoweave_device__devices__device_entry]
-    mut def __init__(self, elements=[]):
+    mut def __init__(self, elements: list[stratoweave_device__devices__device_entry]=[]) -> None:
         self._ns = 'http://stratoweave.org/yang/stratoweave-device.yang'
         self._name = 'device'
         self.elements = elements
 
-    mut def create(self, name, modset_id=None):
+    mut def create(self, name: str, modset_id: ?str=None) -> stratoweave_device__devices__device_entry:
         for e in self:
             match = True
             if e.name != name:
@@ -193,7 +193,7 @@ class stratoweave_device__devices__device(yang.adata.MNode):
             return [stratoweave_device__devices__device_entry.from_gdata(e) for e in n.elements]
         return []
 
-    def copy(self):
+    def copy(self) -> stratoweave_device__devices__device:
         """Create a deep copy of this list object"""
         # Copy each element in the list
         copied_elements = []
@@ -211,7 +211,7 @@ _breaker3 = None
 class stratoweave_device__devices(yang.adata.MNode):
     device: stratoweave_device__devices__device
 
-    mut def __init__(self, device: list[stratoweave_device__devices__device_entry]=[]):
+    mut def __init__(self, device: list[stratoweave_device__devices__device_entry]=[]) -> None:
         self._ns = 'http://stratoweave.org/yang/stratoweave-device.yang'
         self.device = stratoweave_device__devices__device(elements=device)
 
@@ -228,7 +228,7 @@ class stratoweave_device__devices(yang.adata.MNode):
             return stratoweave_device__devices(device=stratoweave_device__devices__device.from_gdata(n.get_opt_list(yang.gdata.Id(NS_stratoweave_device, 'device'))))
         return stratoweave_device__devices()
 
-    def copy(self):
+    def copy(self) -> stratoweave_device__devices:
         """Create a deep copy of this adata object"""
         return stratoweave_device__devices.from_gdata(self.to_gdata())
 
@@ -237,7 +237,7 @@ _breaker4 = None
 class root(yang.adata.MNode):
     devices: stratoweave_device__devices
 
-    mut def __init__(self, devices: ?stratoweave_device__devices=None):
+    mut def __init__(self, devices: ?stratoweave_device__devices=None) -> None:
         self._ns = ''
         self.devices = devices if devices is not None else stratoweave_device__devices()
 
@@ -254,7 +254,7 @@ class root(yang.adata.MNode):
             return root(devices=stratoweave_device__devices.from_gdata(n.get_opt_cnt(yang.gdata.Id(NS_stratoweave_device, 'devices'))))
         return root()
 
-    def copy(self):
+    def copy(self) -> root:
         """Create a deep copy of this adata object"""
         return root.from_gdata(self.to_gdata())
 

--- a/minisys/src/mini/layers/y_2_loose.act
+++ b/minisys/src/mini/layers/y_2_loose.act
@@ -142,7 +142,7 @@ class stratoweave_device__devices__device_entry(yang.adata.MNode):
     name: str
     modset_id: ?str
 
-    mut def __init__(self, name: str, modset_id: ?str):
+    mut def __init__(self, name: str, modset_id: ?str) -> None:
         self._ns = 'http://stratoweave.org/yang/stratoweave-device.yang'
         self.name = name
         self.modset_id = modset_id
@@ -160,19 +160,19 @@ class stratoweave_device__devices__device_entry(yang.adata.MNode):
     mut def from_gdata(n: yang.gdata.Node) -> stratoweave_device__devices__device_entry:
         return stratoweave_device__devices__device_entry(name=n.get_str(yang.gdata.Id(NS_stratoweave_device, 'name')), modset_id=n.get_opt_str(yang.gdata.Id(NS_stratoweave_device, 'modset_id')))
 
-    def copy(self):
+    def copy(self) -> stratoweave_device__devices__device_entry:
         """Create a deep copy of this adata object"""
         return stratoweave_device__devices__device_entry.from_gdata(self.to_gdata())
 
 _breaker2 = None
 class stratoweave_device__devices__device(yang.adata.MNode):
     elements: list[stratoweave_device__devices__device_entry]
-    mut def __init__(self, elements=[]):
+    mut def __init__(self, elements: list[stratoweave_device__devices__device_entry]=[]) -> None:
         self._ns = 'http://stratoweave.org/yang/stratoweave-device.yang'
         self._name = 'device'
         self.elements = elements
 
-    mut def create(self, name, modset_id=None):
+    mut def create(self, name: str, modset_id: ?str=None) -> stratoweave_device__devices__device_entry:
         for e in self:
             match = True
             if e.name != name:
@@ -193,7 +193,7 @@ class stratoweave_device__devices__device(yang.adata.MNode):
             return [stratoweave_device__devices__device_entry.from_gdata(e) for e in n.elements]
         return []
 
-    def copy(self):
+    def copy(self) -> stratoweave_device__devices__device:
         """Create a deep copy of this list object"""
         # Copy each element in the list
         copied_elements = []
@@ -211,7 +211,7 @@ _breaker3 = None
 class stratoweave_device__devices(yang.adata.MNode):
     device: stratoweave_device__devices__device
 
-    mut def __init__(self, device: list[stratoweave_device__devices__device_entry]=[]):
+    mut def __init__(self, device: list[stratoweave_device__devices__device_entry]=[]) -> None:
         self._ns = 'http://stratoweave.org/yang/stratoweave-device.yang'
         self.device = stratoweave_device__devices__device(elements=device)
 
@@ -228,7 +228,7 @@ class stratoweave_device__devices(yang.adata.MNode):
             return stratoweave_device__devices(device=stratoweave_device__devices__device.from_gdata(n.get_opt_list(yang.gdata.Id(NS_stratoweave_device, 'device'))))
         return stratoweave_device__devices()
 
-    def copy(self):
+    def copy(self) -> stratoweave_device__devices:
         """Create a deep copy of this adata object"""
         return stratoweave_device__devices.from_gdata(self.to_gdata())
 
@@ -237,7 +237,7 @@ _breaker4 = None
 class root(yang.adata.MNode):
     devices: stratoweave_device__devices
 
-    mut def __init__(self, devices: ?stratoweave_device__devices=None):
+    mut def __init__(self, devices: ?stratoweave_device__devices=None) -> None:
         self._ns = ''
         self.devices = devices if devices is not None else stratoweave_device__devices()
 
@@ -254,7 +254,7 @@ class root(yang.adata.MNode):
             return root(devices=stratoweave_device__devices.from_gdata(n.get_opt_cnt(yang.gdata.Id(NS_stratoweave_device, 'devices'))))
         return root()
 
-    def copy(self):
+    def copy(self) -> root:
         """Create a deep copy of this adata object"""
         return root.from_gdata(self.to_gdata())
 

--- a/minisys/src/mini/layers/y_2_oper.act
+++ b/minisys/src/mini/layers/y_2_oper.act
@@ -142,7 +142,7 @@ class stratoweave_device__devices__device_entry(yang.adata.MNode):
     name: str
     modset_id: ?str
 
-    mut def __init__(self, name: str, modset_id: ?str):
+    mut def __init__(self, name: str, modset_id: ?str) -> None:
         self._ns = 'http://stratoweave.org/yang/stratoweave-device.yang'
         self.name = name
         self.modset_id = modset_id
@@ -160,19 +160,19 @@ class stratoweave_device__devices__device_entry(yang.adata.MNode):
     mut def from_gdata(n: yang.gdata.Node) -> stratoweave_device__devices__device_entry:
         return stratoweave_device__devices__device_entry(name=n.get_str(yang.gdata.Id(NS_stratoweave_device, 'name')), modset_id=n.get_opt_str(yang.gdata.Id(NS_stratoweave_device, 'modset_id')))
 
-    def copy(self):
+    def copy(self) -> stratoweave_device__devices__device_entry:
         """Create a deep copy of this adata object"""
         return stratoweave_device__devices__device_entry.from_gdata(self.to_gdata())
 
 _breaker2 = None
 class stratoweave_device__devices__device(yang.adata.MNode):
     elements: list[stratoweave_device__devices__device_entry]
-    mut def __init__(self, elements=[]):
+    mut def __init__(self, elements: list[stratoweave_device__devices__device_entry]=[]) -> None:
         self._ns = 'http://stratoweave.org/yang/stratoweave-device.yang'
         self._name = 'device'
         self.elements = elements
 
-    mut def create(self, name, modset_id=None):
+    mut def create(self, name: str, modset_id: ?str=None) -> stratoweave_device__devices__device_entry:
         for e in self:
             match = True
             if e.name != name:
@@ -193,7 +193,7 @@ class stratoweave_device__devices__device(yang.adata.MNode):
             return [stratoweave_device__devices__device_entry.from_gdata(e) for e in n.elements]
         return []
 
-    def copy(self):
+    def copy(self) -> stratoweave_device__devices__device:
         """Create a deep copy of this list object"""
         # Copy each element in the list
         copied_elements = []
@@ -211,7 +211,7 @@ _breaker3 = None
 class stratoweave_device__devices(yang.adata.MNode):
     device: stratoweave_device__devices__device
 
-    mut def __init__(self, device: list[stratoweave_device__devices__device_entry]=[]):
+    mut def __init__(self, device: list[stratoweave_device__devices__device_entry]=[]) -> None:
         self._ns = 'http://stratoweave.org/yang/stratoweave-device.yang'
         self.device = stratoweave_device__devices__device(elements=device)
 
@@ -228,7 +228,7 @@ class stratoweave_device__devices(yang.adata.MNode):
             return stratoweave_device__devices(device=stratoweave_device__devices__device.from_gdata(n.get_opt_list(yang.gdata.Id(NS_stratoweave_device, 'device'))))
         return stratoweave_device__devices()
 
-    def copy(self):
+    def copy(self) -> stratoweave_device__devices:
         """Create a deep copy of this adata object"""
         return stratoweave_device__devices.from_gdata(self.to_gdata())
 
@@ -237,7 +237,7 @@ _breaker4 = None
 class root(yang.adata.MNode):
     devices: stratoweave_device__devices
 
-    mut def __init__(self, devices: ?stratoweave_device__devices=None):
+    mut def __init__(self, devices: ?stratoweave_device__devices=None) -> None:
         self._ns = ''
         self.devices = devices if devices is not None else stratoweave_device__devices()
 
@@ -254,7 +254,7 @@ class root(yang.adata.MNode):
             return root(devices=stratoweave_device__devices.from_gdata(n.get_opt_cnt(yang.gdata.Id(NS_stratoweave_device, 'devices'))))
         return root()
 
-    def copy(self):
+    def copy(self) -> root:
         """Create a deep copy of this adata object"""
         return root.from_gdata(self.to_gdata())
 

--- a/src/stratoweave/device_meta_config.act
+++ b/src/stratoweave/device_meta_config.act
@@ -788,7 +788,7 @@ class stratoweave_rfs__device__address__initial_credentials_entry(yang.adata.MNo
     password: str
     key: str
 
-    mut def __init__(self, username: str, password: str, key: str):
+    mut def __init__(self, username: str, password: str, key: str) -> None:
         self._ns = 'http://stratoweave.org/yang/stratoweave-rfs.yang'
         self.username = username
         self.password = password
@@ -809,19 +809,19 @@ class stratoweave_rfs__device__address__initial_credentials_entry(yang.adata.MNo
     mut def from_gdata(n: yang.gdata.Node) -> stratoweave_rfs__device__address__initial_credentials_entry:
         return stratoweave_rfs__device__address__initial_credentials_entry(username=n.get_str(yang.gdata.Id(NS_stratoweave_rfs, 'username')), password=n.get_str(yang.gdata.Id(NS_stratoweave_rfs, 'password')), key=n.get_str(yang.gdata.Id(NS_stratoweave_rfs, 'key')))
 
-    def copy(self):
+    def copy(self) -> stratoweave_rfs__device__address__initial_credentials_entry:
         """Create a deep copy of this adata object"""
         return stratoweave_rfs__device__address__initial_credentials_entry.from_gdata(self.to_gdata())
 
 _breaker2 = None
 class stratoweave_rfs__device__address__initial_credentials(yang.adata.MNode):
     elements: list[stratoweave_rfs__device__address__initial_credentials_entry]
-    mut def __init__(self, elements=[]):
+    mut def __init__(self, elements: list[stratoweave_rfs__device__address__initial_credentials_entry]=[]) -> None:
         self._ns = 'http://stratoweave.org/yang/stratoweave-rfs.yang'
         self._name = 'initial-credentials'
         self.elements = elements
 
-    mut def create(self, username, password, key):
+    mut def create(self, username: str, password: str, key: str) -> stratoweave_rfs__device__address__initial_credentials_entry:
         for e in self:
             match = True
             if e.username != username:
@@ -846,7 +846,7 @@ class stratoweave_rfs__device__address__initial_credentials(yang.adata.MNode):
             return [stratoweave_rfs__device__address__initial_credentials_entry.from_gdata(e) for e in n.elements]
         return []
 
-    def copy(self):
+    def copy(self) -> stratoweave_rfs__device__address__initial_credentials:
         """Create a deep copy of this list object"""
         # Copy each element in the list
         copied_elements = []
@@ -867,7 +867,7 @@ class stratoweave_rfs__device__address_entry(yang.adata.MNode):
     port: ?u64
     initial_credentials: stratoweave_rfs__device__address__initial_credentials
 
-    mut def __init__(self, name: str, address: str, port: ?u64, initial_credentials: list[stratoweave_rfs__device__address__initial_credentials_entry]=[]):
+    mut def __init__(self, name: str, address: str, port: ?u64, initial_credentials: list[stratoweave_rfs__device__address__initial_credentials_entry]=[]) -> None:
         self._ns = 'http://stratoweave.org/yang/stratoweave-rfs.yang'
         self.name = name
         self.address = address
@@ -891,19 +891,19 @@ class stratoweave_rfs__device__address_entry(yang.adata.MNode):
     mut def from_gdata(n: yang.gdata.Node) -> stratoweave_rfs__device__address_entry:
         return stratoweave_rfs__device__address_entry(name=n.get_str(yang.gdata.Id(NS_stratoweave_rfs, 'name')), address=n.get_str(yang.gdata.Id(NS_stratoweave_rfs, 'address')), port=n.get_opt_u64(yang.gdata.Id(NS_stratoweave_rfs, 'port')), initial_credentials=stratoweave_rfs__device__address__initial_credentials.from_gdata(n.get_opt_list(yang.gdata.Id(NS_stratoweave_rfs, 'initial-credentials'))))
 
-    def copy(self):
+    def copy(self) -> stratoweave_rfs__device__address_entry:
         """Create a deep copy of this adata object"""
         return stratoweave_rfs__device__address_entry.from_gdata(self.to_gdata())
 
 _breaker4 = None
 class stratoweave_rfs__device__address(yang.adata.MNode):
     elements: list[stratoweave_rfs__device__address_entry]
-    mut def __init__(self, elements=[]):
+    mut def __init__(self, elements: list[stratoweave_rfs__device__address_entry]=[]) -> None:
         self._ns = 'http://stratoweave.org/yang/stratoweave-rfs.yang'
         self._name = 'address'
         self.elements = elements
 
-    mut def create(self, name, address, port=None):
+    mut def create(self, name: str, address: str, port: ?u64=None) -> stratoweave_rfs__device__address_entry:
         for e in self:
             match = True
             if e.name != name:
@@ -925,7 +925,7 @@ class stratoweave_rfs__device__address(yang.adata.MNode):
             return [stratoweave_rfs__device__address_entry.from_gdata(e) for e in n.elements]
         return []
 
-    def copy(self):
+    def copy(self) -> stratoweave_rfs__device__address:
         """Create a deep copy of this list object"""
         # Copy each element in the list
         copied_elements = []
@@ -944,7 +944,7 @@ class stratoweave_rfs__device__credentials__key_entry(yang.adata.MNode):
     key: str
     private_key: ?str
 
-    mut def __init__(self, key: str, private_key: ?str):
+    mut def __init__(self, key: str, private_key: ?str) -> None:
         self._ns = 'http://stratoweave.org/yang/stratoweave-rfs.yang'
         self.key = key
         self.private_key = private_key
@@ -962,19 +962,19 @@ class stratoweave_rfs__device__credentials__key_entry(yang.adata.MNode):
     mut def from_gdata(n: yang.gdata.Node) -> stratoweave_rfs__device__credentials__key_entry:
         return stratoweave_rfs__device__credentials__key_entry(key=n.get_str(yang.gdata.Id(NS_stratoweave_rfs, 'key')), private_key=n.get_opt_str(yang.gdata.Id(NS_stratoweave_rfs, 'private-key')))
 
-    def copy(self):
+    def copy(self) -> stratoweave_rfs__device__credentials__key_entry:
         """Create a deep copy of this adata object"""
         return stratoweave_rfs__device__credentials__key_entry.from_gdata(self.to_gdata())
 
 _breaker6 = None
 class stratoweave_rfs__device__credentials__key(yang.adata.MNode):
     elements: list[stratoweave_rfs__device__credentials__key_entry]
-    mut def __init__(self, elements=[]):
+    mut def __init__(self, elements: list[stratoweave_rfs__device__credentials__key_entry]=[]) -> None:
         self._ns = 'http://stratoweave.org/yang/stratoweave-rfs.yang'
         self._name = 'key'
         self.elements = elements
 
-    mut def create(self, key, private_key=None):
+    mut def create(self, key: str, private_key: ?str=None) -> stratoweave_rfs__device__credentials__key_entry:
         for e in self:
             match = True
             if e.key != key:
@@ -995,7 +995,7 @@ class stratoweave_rfs__device__credentials__key(yang.adata.MNode):
             return [stratoweave_rfs__device__credentials__key_entry.from_gdata(e) for e in n.elements]
         return []
 
-    def copy(self):
+    def copy(self) -> stratoweave_rfs__device__credentials__key:
         """Create a deep copy of this list object"""
         # Copy each element in the list
         copied_elements = []
@@ -1015,7 +1015,7 @@ class stratoweave_rfs__device__credentials(yang.adata.MNode):
     password: ?str
     key: stratoweave_rfs__device__credentials__key
 
-    mut def __init__(self, username: str, password: ?str, key: list[stratoweave_rfs__device__credentials__key_entry]=[]):
+    mut def __init__(self, username: str, password: ?str, key: list[stratoweave_rfs__device__credentials__key_entry]=[]) -> None:
         self._ns = 'http://stratoweave.org/yang/stratoweave-rfs.yang'
         self.username = username
         self.password = password
@@ -1038,7 +1038,7 @@ class stratoweave_rfs__device__credentials(yang.adata.MNode):
             return stratoweave_rfs__device__credentials(username=n.get_str(yang.gdata.Id(NS_stratoweave_rfs, 'username')), password=n.get_opt_str(yang.gdata.Id(NS_stratoweave_rfs, 'password')), key=stratoweave_rfs__device__credentials__key.from_gdata(n.get_opt_list(yang.gdata.Id(NS_stratoweave_rfs, 'key'))))
         raise ValueError('Missing required subtree stratoweave_rfs__device__credentials')
 
-    def copy(self):
+    def copy(self) -> stratoweave_rfs__device__credentials:
         """Create a deep copy of this adata object"""
         return stratoweave_rfs__device__credentials.from_gdata(self.to_gdata())
 
@@ -1049,7 +1049,7 @@ class stratoweave_rfs__device__initial_credentials_entry(yang.adata.MNode):
     password: str
     key: str
 
-    mut def __init__(self, username: str, password: str, key: str):
+    mut def __init__(self, username: str, password: str, key: str) -> None:
         self._ns = 'http://stratoweave.org/yang/stratoweave-rfs.yang'
         self.username = username
         self.password = password
@@ -1070,19 +1070,19 @@ class stratoweave_rfs__device__initial_credentials_entry(yang.adata.MNode):
     mut def from_gdata(n: yang.gdata.Node) -> stratoweave_rfs__device__initial_credentials_entry:
         return stratoweave_rfs__device__initial_credentials_entry(username=n.get_str(yang.gdata.Id(NS_stratoweave_rfs, 'username')), password=n.get_str(yang.gdata.Id(NS_stratoweave_rfs, 'password')), key=n.get_str(yang.gdata.Id(NS_stratoweave_rfs, 'key')))
 
-    def copy(self):
+    def copy(self) -> stratoweave_rfs__device__initial_credentials_entry:
         """Create a deep copy of this adata object"""
         return stratoweave_rfs__device__initial_credentials_entry.from_gdata(self.to_gdata())
 
 _breaker9 = None
 class stratoweave_rfs__device__initial_credentials(yang.adata.MNode):
     elements: list[stratoweave_rfs__device__initial_credentials_entry]
-    mut def __init__(self, elements=[]):
+    mut def __init__(self, elements: list[stratoweave_rfs__device__initial_credentials_entry]=[]) -> None:
         self._ns = 'http://stratoweave.org/yang/stratoweave-rfs.yang'
         self._name = 'initial-credentials'
         self.elements = elements
 
-    mut def create(self, username, password, key):
+    mut def create(self, username: str, password: str, key: str) -> stratoweave_rfs__device__initial_credentials_entry:
         for e in self:
             match = True
             if e.username != username:
@@ -1107,7 +1107,7 @@ class stratoweave_rfs__device__initial_credentials(yang.adata.MNode):
             return [stratoweave_rfs__device__initial_credentials_entry.from_gdata(e) for e in n.elements]
         return []
 
-    def copy(self):
+    def copy(self) -> stratoweave_rfs__device__initial_credentials:
         """Create a deep copy of this list object"""
         # Copy each element in the list
         copied_elements = []
@@ -1128,7 +1128,7 @@ class stratoweave_rfs__device__mock__module_entry(yang.adata.MNode):
     revision: ?str
     feature: list[str]
 
-    mut def __init__(self, name: str, namespace: str, revision: ?str, feature: ?list[str]=None):
+    mut def __init__(self, name: str, namespace: str, revision: ?str, feature: ?list[str]=None) -> None:
         self._ns = 'http://stratoweave.org/yang/stratoweave-rfs.yang'
         self.name = name
         self.namespace = namespace
@@ -1152,19 +1152,19 @@ class stratoweave_rfs__device__mock__module_entry(yang.adata.MNode):
     mut def from_gdata(n: yang.gdata.Node) -> stratoweave_rfs__device__mock__module_entry:
         return stratoweave_rfs__device__mock__module_entry(name=n.get_str(yang.gdata.Id(NS_stratoweave_rfs, 'name')), namespace=n.get_str(yang.gdata.Id(NS_stratoweave_rfs, 'namespace')), revision=n.get_opt_str(yang.gdata.Id(NS_stratoweave_rfs, 'revision')), feature=n.get_opt_strs(yang.gdata.Id(NS_stratoweave_rfs, 'feature')))
 
-    def copy(self):
+    def copy(self) -> stratoweave_rfs__device__mock__module_entry:
         """Create a deep copy of this adata object"""
         return stratoweave_rfs__device__mock__module_entry.from_gdata(self.to_gdata())
 
 _breaker11 = None
 class stratoweave_rfs__device__mock__module(yang.adata.MNode):
     elements: list[stratoweave_rfs__device__mock__module_entry]
-    mut def __init__(self, elements=[]):
+    mut def __init__(self, elements: list[stratoweave_rfs__device__mock__module_entry]=[]) -> None:
         self._ns = 'http://stratoweave.org/yang/stratoweave-rfs.yang'
         self._name = 'module'
         self.elements = elements
 
-    mut def create(self, name, namespace, revision=None):
+    mut def create(self, name: str, namespace: str, revision: ?str=None) -> stratoweave_rfs__device__mock__module_entry:
         for e in self:
             match = True
             if e.name != name:
@@ -1186,7 +1186,7 @@ class stratoweave_rfs__device__mock__module(yang.adata.MNode):
             return [stratoweave_rfs__device__mock__module_entry.from_gdata(e) for e in n.elements]
         return []
 
-    def copy(self):
+    def copy(self) -> stratoweave_rfs__device__mock__module:
         """Create a deep copy of this list object"""
         # Copy each element in the list
         copied_elements = []
@@ -1206,7 +1206,7 @@ class stratoweave_rfs__device__mock(yang.adata.MNode):
     preset: list[str]
     module: stratoweave_rfs__device__mock__module
 
-    mut def __init__(self, enabled: ?bool=None, preset: ?list[str]=None, module: list[stratoweave_rfs__device__mock__module_entry]=[]):
+    mut def __init__(self, enabled: ?bool=None, preset: ?list[str]=None, module: list[stratoweave_rfs__device__mock__module_entry]=[]) -> None:
         self._ns = 'http://stratoweave.org/yang/stratoweave-rfs.yang'
         self.enabled = enabled if enabled is not None else False
         self.preset = preset if preset is not None else []
@@ -1229,7 +1229,7 @@ class stratoweave_rfs__device__mock(yang.adata.MNode):
             return stratoweave_rfs__device__mock(enabled=n.get_opt_bool(yang.gdata.Id(NS_stratoweave_rfs, 'enabled')), preset=n.get_opt_strs(yang.gdata.Id(NS_stratoweave_rfs, 'preset')), module=stratoweave_rfs__device__mock__module.from_gdata(n.get_opt_list(yang.gdata.Id(NS_stratoweave_rfs, 'module'))))
         return stratoweave_rfs__device__mock()
 
-    def copy(self):
+    def copy(self) -> stratoweave_rfs__device__mock:
         """Create a deep copy of this adata object"""
         return stratoweave_rfs__device__mock.from_gdata(self.to_gdata())
 
@@ -1238,7 +1238,7 @@ _breaker13 = None
 class stratoweave_rfs__device__debug(yang.adata.MNode):
     connection: bool
 
-    mut def __init__(self, connection: ?bool=None):
+    mut def __init__(self, connection: ?bool=None) -> None:
         self._ns = 'http://stratoweave.org/yang/stratoweave-rfs.yang'
         self.connection = connection if connection is not None else False
 
@@ -1255,7 +1255,7 @@ class stratoweave_rfs__device__debug(yang.adata.MNode):
             return stratoweave_rfs__device__debug(connection=n.get_opt_bool(yang.gdata.Id(NS_stratoweave_rfs, 'connection')))
         return stratoweave_rfs__device__debug()
 
-    def copy(self):
+    def copy(self) -> stratoweave_rfs__device__debug:
         """Create a deep copy of this adata object"""
         return stratoweave_rfs__device__debug.from_gdata(self.to_gdata())
 
@@ -1264,7 +1264,7 @@ _breaker14 = None
 class stratoweave_rfs__device__feature_flags(yang.adata.MNode):
     runtime_schema_fetch: bool
 
-    mut def __init__(self, runtime_schema_fetch: ?bool=None):
+    mut def __init__(self, runtime_schema_fetch: ?bool=None) -> None:
         self._ns = 'http://stratoweave.org/yang/stratoweave-rfs.yang'
         self.runtime_schema_fetch = runtime_schema_fetch if runtime_schema_fetch is not None else False
 
@@ -1281,7 +1281,7 @@ class stratoweave_rfs__device__feature_flags(yang.adata.MNode):
             return stratoweave_rfs__device__feature_flags(runtime_schema_fetch=n.get_opt_bool(yang.gdata.Id(NS_stratoweave_rfs, 'runtime-schema-fetch')))
         return stratoweave_rfs__device__feature_flags()
 
-    def copy(self):
+    def copy(self) -> stratoweave_rfs__device__feature_flags:
         """Create a deep copy of this adata object"""
         return stratoweave_rfs__device__feature_flags.from_gdata(self.to_gdata())
 
@@ -1299,7 +1299,7 @@ class stratoweave_rfs__device_entry(yang.adata.MNode):
     debug: stratoweave_rfs__device__debug
     feature_flags: stratoweave_rfs__device__feature_flags
 
-    mut def __init__(self, name: str, credentials: stratoweave_rfs__device__credentials, description: ?str, type: ?str, address: list[stratoweave_rfs__device__address_entry]=[], initial_credentials: list[stratoweave_rfs__device__initial_credentials_entry]=[], approval_required: ?bool=None, mock: ?stratoweave_rfs__device__mock=None, debug: ?stratoweave_rfs__device__debug=None, feature_flags: ?stratoweave_rfs__device__feature_flags=None):
+    mut def __init__(self, name: str, credentials: stratoweave_rfs__device__credentials, description: ?str, type: ?str, address: list[stratoweave_rfs__device__address_entry]=[], initial_credentials: list[stratoweave_rfs__device__initial_credentials_entry]=[], approval_required: ?bool=None, mock: ?stratoweave_rfs__device__mock=None, debug: ?stratoweave_rfs__device__debug=None, feature_flags: ?stratoweave_rfs__device__feature_flags=None) -> None:
         self._ns = 'http://stratoweave.org/yang/stratoweave-rfs.yang'
         self.name = name
         self.description = description
@@ -1341,19 +1341,19 @@ class stratoweave_rfs__device_entry(yang.adata.MNode):
     mut def from_gdata(n: yang.gdata.Node) -> stratoweave_rfs__device_entry:
         return stratoweave_rfs__device_entry(name=n.get_str(yang.gdata.Id(NS_stratoweave_rfs, 'name')), description=n.get_opt_str(yang.gdata.Id(NS_stratoweave_rfs, 'description')), type=n.get_opt_str(yang.gdata.Id(NS_stratoweave_rfs, 'type')), address=stratoweave_rfs__device__address.from_gdata(n.get_opt_list(yang.gdata.Id(NS_stratoweave_rfs, 'address'))), credentials=stratoweave_rfs__device__credentials.from_gdata(n.get_cnt(yang.gdata.Id(NS_stratoweave_rfs, 'credentials'))), initial_credentials=stratoweave_rfs__device__initial_credentials.from_gdata(n.get_opt_list(yang.gdata.Id(NS_stratoweave_rfs, 'initial-credentials'))), approval_required=n.get_opt_bool(yang.gdata.Id(NS_stratoweave_rfs, 'approval-required')), mock=stratoweave_rfs__device__mock.from_gdata(n.get_opt_cnt(yang.gdata.Id(NS_stratoweave_rfs, 'mock'))), debug=stratoweave_rfs__device__debug.from_gdata(n.get_opt_cnt(yang.gdata.Id(NS_stratoweave_rfs, 'debug'))), feature_flags=stratoweave_rfs__device__feature_flags.from_gdata(n.get_opt_cnt(yang.gdata.Id(NS_stratoweave_rfs, 'feature-flags'))))
 
-    def copy(self):
+    def copy(self) -> stratoweave_rfs__device_entry:
         """Create a deep copy of this adata object"""
         return stratoweave_rfs__device_entry.from_gdata(self.to_gdata())
 
 _breaker16 = None
 class stratoweave_rfs__device(yang.adata.MNode):
     elements: list[stratoweave_rfs__device_entry]
-    mut def __init__(self, elements=[]):
+    mut def __init__(self, elements: list[stratoweave_rfs__device_entry]=[]) -> None:
         self._ns = 'http://stratoweave.org/yang/stratoweave-rfs.yang'
         self._name = 'device'
         self.elements = elements
 
-    mut def create(self, name, credentials, description=None, type=None, approval_required=None):
+    mut def create(self, name: str, credentials: stratoweave_rfs__device__credentials, description: ?str=None, type: ?str=None, approval_required: ?bool=None) -> stratoweave_rfs__device_entry:
         for e in self:
             match = True
             if e.name != name:
@@ -1379,7 +1379,7 @@ class stratoweave_rfs__device(yang.adata.MNode):
             return [stratoweave_rfs__device_entry.from_gdata(e) for e in n.elements]
         return []
 
-    def copy(self):
+    def copy(self) -> stratoweave_rfs__device:
         """Create a deep copy of this list object"""
         # Copy each element in the list
         copied_elements = []

--- a/src/stratoweave/ietf_restconf_monitoring.act
+++ b/src/stratoweave/ietf_restconf_monitoring.act
@@ -1433,7 +1433,7 @@ _breaker1 = None
 class ietf_restconf_monitoring__restconf_state__capabilities(yang.adata.MNode):
     capability: list[str]
 
-    mut def __init__(self, capability: ?list[str]=None):
+    mut def __init__(self, capability: ?list[str]=None) -> None:
         self._ns = 'urn:ietf:params:xml:ns:yang:ietf-restconf-monitoring'
         self.capability = capability if capability is not None else []
 
@@ -1450,7 +1450,7 @@ class ietf_restconf_monitoring__restconf_state__capabilities(yang.adata.MNode):
             return ietf_restconf_monitoring__restconf_state__capabilities(capability=n.get_opt_strs(yang.gdata.Id(NS_ietf_restconf_monitoring, 'capability')))
         return ietf_restconf_monitoring__restconf_state__capabilities()
 
-    def copy(self):
+    def copy(self) -> ietf_restconf_monitoring__restconf_state__capabilities:
         """Create a deep copy of this adata object"""
         return ietf_restconf_monitoring__restconf_state__capabilities.from_gdata(self.to_gdata())
 
@@ -1460,7 +1460,7 @@ class ietf_restconf_monitoring__restconf_state__streams__stream__access_entry(ya
     encoding: str
     location: str
 
-    mut def __init__(self, encoding: str, location: str):
+    mut def __init__(self, encoding: str, location: str) -> None:
         self._ns = 'urn:ietf:params:xml:ns:yang:ietf-restconf-monitoring'
         self.encoding = encoding
         self.location = location
@@ -1478,19 +1478,19 @@ class ietf_restconf_monitoring__restconf_state__streams__stream__access_entry(ya
     mut def from_gdata(n: yang.gdata.Node) -> ietf_restconf_monitoring__restconf_state__streams__stream__access_entry:
         return ietf_restconf_monitoring__restconf_state__streams__stream__access_entry(encoding=n.get_str(yang.gdata.Id(NS_ietf_restconf_monitoring, 'encoding')), location=n.get_str(yang.gdata.Id(NS_ietf_restconf_monitoring, 'location')))
 
-    def copy(self):
+    def copy(self) -> ietf_restconf_monitoring__restconf_state__streams__stream__access_entry:
         """Create a deep copy of this adata object"""
         return ietf_restconf_monitoring__restconf_state__streams__stream__access_entry.from_gdata(self.to_gdata())
 
 _breaker3 = None
 class ietf_restconf_monitoring__restconf_state__streams__stream__access(yang.adata.MNode):
     elements: list[ietf_restconf_monitoring__restconf_state__streams__stream__access_entry]
-    mut def __init__(self, elements=[]):
+    mut def __init__(self, elements: list[ietf_restconf_monitoring__restconf_state__streams__stream__access_entry]=[]) -> None:
         self._ns = 'urn:ietf:params:xml:ns:yang:ietf-restconf-monitoring'
         self._name = 'access'
         self.elements = elements
 
-    mut def create(self, encoding, location):
+    mut def create(self, encoding: str, location: str) -> ietf_restconf_monitoring__restconf_state__streams__stream__access_entry:
         for e in self:
             match = True
             if e.encoding != encoding:
@@ -1510,7 +1510,7 @@ class ietf_restconf_monitoring__restconf_state__streams__stream__access(yang.ada
             return [ietf_restconf_monitoring__restconf_state__streams__stream__access_entry.from_gdata(e) for e in n.elements]
         return []
 
-    def copy(self):
+    def copy(self) -> ietf_restconf_monitoring__restconf_state__streams__stream__access:
         """Create a deep copy of this list object"""
         # Copy each element in the list
         copied_elements = []
@@ -1532,7 +1532,7 @@ class ietf_restconf_monitoring__restconf_state__streams__stream_entry(yang.adata
     replay_log_creation_time: ?str
     access: ietf_restconf_monitoring__restconf_state__streams__stream__access
 
-    mut def __init__(self, name: str, description: ?str, replay_support: ?bool=None, replay_log_creation_time: ?str, access: list[ietf_restconf_monitoring__restconf_state__streams__stream__access_entry]=[]):
+    mut def __init__(self, name: str, description: ?str, replay_support: ?bool=None, replay_log_creation_time: ?str, access: list[ietf_restconf_monitoring__restconf_state__streams__stream__access_entry]=[]) -> None:
         self._ns = 'urn:ietf:params:xml:ns:yang:ietf-restconf-monitoring'
         self.name = name
         self.description = description
@@ -1559,19 +1559,19 @@ class ietf_restconf_monitoring__restconf_state__streams__stream_entry(yang.adata
     mut def from_gdata(n: yang.gdata.Node) -> ietf_restconf_monitoring__restconf_state__streams__stream_entry:
         return ietf_restconf_monitoring__restconf_state__streams__stream_entry(name=n.get_str(yang.gdata.Id(NS_ietf_restconf_monitoring, 'name')), description=n.get_opt_str(yang.gdata.Id(NS_ietf_restconf_monitoring, 'description')), replay_support=n.get_opt_bool(yang.gdata.Id(NS_ietf_restconf_monitoring, 'replay-support')), replay_log_creation_time=n.get_opt_str(yang.gdata.Id(NS_ietf_restconf_monitoring, 'replay-log-creation-time')), access=ietf_restconf_monitoring__restconf_state__streams__stream__access.from_gdata(n.get_list(yang.gdata.Id(NS_ietf_restconf_monitoring, 'access'))))
 
-    def copy(self):
+    def copy(self) -> ietf_restconf_monitoring__restconf_state__streams__stream_entry:
         """Create a deep copy of this adata object"""
         return ietf_restconf_monitoring__restconf_state__streams__stream_entry.from_gdata(self.to_gdata())
 
 _breaker5 = None
 class ietf_restconf_monitoring__restconf_state__streams__stream(yang.adata.MNode):
     elements: list[ietf_restconf_monitoring__restconf_state__streams__stream_entry]
-    mut def __init__(self, elements=[]):
+    mut def __init__(self, elements: list[ietf_restconf_monitoring__restconf_state__streams__stream_entry]=[]) -> None:
         self._ns = 'urn:ietf:params:xml:ns:yang:ietf-restconf-monitoring'
         self._name = 'stream'
         self.elements = elements
 
-    mut def create(self, name, description=None, replay_support=None, replay_log_creation_time=None):
+    mut def create(self, name: str, description: ?str=None, replay_support: ?bool=None, replay_log_creation_time: ?str=None) -> ietf_restconf_monitoring__restconf_state__streams__stream_entry:
         for e in self:
             match = True
             if e.name != name:
@@ -1596,7 +1596,7 @@ class ietf_restconf_monitoring__restconf_state__streams__stream(yang.adata.MNode
             return [ietf_restconf_monitoring__restconf_state__streams__stream_entry.from_gdata(e) for e in n.elements]
         return []
 
-    def copy(self):
+    def copy(self) -> ietf_restconf_monitoring__restconf_state__streams__stream:
         """Create a deep copy of this list object"""
         # Copy each element in the list
         copied_elements = []
@@ -1614,7 +1614,7 @@ _breaker6 = None
 class ietf_restconf_monitoring__restconf_state__streams(yang.adata.MNode):
     stream: ietf_restconf_monitoring__restconf_state__streams__stream
 
-    mut def __init__(self, stream: list[ietf_restconf_monitoring__restconf_state__streams__stream_entry]=[]):
+    mut def __init__(self, stream: list[ietf_restconf_monitoring__restconf_state__streams__stream_entry]=[]) -> None:
         self._ns = 'urn:ietf:params:xml:ns:yang:ietf-restconf-monitoring'
         self.stream = ietf_restconf_monitoring__restconf_state__streams__stream(elements=stream)
 
@@ -1631,7 +1631,7 @@ class ietf_restconf_monitoring__restconf_state__streams(yang.adata.MNode):
             return ietf_restconf_monitoring__restconf_state__streams(stream=ietf_restconf_monitoring__restconf_state__streams__stream.from_gdata(n.get_opt_list(yang.gdata.Id(NS_ietf_restconf_monitoring, 'stream'))))
         return ietf_restconf_monitoring__restconf_state__streams()
 
-    def copy(self):
+    def copy(self) -> ietf_restconf_monitoring__restconf_state__streams:
         """Create a deep copy of this adata object"""
         return ietf_restconf_monitoring__restconf_state__streams.from_gdata(self.to_gdata())
 
@@ -1641,7 +1641,7 @@ class ietf_restconf_monitoring__restconf_state(yang.adata.MNode):
     capabilities: ietf_restconf_monitoring__restconf_state__capabilities
     streams: ietf_restconf_monitoring__restconf_state__streams
 
-    mut def __init__(self, capabilities: ?ietf_restconf_monitoring__restconf_state__capabilities=None, streams: ?ietf_restconf_monitoring__restconf_state__streams=None):
+    mut def __init__(self, capabilities: ?ietf_restconf_monitoring__restconf_state__capabilities=None, streams: ?ietf_restconf_monitoring__restconf_state__streams=None) -> None:
         self._ns = 'urn:ietf:params:xml:ns:yang:ietf-restconf-monitoring'
         self.capabilities = capabilities if capabilities is not None else ietf_restconf_monitoring__restconf_state__capabilities()
         self.streams = streams if streams is not None else ietf_restconf_monitoring__restconf_state__streams()
@@ -1661,7 +1661,7 @@ class ietf_restconf_monitoring__restconf_state(yang.adata.MNode):
             return ietf_restconf_monitoring__restconf_state(capabilities=ietf_restconf_monitoring__restconf_state__capabilities.from_gdata(n.get_opt_cnt(yang.gdata.Id(NS_ietf_restconf_monitoring, 'capabilities'))), streams=ietf_restconf_monitoring__restconf_state__streams.from_gdata(n.get_opt_cnt(yang.gdata.Id(NS_ietf_restconf_monitoring, 'streams'))))
         return ietf_restconf_monitoring__restconf_state()
 
-    def copy(self):
+    def copy(self) -> ietf_restconf_monitoring__restconf_state:
         """Create a deep copy of this adata object"""
         return ietf_restconf_monitoring__restconf_state.from_gdata(self.to_gdata())
 
@@ -1670,7 +1670,7 @@ _breaker8 = None
 class root(yang.adata.MNode):
     restconf_state: ietf_restconf_monitoring__restconf_state
 
-    mut def __init__(self, restconf_state: ?ietf_restconf_monitoring__restconf_state=None):
+    mut def __init__(self, restconf_state: ?ietf_restconf_monitoring__restconf_state=None) -> None:
         self._ns = ''
         self.restconf_state = restconf_state if restconf_state is not None else ietf_restconf_monitoring__restconf_state()
 
@@ -1687,7 +1687,7 @@ class root(yang.adata.MNode):
             return root(restconf_state=ietf_restconf_monitoring__restconf_state.from_gdata(n.get_opt_cnt(yang.gdata.Id(NS_ietf_restconf_monitoring, 'restconf-state'))))
         return root()
 
-    def copy(self):
+    def copy(self) -> root:
         """Create a deep copy of this adata object"""
         return root.from_gdata(self.to_gdata())
 

--- a/src/stratoweave/ietf_yang_library.act
+++ b/src/stratoweave/ietf_yang_library.act
@@ -2043,7 +2043,7 @@ class ietf_yang_library__yang_library__module_set__module__submodule_entry(yang.
     revision: ?str
     location: list[str]
 
-    mut def __init__(self, name: str, revision: ?str, location: ?list[str]=None):
+    mut def __init__(self, name: str, revision: ?str, location: ?list[str]=None) -> None:
         self._ns = 'urn:ietf:params:xml:ns:yang:ietf-yang-library'
         self.name = name
         self.revision = revision
@@ -2064,19 +2064,19 @@ class ietf_yang_library__yang_library__module_set__module__submodule_entry(yang.
     mut def from_gdata(n: yang.gdata.Node) -> ietf_yang_library__yang_library__module_set__module__submodule_entry:
         return ietf_yang_library__yang_library__module_set__module__submodule_entry(name=n.get_str(yang.gdata.Id(NS_ietf_yang_library, 'name')), revision=n.get_opt_str(yang.gdata.Id(NS_ietf_yang_library, 'revision')), location=n.get_opt_strs(yang.gdata.Id(NS_ietf_yang_library, 'location')))
 
-    def copy(self):
+    def copy(self) -> ietf_yang_library__yang_library__module_set__module__submodule_entry:
         """Create a deep copy of this adata object"""
         return ietf_yang_library__yang_library__module_set__module__submodule_entry.from_gdata(self.to_gdata())
 
 _breaker2 = None
 class ietf_yang_library__yang_library__module_set__module__submodule(yang.adata.MNode):
     elements: list[ietf_yang_library__yang_library__module_set__module__submodule_entry]
-    mut def __init__(self, elements=[]):
+    mut def __init__(self, elements: list[ietf_yang_library__yang_library__module_set__module__submodule_entry]=[]) -> None:
         self._ns = 'urn:ietf:params:xml:ns:yang:ietf-yang-library'
         self._name = 'submodule'
         self.elements = elements
 
-    mut def create(self, name, revision=None):
+    mut def create(self, name: str, revision: ?str=None) -> ietf_yang_library__yang_library__module_set__module__submodule_entry:
         for e in self:
             match = True
             if e.name != name:
@@ -2097,7 +2097,7 @@ class ietf_yang_library__yang_library__module_set__module__submodule(yang.adata.
             return [ietf_yang_library__yang_library__module_set__module__submodule_entry.from_gdata(e) for e in n.elements]
         return []
 
-    def copy(self):
+    def copy(self) -> ietf_yang_library__yang_library__module_set__module__submodule:
         """Create a deep copy of this list object"""
         # Copy each element in the list
         copied_elements = []
@@ -2121,7 +2121,7 @@ class ietf_yang_library__yang_library__module_set__module_entry(yang.adata.MNode
     feature: list[str]
     deviation: list[str]
 
-    mut def __init__(self, name: str, namespace: str, revision: ?str, location: ?list[str]=None, submodule: list[ietf_yang_library__yang_library__module_set__module__submodule_entry]=[], feature: ?list[str]=None, deviation: ?list[str]=None):
+    mut def __init__(self, name: str, namespace: str, revision: ?str, location: ?list[str]=None, submodule: list[ietf_yang_library__yang_library__module_set__module__submodule_entry]=[], feature: ?list[str]=None, deviation: ?list[str]=None) -> None:
         self._ns = 'urn:ietf:params:xml:ns:yang:ietf-yang-library'
         self.name = name
         self.revision = revision
@@ -2154,19 +2154,19 @@ class ietf_yang_library__yang_library__module_set__module_entry(yang.adata.MNode
     mut def from_gdata(n: yang.gdata.Node) -> ietf_yang_library__yang_library__module_set__module_entry:
         return ietf_yang_library__yang_library__module_set__module_entry(name=n.get_str(yang.gdata.Id(NS_ietf_yang_library, 'name')), revision=n.get_opt_str(yang.gdata.Id(NS_ietf_yang_library, 'revision')), namespace=n.get_str(yang.gdata.Id(NS_ietf_yang_library, 'namespace')), location=n.get_opt_strs(yang.gdata.Id(NS_ietf_yang_library, 'location')), submodule=ietf_yang_library__yang_library__module_set__module__submodule.from_gdata(n.get_opt_list(yang.gdata.Id(NS_ietf_yang_library, 'submodule'))), feature=n.get_opt_strs(yang.gdata.Id(NS_ietf_yang_library, 'feature')), deviation=n.get_opt_strs(yang.gdata.Id(NS_ietf_yang_library, 'deviation')))
 
-    def copy(self):
+    def copy(self) -> ietf_yang_library__yang_library__module_set__module_entry:
         """Create a deep copy of this adata object"""
         return ietf_yang_library__yang_library__module_set__module_entry.from_gdata(self.to_gdata())
 
 _breaker4 = None
 class ietf_yang_library__yang_library__module_set__module(yang.adata.MNode):
     elements: list[ietf_yang_library__yang_library__module_set__module_entry]
-    mut def __init__(self, elements=[]):
+    mut def __init__(self, elements: list[ietf_yang_library__yang_library__module_set__module_entry]=[]) -> None:
         self._ns = 'urn:ietf:params:xml:ns:yang:ietf-yang-library'
         self._name = 'module'
         self.elements = elements
 
-    mut def create(self, name, namespace, revision=None):
+    mut def create(self, name: str, namespace: str, revision: ?str=None) -> ietf_yang_library__yang_library__module_set__module_entry:
         for e in self:
             match = True
             if e.name != name:
@@ -2188,7 +2188,7 @@ class ietf_yang_library__yang_library__module_set__module(yang.adata.MNode):
             return [ietf_yang_library__yang_library__module_set__module_entry.from_gdata(e) for e in n.elements]
         return []
 
-    def copy(self):
+    def copy(self) -> ietf_yang_library__yang_library__module_set__module:
         """Create a deep copy of this list object"""
         # Copy each element in the list
         copied_elements = []
@@ -2208,7 +2208,7 @@ class ietf_yang_library__yang_library__module_set__import_only_module__submodule
     revision: ?str
     location: list[str]
 
-    mut def __init__(self, name: str, revision: ?str, location: ?list[str]=None):
+    mut def __init__(self, name: str, revision: ?str, location: ?list[str]=None) -> None:
         self._ns = 'urn:ietf:params:xml:ns:yang:ietf-yang-library'
         self.name = name
         self.revision = revision
@@ -2229,19 +2229,19 @@ class ietf_yang_library__yang_library__module_set__import_only_module__submodule
     mut def from_gdata(n: yang.gdata.Node) -> ietf_yang_library__yang_library__module_set__import_only_module__submodule_entry:
         return ietf_yang_library__yang_library__module_set__import_only_module__submodule_entry(name=n.get_str(yang.gdata.Id(NS_ietf_yang_library, 'name')), revision=n.get_opt_str(yang.gdata.Id(NS_ietf_yang_library, 'revision')), location=n.get_opt_strs(yang.gdata.Id(NS_ietf_yang_library, 'location')))
 
-    def copy(self):
+    def copy(self) -> ietf_yang_library__yang_library__module_set__import_only_module__submodule_entry:
         """Create a deep copy of this adata object"""
         return ietf_yang_library__yang_library__module_set__import_only_module__submodule_entry.from_gdata(self.to_gdata())
 
 _breaker6 = None
 class ietf_yang_library__yang_library__module_set__import_only_module__submodule(yang.adata.MNode):
     elements: list[ietf_yang_library__yang_library__module_set__import_only_module__submodule_entry]
-    mut def __init__(self, elements=[]):
+    mut def __init__(self, elements: list[ietf_yang_library__yang_library__module_set__import_only_module__submodule_entry]=[]) -> None:
         self._ns = 'urn:ietf:params:xml:ns:yang:ietf-yang-library'
         self._name = 'submodule'
         self.elements = elements
 
-    mut def create(self, name, revision=None):
+    mut def create(self, name: str, revision: ?str=None) -> ietf_yang_library__yang_library__module_set__import_only_module__submodule_entry:
         for e in self:
             match = True
             if e.name != name:
@@ -2262,7 +2262,7 @@ class ietf_yang_library__yang_library__module_set__import_only_module__submodule
             return [ietf_yang_library__yang_library__module_set__import_only_module__submodule_entry.from_gdata(e) for e in n.elements]
         return []
 
-    def copy(self):
+    def copy(self) -> ietf_yang_library__yang_library__module_set__import_only_module__submodule:
         """Create a deep copy of this list object"""
         # Copy each element in the list
         copied_elements = []
@@ -2284,7 +2284,7 @@ class ietf_yang_library__yang_library__module_set__import_only_module_entry(yang
     location: list[str]
     submodule: ietf_yang_library__yang_library__module_set__import_only_module__submodule
 
-    mut def __init__(self, name: str, revision: str, namespace: str, location: ?list[str]=None, submodule: list[ietf_yang_library__yang_library__module_set__import_only_module__submodule_entry]=[]):
+    mut def __init__(self, name: str, revision: str, namespace: str, location: ?list[str]=None, submodule: list[ietf_yang_library__yang_library__module_set__import_only_module__submodule_entry]=[]) -> None:
         self._ns = 'urn:ietf:params:xml:ns:yang:ietf-yang-library'
         self.name = name
         self.revision = revision
@@ -2311,19 +2311,19 @@ class ietf_yang_library__yang_library__module_set__import_only_module_entry(yang
     mut def from_gdata(n: yang.gdata.Node) -> ietf_yang_library__yang_library__module_set__import_only_module_entry:
         return ietf_yang_library__yang_library__module_set__import_only_module_entry(name=n.get_str(yang.gdata.Id(NS_ietf_yang_library, 'name')), revision=n.get_str(yang.gdata.Id(NS_ietf_yang_library, 'revision')), namespace=n.get_str(yang.gdata.Id(NS_ietf_yang_library, 'namespace')), location=n.get_opt_strs(yang.gdata.Id(NS_ietf_yang_library, 'location')), submodule=ietf_yang_library__yang_library__module_set__import_only_module__submodule.from_gdata(n.get_opt_list(yang.gdata.Id(NS_ietf_yang_library, 'submodule'))))
 
-    def copy(self):
+    def copy(self) -> ietf_yang_library__yang_library__module_set__import_only_module_entry:
         """Create a deep copy of this adata object"""
         return ietf_yang_library__yang_library__module_set__import_only_module_entry.from_gdata(self.to_gdata())
 
 _breaker8 = None
 class ietf_yang_library__yang_library__module_set__import_only_module(yang.adata.MNode):
     elements: list[ietf_yang_library__yang_library__module_set__import_only_module_entry]
-    mut def __init__(self, elements=[]):
+    mut def __init__(self, elements: list[ietf_yang_library__yang_library__module_set__import_only_module_entry]=[]) -> None:
         self._ns = 'urn:ietf:params:xml:ns:yang:ietf-yang-library'
         self._name = 'import-only-module'
         self.elements = elements
 
-    mut def create(self, name, revision, namespace):
+    mut def create(self, name: str, revision: str, namespace: str) -> ietf_yang_library__yang_library__module_set__import_only_module_entry:
         for e in self:
             match = True
             if e.name != name:
@@ -2348,7 +2348,7 @@ class ietf_yang_library__yang_library__module_set__import_only_module(yang.adata
             return [ietf_yang_library__yang_library__module_set__import_only_module_entry.from_gdata(e) for e in n.elements]
         return []
 
-    def copy(self):
+    def copy(self) -> ietf_yang_library__yang_library__module_set__import_only_module:
         """Create a deep copy of this list object"""
         # Copy each element in the list
         copied_elements = []
@@ -2368,7 +2368,7 @@ class ietf_yang_library__yang_library__module_set_entry(yang.adata.MNode):
     module: ietf_yang_library__yang_library__module_set__module
     import_only_module: ietf_yang_library__yang_library__module_set__import_only_module
 
-    mut def __init__(self, name: str, module: list[ietf_yang_library__yang_library__module_set__module_entry]=[], import_only_module: list[ietf_yang_library__yang_library__module_set__import_only_module_entry]=[]):
+    mut def __init__(self, name: str, module: list[ietf_yang_library__yang_library__module_set__module_entry]=[], import_only_module: list[ietf_yang_library__yang_library__module_set__import_only_module_entry]=[]) -> None:
         self._ns = 'urn:ietf:params:xml:ns:yang:ietf-yang-library'
         self.name = name
         self.module = ietf_yang_library__yang_library__module_set__module(elements=module)
@@ -2389,19 +2389,19 @@ class ietf_yang_library__yang_library__module_set_entry(yang.adata.MNode):
     mut def from_gdata(n: yang.gdata.Node) -> ietf_yang_library__yang_library__module_set_entry:
         return ietf_yang_library__yang_library__module_set_entry(name=n.get_str(yang.gdata.Id(NS_ietf_yang_library, 'name')), module=ietf_yang_library__yang_library__module_set__module.from_gdata(n.get_opt_list(yang.gdata.Id(NS_ietf_yang_library, 'module'))), import_only_module=ietf_yang_library__yang_library__module_set__import_only_module.from_gdata(n.get_opt_list(yang.gdata.Id(NS_ietf_yang_library, 'import-only-module'))))
 
-    def copy(self):
+    def copy(self) -> ietf_yang_library__yang_library__module_set_entry:
         """Create a deep copy of this adata object"""
         return ietf_yang_library__yang_library__module_set_entry.from_gdata(self.to_gdata())
 
 _breaker10 = None
 class ietf_yang_library__yang_library__module_set(yang.adata.MNode):
     elements: list[ietf_yang_library__yang_library__module_set_entry]
-    mut def __init__(self, elements=[]):
+    mut def __init__(self, elements: list[ietf_yang_library__yang_library__module_set_entry]=[]) -> None:
         self._ns = 'urn:ietf:params:xml:ns:yang:ietf-yang-library'
         self._name = 'module-set'
         self.elements = elements
 
-    mut def create(self, name):
+    mut def create(self, name: str) -> ietf_yang_library__yang_library__module_set_entry:
         for e in self:
             match = True
             if e.name != name:
@@ -2420,7 +2420,7 @@ class ietf_yang_library__yang_library__module_set(yang.adata.MNode):
             return [ietf_yang_library__yang_library__module_set_entry.from_gdata(e) for e in n.elements]
         return []
 
-    def copy(self):
+    def copy(self) -> ietf_yang_library__yang_library__module_set:
         """Create a deep copy of this list object"""
         # Copy each element in the list
         copied_elements = []
@@ -2439,7 +2439,7 @@ class ietf_yang_library__yang_library__schema_entry(yang.adata.MNode):
     name: str
     module_set: list[str]
 
-    mut def __init__(self, name: str, module_set: ?list[str]=None):
+    mut def __init__(self, name: str, module_set: ?list[str]=None) -> None:
         self._ns = 'urn:ietf:params:xml:ns:yang:ietf-yang-library'
         self.name = name
         self.module_set = module_set if module_set is not None else []
@@ -2457,19 +2457,19 @@ class ietf_yang_library__yang_library__schema_entry(yang.adata.MNode):
     mut def from_gdata(n: yang.gdata.Node) -> ietf_yang_library__yang_library__schema_entry:
         return ietf_yang_library__yang_library__schema_entry(name=n.get_str(yang.gdata.Id(NS_ietf_yang_library, 'name')), module_set=n.get_opt_strs(yang.gdata.Id(NS_ietf_yang_library, 'module-set')))
 
-    def copy(self):
+    def copy(self) -> ietf_yang_library__yang_library__schema_entry:
         """Create a deep copy of this adata object"""
         return ietf_yang_library__yang_library__schema_entry.from_gdata(self.to_gdata())
 
 _breaker12 = None
 class ietf_yang_library__yang_library__schema(yang.adata.MNode):
     elements: list[ietf_yang_library__yang_library__schema_entry]
-    mut def __init__(self, elements=[]):
+    mut def __init__(self, elements: list[ietf_yang_library__yang_library__schema_entry]=[]) -> None:
         self._ns = 'urn:ietf:params:xml:ns:yang:ietf-yang-library'
         self._name = 'schema'
         self.elements = elements
 
-    mut def create(self, name):
+    mut def create(self, name: str) -> ietf_yang_library__yang_library__schema_entry:
         for e in self:
             match = True
             if e.name != name:
@@ -2488,7 +2488,7 @@ class ietf_yang_library__yang_library__schema(yang.adata.MNode):
             return [ietf_yang_library__yang_library__schema_entry.from_gdata(e) for e in n.elements]
         return []
 
-    def copy(self):
+    def copy(self) -> ietf_yang_library__yang_library__schema:
         """Create a deep copy of this list object"""
         # Copy each element in the list
         copied_elements = []
@@ -2507,7 +2507,7 @@ class ietf_yang_library__yang_library__datastore_entry(yang.adata.MNode):
     name: Identityref
     schema: str
 
-    mut def __init__(self, name: Identityref, schema: str):
+    mut def __init__(self, name: Identityref, schema: str) -> None:
         self._ns = 'urn:ietf:params:xml:ns:yang:ietf-yang-library'
         self.name = name
         self.schema = schema
@@ -2525,19 +2525,19 @@ class ietf_yang_library__yang_library__datastore_entry(yang.adata.MNode):
     mut def from_gdata(n: yang.gdata.Node) -> ietf_yang_library__yang_library__datastore_entry:
         return ietf_yang_library__yang_library__datastore_entry(name=n.get_Identityref(yang.gdata.Id(NS_ietf_yang_library, 'name')), schema=n.get_str(yang.gdata.Id(NS_ietf_yang_library, 'schema')))
 
-    def copy(self):
+    def copy(self) -> ietf_yang_library__yang_library__datastore_entry:
         """Create a deep copy of this adata object"""
         return ietf_yang_library__yang_library__datastore_entry.from_gdata(self.to_gdata())
 
 _breaker14 = None
 class ietf_yang_library__yang_library__datastore(yang.adata.MNode):
     elements: list[ietf_yang_library__yang_library__datastore_entry]
-    mut def __init__(self, elements=[]):
+    mut def __init__(self, elements: list[ietf_yang_library__yang_library__datastore_entry]=[]) -> None:
         self._ns = 'urn:ietf:params:xml:ns:yang:ietf-yang-library'
         self._name = 'datastore'
         self.elements = elements
 
-    mut def create(self, name, schema):
+    mut def create(self, name: Identityref, schema: str) -> ietf_yang_library__yang_library__datastore_entry:
         for e in self:
             match = True
             if e.name != name:
@@ -2557,7 +2557,7 @@ class ietf_yang_library__yang_library__datastore(yang.adata.MNode):
             return [ietf_yang_library__yang_library__datastore_entry.from_gdata(e) for e in n.elements]
         return []
 
-    def copy(self):
+    def copy(self) -> ietf_yang_library__yang_library__datastore:
         """Create a deep copy of this list object"""
         # Copy each element in the list
         copied_elements = []
@@ -2578,7 +2578,7 @@ class ietf_yang_library__yang_library(yang.adata.MNode):
     datastore: ietf_yang_library__yang_library__datastore
     content_id: str
 
-    mut def __init__(self, content_id: str, module_set: list[ietf_yang_library__yang_library__module_set_entry]=[], schema: list[ietf_yang_library__yang_library__schema_entry]=[], datastore: list[ietf_yang_library__yang_library__datastore_entry]=[]):
+    mut def __init__(self, content_id: str, module_set: list[ietf_yang_library__yang_library__module_set_entry]=[], schema: list[ietf_yang_library__yang_library__schema_entry]=[], datastore: list[ietf_yang_library__yang_library__datastore_entry]=[]) -> None:
         self._ns = 'urn:ietf:params:xml:ns:yang:ietf-yang-library'
         self.module_set = ietf_yang_library__yang_library__module_set(elements=module_set)
         self.schema = ietf_yang_library__yang_library__schema(elements=schema)
@@ -2604,7 +2604,7 @@ class ietf_yang_library__yang_library(yang.adata.MNode):
             return ietf_yang_library__yang_library(module_set=ietf_yang_library__yang_library__module_set.from_gdata(n.get_opt_list(yang.gdata.Id(NS_ietf_yang_library, 'module-set'))), schema=ietf_yang_library__yang_library__schema.from_gdata(n.get_opt_list(yang.gdata.Id(NS_ietf_yang_library, 'schema'))), datastore=ietf_yang_library__yang_library__datastore.from_gdata(n.get_opt_list(yang.gdata.Id(NS_ietf_yang_library, 'datastore'))), content_id=n.get_str(yang.gdata.Id(NS_ietf_yang_library, 'content-id')))
         raise ValueError('Missing required subtree ietf_yang_library__yang_library')
 
-    def copy(self):
+    def copy(self) -> ietf_yang_library__yang_library:
         """Create a deep copy of this adata object"""
         return ietf_yang_library__yang_library.from_gdata(self.to_gdata())
 
@@ -2613,7 +2613,7 @@ _breaker16 = None
 class root(yang.adata.MNode):
     yang_library: ietf_yang_library__yang_library
 
-    mut def __init__(self, yang_library: ietf_yang_library__yang_library):
+    mut def __init__(self, yang_library: ietf_yang_library__yang_library) -> None:
         self._ns = ''
         self.yang_library = yang_library
 
@@ -2630,7 +2630,7 @@ class root(yang.adata.MNode):
             return root(yang_library=ietf_yang_library__yang_library.from_gdata(n.get_cnt(yang.gdata.Id(NS_ietf_yang_library, 'yang-library'))))
         raise ValueError('Missing required subtree root')
 
-    def copy(self):
+    def copy(self) -> root:
         """Create a deep copy of this adata object"""
         return root.from_gdata(self.to_gdata())
 

--- a/src/stratoweave/test_devicemgr_netconf.act
+++ b/src/stratoweave/test_devicemgr_netconf.act
@@ -243,7 +243,7 @@ actor _test_subscribe_periodic(t: testing.EnvT):
 
     start()
 
-    after 0.5: fail("Timed out waiting for periodic subscription updates")
+    after 2.0: fail("Timed out waiting for periodic subscription updates")
 
 
 actor _test_subscription_manager_declare(t: testing.EnvT):
@@ -339,7 +339,7 @@ actor _test_subscription_manager_declare(t: testing.EnvT):
 
     start()
 
-    after 0.5: fail("Timed out waiting for declarative subscription manager updates")
+    after 2.0: fail("Timed out waiting for declarative subscription manager updates")
 
 
 actor _test_subscription_manager_idempotent(t: testing.EnvT):
@@ -423,4 +423,4 @@ actor _test_subscription_manager_idempotent(t: testing.EnvT):
 
     start()
 
-    after 0.5: fail("Timed out waiting for idempotent subscription manager test")
+    after 2.0: fail("Timed out waiting for idempotent subscription manager test")

--- a/src/stratoweave/ttt.act
+++ b/src/stratoweave/ttt.act
@@ -235,14 +235,152 @@ def path_key_data(p: Path) -> gdata.Node:
         return gdata.Container(dict(p.keyvals.items()))
     return gdata.Container()
 
-def _filter_data(data: ?gdata.Node, filt: ?gdata.FNode) -> ?gdata.Node:
-    if data is None:
-        return None
+def root_filter(filt: ?gdata.FNode) -> ?gdata.FNode:
+    """Adapt an external root filter to the implicit TTT root container.
+
+    A named RESTCONF filter describes a top-level data node. The TTT root is
+    the parent of those nodes, so the named filter must become a child filter
+    before container traversal starts.
+    """
+    if filt is not None and filt.name is not None:
+        return gdata.FNode(children=[filt])
+    return filt
+
+def filter_transpose(filt: ?gdata.FNode) -> ?dict[gdata.Id, gdata.FNode]:
+    """Transpose a container filter into filter branches per child node.
+
+    For a container filter like:
+
+        FNode(children=[
+            FNode(router, children=[
+                FNode(name, value_match="ce1"),
+                FNode(state, children=[
+                    FNode(current-datetime),
+                ]),
+            ]),
+            FNode(switch, children=[
+                FNode(name, value_match="sw1"),
+            ]),
+        ])
+
+    this returns:
+
+        router -> FNode(router, children=[
+            FNode(name, value_match="ce1"),
+            FNode(state, children=[
+                FNode(current-datetime),
+            ]),
+        ])
+        switch -> FNode(switch, children=[
+            FNode(name, value_match="sw1"),
+        ])
+
+    Repeated child filters are merged when they describe the same predicate
+    context. Repeated child filters with different predicates stay wrapped
+    in a single anonymous FNode under the same child key, for example:
+
+        router -> FNode(children=[
+            FNode(router, children=[
+                FNode(name, value_match="ce1"),
+                FNode(state),
+            ]),
+            FNode(router, children=[
+                FNode(name, value_match="ce2"),
+                FNode(state),
+            ]),
+        ])
+
+    A bare named filter with no children means "read this whole subtree" once
+    the parent has already selected this node.
+    """
     if filt is not None:
-        if filt.name is not None:
-            return gdata.filter(data, gdata.FNode(children=[filt]))
-        return gdata.filter(data, filt)
-    return data
+        if filt.value_match is not None:
+            raise ValueError("Container filter cannot have value match")
+        if len(filt.children) == 0:
+            return None
+        children = gdata.filter_merge_list(filt.children)
+        branches: dict[gdata.Id, gdata.FNode] = {}
+        for child in children:
+            tag = child.name
+            if tag is not None:
+                if tag in branches:
+                    prev = branches[tag]
+                    siblings = prev.children if prev.name is None else [prev]
+                    merged = gdata.filter_merge_list(siblings + [child])
+                    branches[tag] = merged[0] if len(merged) == 1 else gdata.FNode(children=merged)
+                else:
+                    branches[tag] = child
+            else:
+                raise ValueError("Container filter child must have name")
+        return branches
+    return None
+
+def list_filters(filt: ?gdata.FNode) -> list[gdata.FNode]:
+    """Normalize the filter received by a TTT list node.
+
+    Parent containers send a single named filter for one list predicate, or
+    an anonymous wrapper when the same list is selected by multiple distinct
+    predicates. Returning a list of named filters gives list reads one common
+    shape for exact-key routing and final gdata filtering.
+    """
+    if filt is not None:
+        if filt.name is None:
+            return filt.children
+        return [filt]
+    return []
+
+def filter_exact_list_key(filt: gdata.FNode, key_names: list[gdata.Id]) -> ?str:
+    """Return the exact list key selected by a filter, if it is routable.
+
+    Only plain key value matches are safe to route directly to one TTT list
+    element. Wildcards, missing key predicates, and key filters with children
+    fall back to scanning the list and applying the normal gdata filter.
+    """
+    leaves: dict[gdata.Id, gdata.Leaf] = {}
+    for key_name in key_names:
+        found = False
+        for child in filt.children:
+            vm = child.value_match
+            if child.name == key_name and vm is not None and len(child.children) == 0:
+                if isinstance(vm, gdata.ValueMatch):
+                    return None
+                leaves[key_name] = gdata.Leaf(vm)
+                found = True
+                break
+        if not found:
+            return None
+    return gdata.Container(leaves).key_str(key_names)
+
+def list_element_filters(filters: list[gdata.FNode]) -> list[gdata.FNode]:
+    """Return element-local filters for routed or scanned list reads.
+
+    TTT list nodes route to list elements, so the list node itself has
+    already been consumed. The child filter sent to an element is therefore
+    anonymous and contains the list predicate's children.
+    """
+    return gdata.filter_merge_list([gdata.FNode(children=f.children) for f in filters])
+
+def exact_list_filter_branches(filters: list[gdata.FNode], key_names: list[gdata.Id]) -> ?dict[str, list[gdata.FNode]]:
+    """Return per-key element filters when every branch has an exact key.
+
+    The result maps each selected TTT list key to the filter that should be
+    passed to that list element. None means at least one branch either cannot
+    be mapped to a concrete key.
+    """
+    if len(filters) == 0:
+        return None
+    branches: dict[str, list[gdata.FNode]] = {}
+    for filt in filters:
+        key = filter_exact_list_key(filt, key_names)
+        if key is not None:
+            elem_filter = gdata.FNode(children=filt.children)
+            if key in branches:
+                branches[key] = gdata.filter_merge_list(branches[key] + [elem_filter])
+            else:
+                branches[key] = [elem_filter]
+        else:
+            return None
+    return branches
 
 def _db_path(path: Path) -> list[value]:
     if isinstance(path, PathElem):
@@ -289,8 +427,8 @@ actor Node(impl: _Node):
     def get():
         return impl.get()
 
-    def get_data():
-        return impl.get_data()
+    def get_data(filt: ?gdata.FNode=None):
+        return impl.get_data(filt)
 
     def bind_db(db: ?lmdb.Db):
         """Attach DB handle to this node (and its children)
@@ -311,8 +449,8 @@ class _Node(object):
     path: Path
     newtrans: proc() -> Transaction
     get: proc() -> gdata.Node
-    def get_data(self) -> gdata.Node:
-        return self.get()
+    def get_data(self, filt: ?gdata.FNode=None) -> ?gdata.Node:
+        return gdata.filter(self.get(), filt)
     def bind_db(self, db: ?lmdb.Db) -> None:
         pass
     restore: proc(list[str], str, ?str, bytes) -> None
@@ -346,8 +484,8 @@ actor Transaction(impl: _Transaction):
     def get():
         return impl.get()
 
-    def get_data():
-        return impl.get_data()
+    def get_data(filt: ?gdata.FNode=None):
+        return impl.get_data(filt)
 
     def bind_db(db: ?lmdb.Db):
         impl.bind_db(db)
@@ -378,8 +516,8 @@ class _Transaction(object):
     wait_complete: proc(actself: Transaction, tid: str, done: action(value) -> None) -> None
     wait_complete_cont: proc(actself: Transaction, res: value) -> None
     get: proc() -> gdata.Node
-    def get_data(self) -> gdata.Node:
-        return self.get()
+    def get_data(self, filt: ?gdata.FNode=None) -> ?gdata.Node:
+        return gdata.filter(self.get(), filt)
 
     def bind_db(self, db: ?lmdb.Db) -> None:
         pass
@@ -453,7 +591,7 @@ actor Layer(name: str, rootgen: proc(Path, ?Layer)->Node, lower: ?Layer, db_arg:
         return root.get()
 
     def get_data(filt: ?gdata.FNode=None) -> ?gdata.Node:
-        return _filter_data(root.get_data(), filt)
+        return root.get_data(root_filter(filt))
 
 
 actor Session(name: str, rootnode: Node, lowerlayer: ?Layer, db: ?lmdb.Db, dbuf_arg: ?swdb.Buffer=None):
@@ -639,7 +777,7 @@ actor Session(name: str, rootnode: Node, lowerlayer: ?Layer, db: ?lmdb.Db, dbuf_
         return root.get()
 
     def get_data(filt: ?gdata.FNode=None) -> ?gdata.Node:
-        return _filter_data(root.get_data(), filt)
+        return root.get_data(root_filter(filt))
 
     def below():
         return lower if lower is not None else self
@@ -672,11 +810,22 @@ class _Container(_Node):
             res.update(path.keyvals.items())
         return gdata.Container(res, ns=self.ns, module=self.module)
 
-    def get_data(self):
-        res = {tag: node.get_data() for tag, node in self.elems.items()}
+    def get_data(self, filt: ?gdata.FNode=None):
+        branches = filter_transpose(filt)
+        if branches is not None:
+            res = {}
+            for tag, child_filter in branches.items():
+                if tag in self.elems:
+                    data = self.elems[tag].get_data(child_filter)
+                    if data is not None:
+                        res[tag] = data
+        else:
+            res = {tag: expect(node.get_data(), "container child data") for tag, node in self.elems.items()}
         path = self.path
         if isinstance(path, PathKey):
             res.update(path.keyvals.items())
+        elif branches is not None and len(res) == 0:
+            return None
         return gdata.Container(res, ns=self.ns, module=self.module)
 
     def bind_db(self, db: ?lmdb.Db) -> None:
@@ -863,11 +1012,22 @@ class _ContainerTransaction(_Transaction):
             res.update(path.keyvals.items())
         return gdata.Container(res, ns=self.ns, module=self.module)
 
-    def get_data(self):
-        res = {tag: elem.get_data() for tag, elem in self.elems.items()}
+    def get_data(self, filt: ?gdata.FNode=None):
+        branches = filter_transpose(filt)
+        if branches is not None:
+            res = {}
+            for tag, child_filter in branches.items():
+                if tag in self.elems:
+                    data = self.elems[tag].get_data(child_filter)
+                    if data is not None:
+                        res[tag] = data
+        else:
+            res = {tag: expect(elem.get_data(), "container child data") for tag, elem in self.elems.items()}
         path = self.path
         if isinstance(path, PathKey):
             res.update(path.keyvals.items())
+        elif branches is not None and len(res) == 0:
+            return None
         return gdata.Container(res, ns=self.ns, module=self.module)
 
 
@@ -899,10 +1059,31 @@ class _List(_Node):
             res.append(r)
         return gdata.List(self.key_names, res, ns=self.ns, module=self.module)
 
-    def get_data(self):
+    def get_data(self, filt: ?gdata.FNode=None):
+        filters = list_filters(filt)
+        filter_branches = exact_list_filter_branches(filters, self.key_names)
+        scan_filters = list_element_filters(filters)
         res = []
+        # TODO: when filter_branches is not None, fetch only those exact keys
+        # from ListState instead of enumerating all committed entries.
         for key, node in self.liststate.all().items():
-            res.append(node.get_data())
+            element_filters = scan_filters
+            if filter_branches is not None:
+                if key not in filter_branches:
+                    continue
+                element_filters = filter_branches[key]
+            if len(element_filters) == 0:
+                elem = node.get_data()
+                if elem is not None:
+                    res.append(elem)
+            else:
+                for element_filter in element_filters:
+                    elem = node.get_data(element_filter)
+                    if elem is not None:
+                        res.append(elem)
+                        break
+        if len(filters) > 0 and len(res) == 0:
+            return None
         return gdata.List(self.key_names, res, ns=self.ns, module=self.module)
 
     def bind_db(self, db: ?lmdb.Db) -> None:
@@ -1181,14 +1362,37 @@ class _ListTransaction(_Transaction):
             res.append(r)
         return gdata.List(self.key_names, res, ns=self.ns, module=self.module)
 
-    def get_data(self):
+    def get_data(self, filt: ?gdata.FNode=None):
+        filters = list_filters(filt)
+        filter_branches = exact_list_filter_branches(filters, self.key_names)
+        scan_filters = list_element_filters(filters)
         res = []
+        # TODO: when filter_branches is not None, fetch only those exact keys
+        # from ListState instead of enumerating all committed entries.
         for key, node in self.liststate.all().items():
-            if key in self.elems:
-                r = self.elems[key].get_data()
+            element_filters = scan_filters
+            if filter_branches is not None:
+                if key not in filter_branches:
+                    continue
+                element_filters = filter_branches[key]
+            if len(element_filters) == 0:
+                if key in self.elems:
+                    r = self.elems[key].get_data()
+                else:
+                    r = node.get_data()
+                if r is not None:
+                    res.append(r)
             else:
-                r = node.get_data()
-            res.append(r)
+                for element_filter in element_filters:
+                    if key in self.elems:
+                        r = self.elems[key].get_data(element_filter)
+                    else:
+                        r = node.get_data(element_filter)
+                    if r is not None:
+                        res.append(r)
+                        break
+        if len(filters) > 0 and len(res) == 0:
+            return None
         return gdata.List(self.key_names, res, ns=self.ns, module=self.module)
 
 def ListTransaction(path, liststate: ListState, key_names, ns, module):
@@ -1206,8 +1410,8 @@ class _TransformBase(_Node):
     def get(self):
         return self.transaction.get()
 
-    def get_data(self):
-        return self.transaction.get_data()
+    def get_data(self, filt: ?gdata.FNode=None):
+        return self.transaction.get_data(filt)
 
     def bind_db(self, db: ?lmdb.Db) -> None:
         self.transaction.bind_db(db)
@@ -1484,12 +1688,15 @@ class _TransformTransactionBase(_Transaction):
         else:
             return gdata.Container()
 
-    def get_data(self):
+    def get_data(self, filt: ?gdata.FNode=None):
         data = self.get()
         oper = self.oper
         if oper is not None:
             data = gdata.merge(data, _with_path_keys(self.path, oper))
-        return _with_path_keys(self.path, data)
+        filtered = gdata.filter(_with_path_keys(self.path, data), filt)
+        if filtered is not None:
+            return _with_path_keys(self.path, filtered)
+        return None
 
     proc def update_oper(self, oper):
         self.oper = oper

--- a/src/test_ttt_oper_read.act
+++ b/src/test_ttt_oper_read.act
@@ -93,13 +93,13 @@ actor get_data_filters_list_entries(t: testing.AsyncT):
         })
         filtered = layer.newsession().get_data(filt)
         if filtered is None:
-            if attempts > 20:
+            if attempts > 100:
                 t.failure(ValueError("Timed out waiting for filtered data, got None"))
                 return
             after 0.01: check()
             return
         if filtered != expected:
-            if attempts > 20:
+            if attempts > 100:
                 t.failure(ValueError("Timed out waiting for filtered data, got " + filtered!.prsrc(deterministic=True)))
                 return
             after 0.01: check()
@@ -147,13 +147,13 @@ actor get_data_merges_repeated_filter_branches(t: testing.AsyncT):
         })
         filtered = layer.newsession().get_data(filt)
         if filtered is None:
-            if attempts > 20:
+            if attempts > 100:
                 t.failure(ValueError("Timed out waiting for repeated filter data, got None"))
                 return
             after 0.01: check()
             return
         if filtered != expected:
-            if attempts > 20:
+            if attempts > 100:
                 t.failure(ValueError("Timed out waiting for repeated filter data, got " + filtered!.prsrc(deterministic=True)))
                 return
             after 0.01: check()
@@ -192,13 +192,13 @@ actor get_data_routes_exact_key_with_element_predicate(t: testing.AsyncT):
         })
         filtered = layer.newsession().get_data(filt)
         if filtered is None:
-            if attempts > 20:
+            if attempts > 100:
                 t.failure(ValueError("Timed out waiting for predicate routed data, got None"))
                 return
             after 0.01: check()
             return
         if filtered != expected:
-            if attempts > 20:
+            if attempts > 100:
                 t.failure(ValueError("Timed out waiting for predicate routed data, got " + filtered!.prsrc(deterministic=True)))
                 return
             after 0.01: check()
@@ -236,13 +236,13 @@ actor get_data_scans_with_element_predicate(t: testing.AsyncT):
         })
         filtered = layer.newsession().get_data(filt)
         if filtered is None:
-            if attempts > 20:
+            if attempts > 100:
                 t.failure(ValueError("Timed out waiting for scanned predicate data, got None"))
                 return
             after 0.01: check()
             return
         if filtered != expected:
-            if attempts > 20:
+            if attempts > 100:
                 t.failure(ValueError("Timed out waiting for scanned predicate data, got " + filtered!.prsrc(deterministic=True)))
                 return
             after 0.01: check()
@@ -266,7 +266,7 @@ actor read_data_merges_config_and_oper(t: testing.AsyncT):
         attempts += 1
         data = layer.newsession().get_data()
         if data is None:
-            if attempts > 20:
+            if attempts > 100:
                 t.failure(ValueError("Timed out waiting for merged data, got None"))
                 return
             after 0.01: check()
@@ -288,13 +288,13 @@ actor read_data_merges_config_and_oper(t: testing.AsyncT):
             ]),
         })
         if filtered is None:
-            if attempts > 20:
+            if attempts > 100:
                 t.failure(ValueError("Timed out waiting for merged data, got " + data!.prsrc(deterministic=True)))
                 return
             after 0.01: check()
             return
         if filtered != expected:
-            if attempts > 20:
+            if attempts > 100:
                 t.failure(ValueError("Timed out waiting for merged data, got " + filtered!.prsrc(deterministic=True)))
                 return
             after 0.01: check()

--- a/src/test_ttt_oper_read.act
+++ b/src/test_ttt_oper_read.act
@@ -110,6 +110,149 @@ actor get_data_filters_list_entries(t: testing.AsyncT):
     layer.edit_config(_service_cfg(), cont)
 
 
+actor get_data_merges_repeated_filter_branches(t: testing.AsyncT):
+    layer = ttt.Layer("top", ttt.Container({
+        q("service"): ttt.List(ttt.Transform(OperTransform, OperPublisherCtor), [q("name")]),
+    }), None)
+    var attempts = 0
+
+    def cont(_r: value):
+        after 0: check()
+
+    def check():
+        attempts += 1
+        filt = gdata.FNode(children=[
+            gdata.FNode(q("service"), children=[
+                gdata.FNode(q("name"), value_match="svc-a"),
+                gdata.FNode(q("status")),
+            ]),
+            gdata.FNode(q("service"), children=[
+                gdata.FNode(q("name"), value_match="svc-b"),
+                gdata.FNode(q("metrics"), children=[gdata.FNode(q("rx"))]),
+            ]),
+        ])
+        expected = gdata.Container({
+            q("service"): gdata.List([q("name")], [
+                gdata.Container({
+                    q("name"): gdata.Leaf("svc-a"),
+                    q("status"): gdata.Leaf("up-svc-a"),
+                }),
+                gdata.Container({
+                    q("name"): gdata.Leaf("svc-b"),
+                    q("metrics"): gdata.Container({
+                        q("rx"): gdata.Leaf(u64(5)),
+                    }),
+                }),
+            ]),
+        })
+        filtered = layer.newsession().get_data(filt)
+        if filtered is None:
+            if attempts > 20:
+                t.failure(ValueError("Timed out waiting for repeated filter data, got None"))
+                return
+            after 0.01: check()
+            return
+        if filtered != expected:
+            if attempts > 20:
+                t.failure(ValueError("Timed out waiting for repeated filter data, got " + filtered!.prsrc(deterministic=True)))
+                return
+            after 0.01: check()
+            return
+        testing.assertEqual(filtered!.prsrc(deterministic=True), expected.prsrc(deterministic=True))
+        t.success()
+
+    layer.edit_config(_service_cfg(), cont)
+
+
+actor get_data_routes_exact_key_with_element_predicate(t: testing.AsyncT):
+    layer = ttt.Layer("top", ttt.Container({
+        q("service"): ttt.List(ttt.Transform(OperTransform, OperPublisherCtor), [q("name")]),
+    }), None)
+    var attempts = 0
+
+    def cont(_r: value):
+        after 0: check()
+
+    def check():
+        attempts += 1
+        filt = gdata.FNode(q("service"), children=[
+            gdata.FNode(q("name"), value_match="svc-b"),
+            gdata.FNode(q("status"), value_match="up-svc-b"),
+            gdata.FNode(q("metrics"), children=[gdata.FNode(q("rx"))]),
+        ])
+        expected = gdata.Container({
+            q("service"): gdata.List([q("name")], [
+                gdata.Container({
+                    q("name"): gdata.Leaf("svc-b"),
+                    q("metrics"): gdata.Container({
+                        q("rx"): gdata.Leaf(u64(5)),
+                    }),
+                }),
+            ]),
+        })
+        filtered = layer.newsession().get_data(filt)
+        if filtered is None:
+            if attempts > 20:
+                t.failure(ValueError("Timed out waiting for predicate routed data, got None"))
+                return
+            after 0.01: check()
+            return
+        if filtered != expected:
+            if attempts > 20:
+                t.failure(ValueError("Timed out waiting for predicate routed data, got " + filtered!.prsrc(deterministic=True)))
+                return
+            after 0.01: check()
+            return
+        testing.assertEqual(filtered!.prsrc(deterministic=True), expected.prsrc(deterministic=True))
+        t.success()
+
+    layer.edit_config(_service_cfg(), cont)
+
+
+actor get_data_scans_with_element_predicate(t: testing.AsyncT):
+    layer = ttt.Layer("top", ttt.Container({
+        q("service"): ttt.List(ttt.Transform(OperTransform, OperPublisherCtor), [q("name")]),
+    }), None)
+    var attempts = 0
+
+    def cont(_r: value):
+        after 0: check()
+
+    def check():
+        attempts += 1
+        filt = gdata.FNode(q("service"), children=[
+            gdata.FNode(q("status"), value_match="up-svc-b"),
+            gdata.FNode(q("metrics"), children=[gdata.FNode(q("rx"))]),
+        ])
+        expected = gdata.Container({
+            q("service"): gdata.List([q("name")], [
+                gdata.Container({
+                    q("name"): gdata.Leaf("svc-b"),
+                    q("metrics"): gdata.Container({
+                        q("rx"): gdata.Leaf(u64(5)),
+                    }),
+                }),
+            ]),
+        })
+        filtered = layer.newsession().get_data(filt)
+        if filtered is None:
+            if attempts > 20:
+                t.failure(ValueError("Timed out waiting for scanned predicate data, got None"))
+                return
+            after 0.01: check()
+            return
+        if filtered != expected:
+            if attempts > 20:
+                t.failure(ValueError("Timed out waiting for scanned predicate data, got " + filtered!.prsrc(deterministic=True)))
+                return
+            after 0.01: check()
+            return
+        testing.assertEqual(filtered!.prsrc(deterministic=True), expected.prsrc(deterministic=True))
+        t.success()
+
+    layer.edit_config(_service_cfg(), cont)
+
+
 actor read_data_merges_config_and_oper(t: testing.AsyncT):
     layer = ttt.Layer("top", ttt.Container({
         q("service"): ttt.List(ttt.Transform(OperTransform, OperPublisherCtor), [q("name")]),

--- a/src/test_ttt_transform.act
+++ b/src/test_ttt_transform.act
@@ -165,6 +165,195 @@ def _test_transpose_absent():
     }
     testing.assertEqual(out1, exp1)
 
+def _test_filter_transpose_none():
+    testing.assertEqual(ttt.filter_transpose(None) is None, True)
+    testing.assertEqual(ttt.filter_transpose(gdata.FNode()) is None, True)
+    testing.assertEqual(ttt.filter_transpose(gdata.FNode(q("router"))) is None, True)
+
+def _test_filter_transpose_named_filter():
+    res = ttt.filter_transpose(gdata.FNode(q("router"), children=[
+        gdata.FNode(q("name"), value_match="ce1"),
+        gdata.FNode(q("state")),
+    ]))
+    if res is not None:
+        testing.assertEqual(len(res), 2)
+        testing.assertEqual(res[q("name")].prsrc(deterministic=True), gdata.FNode(q("name"), value_match="ce1").prsrc(deterministic=True))
+        testing.assertEqual(res[q("state")].prsrc(deterministic=True), gdata.FNode(q("state")).prsrc(deterministic=True))
+    else:
+        testing.assertEqual("dict", "None")
+
+def _test_filter_transpose_buckets_child_branches():
+    res = ttt.filter_transpose(gdata.FNode(children=[
+        gdata.FNode(q("router"), children=[
+            gdata.FNode(q("name"), value_match="ce1"),
+            gdata.FNode(q("state")),
+        ]),
+        gdata.FNode(q("router"), children=[
+            gdata.FNode(q("name"), value_match="ce1"),
+            gdata.FNode(q("state"), children=[
+                gdata.FNode(q("current-datetime")),
+            ]),
+        ]),
+        gdata.FNode(q("switch")),
+    ]))
+    if res is not None:
+        testing.assertEqual(len(res), 2)
+        testing.assertEqual(res[q("router")].prsrc(deterministic=True), gdata.FNode(q("router"), children=[
+            gdata.FNode(q("name"), value_match="ce1"),
+            gdata.FNode(q("state")),
+        ]).prsrc(deterministic=True))
+        testing.assertEqual(res[q("switch")].prsrc(deterministic=True), gdata.FNode(q("switch")).prsrc(deterministic=True))
+    else:
+        testing.assertEqual("dict", "None")
+
+def _test_filter_transpose_preserves_distinct_predicates():
+    res = ttt.filter_transpose(gdata.FNode(children=[
+        gdata.FNode(q("router"), children=[
+            gdata.FNode(q("name"), value_match="ce1"),
+            gdata.FNode(q("state")),
+        ]),
+        gdata.FNode(q("router"), children=[
+            gdata.FNode(q("name"), value_match="ce2"),
+            gdata.FNode(q("state")),
+        ]),
+    ]))
+    if res is not None:
+        testing.assertEqual(len(res), 1)
+        testing.assertEqual(res[q("router")].prsrc(deterministic=True), gdata.FNode(children=[
+            gdata.FNode(q("router"), children=[
+                gdata.FNode(q("name"), value_match="ce1"),
+                gdata.FNode(q("state")),
+            ]),
+            gdata.FNode(q("router"), children=[
+                gdata.FNode(q("name"), value_match="ce2"),
+                gdata.FNode(q("state")),
+            ]),
+        ]).prsrc(deterministic=True))
+    else:
+        testing.assertEqual("dict", "None")
+
+def _test_list_filters_extracts_repeated_predicates():
+    filters = ttt.list_filters(gdata.FNode(children=[
+        gdata.FNode(q("router"), children=[
+            gdata.FNode(q("name"), value_match="ce1"),
+            gdata.FNode(q("state")),
+        ]),
+        gdata.FNode(q("router"), children=[
+            gdata.FNode(q("name"), value_match="ce2"),
+            gdata.FNode(q("state")),
+        ]),
+    ]))
+    testing.assertEqual(len(filters), 2)
+    testing.assertEqual(filters[0].prsrc(deterministic=True), gdata.FNode(q("router"), children=[
+        gdata.FNode(q("name"), value_match="ce1"),
+        gdata.FNode(q("state")),
+    ]).prsrc(deterministic=True))
+    testing.assertEqual(filters[1].prsrc(deterministic=True), gdata.FNode(q("router"), children=[
+        gdata.FNode(q("name"), value_match="ce2"),
+        gdata.FNode(q("state")),
+    ]).prsrc(deterministic=True))
+
+def _test_exact_list_filter_branches_extracts_plain_keys():
+    branches = ttt.exact_list_filter_branches([
+        gdata.FNode(q("router"), children=[
+            gdata.FNode(q("name"), value_match="ce1"),
+            gdata.FNode(q("state")),
+        ]),
+        gdata.FNode(q("router"), children=[
+            gdata.FNode(q("name"), value_match="ce2"),
+            gdata.FNode(q("state")),
+        ]),
+    ], [q("name")])
+    if branches is not None:
+        testing.assertEqual(len(branches), 2)
+        testing.assertEqual(branches["ce1"][0].prsrc(deterministic=True), gdata.FNode(children=[
+            gdata.FNode(q("name"), value_match="ce1"),
+            gdata.FNode(q("state")),
+        ]).prsrc(deterministic=True))
+        testing.assertEqual(branches["ce2"][0].prsrc(deterministic=True), gdata.FNode(children=[
+            gdata.FNode(q("name"), value_match="ce2"),
+            gdata.FNode(q("state")),
+        ]).prsrc(deterministic=True))
+    else:
+        testing.assertEqual("branches", "None")
+
+def _test_exact_list_filter_branches_merges_same_key():
+    branches = ttt.exact_list_filter_branches([
+        gdata.FNode(q("router"), children=[
+            gdata.FNode(q("name"), value_match="ce1"),
+            gdata.FNode(q("state")),
+        ]),
+        gdata.FNode(q("router"), children=[
+            gdata.FNode(q("name"), value_match="ce1"),
+            gdata.FNode(q("metrics")),
+        ]),
+    ], [q("name")])
+    if branches is not None:
+        testing.assertEqual(len(branches), 1)
+        testing.assertEqual(len(branches["ce1"]), 1)
+        testing.assertEqual(branches["ce1"][0].prsrc(deterministic=True), gdata.FNode(children=[
+            gdata.FNode(q("name"), value_match="ce1"),
+            gdata.FNode(q("state")),
+            gdata.FNode(q("metrics")),
+        ]).prsrc(deterministic=True))
+    else:
+        testing.assertEqual("branches", "None")
+
+def _test_exact_list_filter_branches_rejects_wildcards():
+    branches = ttt.exact_list_filter_branches([
+        gdata.FNode(q("router"), children=[
+            gdata.FNode(q("name"), value_match=gdata.VWildcard("ce*")),
+            gdata.FNode(q("state")),
+        ]),
+    ], [q("name")])
+    testing.assertEqual(branches is None, True)
+
+def _test_exact_list_filter_branches_keeps_element_predicates():
+    branches = ttt.exact_list_filter_branches([
+        gdata.FNode(q("router"), children=[
+            gdata.FNode(q("name"), value_match="ce1"),
+            gdata.FNode(q("status"), value_match="up"),
+            gdata.FNode(q("metrics")),
+        ]),
+    ], [q("name")])
+    if branches is not None:
+        testing.assertEqual(branches["ce1"][0].prsrc(deterministic=True), gdata.FNode(children=[
+            gdata.FNode(q("name"), value_match="ce1"),
+            gdata.FNode(q("status"), value_match="up"),
+            gdata.FNode(q("metrics")),
+        ]).prsrc(deterministic=True))
+    else:
+        testing.assertEqual("branches", "None")
+
+def _test_exact_list_filter_branches_keeps_unmerged_element_predicates():
+    branches = ttt.exact_list_filter_branches([
+        gdata.FNode(q("router"), children=[
+            gdata.FNode(q("name"), value_match="ce1"),
+            gdata.FNode(q("status"), value_match="up"),
+            gdata.FNode(q("metrics")),
+        ]),
+        gdata.FNode(q("router"), children=[
+            gdata.FNode(q("name"), value_match="ce1"),
+            gdata.FNode(q("status"), value_match="down"),
+            gdata.FNode(q("metrics")),
+        ]),
+    ], [q("name")])
+    if branches is not None:
+        testing.assertEqual(len(branches), 1)
+        testing.assertEqual(len(branches["ce1"]), 2)
+        testing.assertEqual(branches["ce1"][0].prsrc(deterministic=True), gdata.FNode(children=[
+            gdata.FNode(q("name"), value_match="ce1"),
+            gdata.FNode(q("status"), value_match="up"),
+            gdata.FNode(q("metrics")),
+        ]).prsrc(deterministic=True))
+        testing.assertEqual(branches["ce1"][1].prsrc(deterministic=True), gdata.FNode(children=[
+            gdata.FNode(q("name"), value_match="ce1"),
+            gdata.FNode(q("status"), value_match="down"),
+            gdata.FNode(q("metrics")),
+        ]).prsrc(deterministic=True))
+    else:
+        testing.assertEqual("branches", "None")
+
 ########################
 
 def _test_multi_merge():


### PR DESCRIPTION
Operational reads applied filters only after materializing the full TTT tree. That gives the right result, but it does not exercise the routing shape needed by subscriptions and keeps every sibling branch on the read path.

This change carries an optional filter through Layer, Session, Node and Transaction get_data calls. Containers transpose filters into one child filter per matching TTT child, while repeated list predicates are preserved in an anonymous wrapper instead of being collapsed into one invalid predicate. Lists convert list predicates to element-local filters for every filtered read. Exact key predicates also restrict which elements are visited; non-exact predicates still scan the list, but only request filtered data from each element. Transform nodes apply the local filter after merging config output with operational state and preserve path keys in filtered list entries.

The yang dependency is bumped to a version where gdata.filter accepts an absent filter directly. That keeps the read path from synthesizing empty FNode values just to represent an unfiltered read.