### PR TITLE
Stabilize mock NETCONF get test

### DIFF
--- a/src/stratoweave/test_devicemgr_netconf.act
+++ b/src/stratoweave/test_devicemgr_netconf.act
@@ -129,18 +129,35 @@ actor _test_get(t: testing.EnvT):
     def noop_on_reconf(name: str):
         pass
     dev = new_netconf_mock_device_mgr(t, "dev1", noop_on_reconf)
+    var done = False
 
     def fail(msg: str):
+        if done:
+            return
+        done = True
         t.failure(ValueError(msg))
 
+    def succeed(data: ?str):
+        if done:
+            return
+        done = True
+        t.success(data)
+
     def on_get(r: ?xml.Node, err: ?Exception):
+        if done:
+            return
         if err is not None:
             fail("Mock <get> failed: {err}")
             return
 
-        t.success(_data_xml_from_rpc_reply(r))
+        succeed(_data_xml_from_rpc_reply(r))
 
     def start():
+        if done:
+            return
+        if IETF_SYSTEM_MODULE not in dev.get_modules().0:
+            after 0.01: start()
+            return
         msg = async dev.get_adapter()
         adapter = await msg
         if isinstance(adapter, stratoweave.device.NetconfAdapter):
@@ -158,6 +175,7 @@ actor _test_get(t: testing.EnvT):
             fail("Expected NetconfAdapter from DeviceMgr")
 
     start()
+    after 2.0: fail("Timed out waiting for mock NETCONF get")
 
 
 actor _test_subscribe_periodic(t: testing.EnvT):


### PR DESCRIPTION
The mock NETCONF get test could issue an RPC as soon as the adapter object was available. Under the perf runner that can race with mock client startup, leaving the RPC without a fully connected NETCONF session and causing an occasional test timeout.

The test now waits until the device manager has reported the bundled ietf-system module before sending the RPC, and guards late callbacks with the same done flag pattern used by the subscription tests. The assertion remains unchanged; only the startup timing assumption is removed.