### PR TITLE
Wait for commit before config read

### DIFF
--- a/src/test_ttt_container.act
+++ b/src/test_ttt_container.act
@@ -377,11 +377,15 @@ actor config_failure(t: testing.AsyncT):
         def cont2(_r: ttt.CfgResult):
             if _r.errors:
                 t2.configure("2", {'srcB': b1}, None)
-            t2.commit("2", True)
-            r = t2.get()
-            if r != a0b1:
-                testing.assertEqual(r.prsrc(deterministic=True), a0b1.prsrc(deterministic=True))
-            t.success()
+            await async t2.commit("2", True)
+
+            def cont3(_r: value):
+                r = t2.get()
+                if r != a0b1:
+                    testing.assertEqual(r.prsrc(deterministic=True), a0b1.prsrc(deterministic=True))
+                t.success()
+
+            t1.wait_complete("1", cont3)
 
         t2.lock("2", None, cont2)
 


### PR DESCRIPTION
config_failure intentionally lets t2 contend with t1 while t1 is committing. The final assertion then called get() as soon as t2 resumed, even though t1's commit could still be settling on sibling nodes.  Since get() is a live configuration read rather than a transactional snapshot, the test could observe t1-updated left data and not-yet-updated right data in the same tree.

We now keep the lock race intact, but wait for t1.wait_complete("1") before performing the final get(). That makes the assertion depend on state after the transaction under test has completed, while still exercising t2's stale candidate retry path.