### PR TITLE
Update acton-yang

### DIFF
--- a/Build.act
+++ b/Build.act
@@ -23,8 +23,8 @@ dependencies = {
     ),
     "yang": (
         repo_url="https://github.com/stratoweave/acton-yang.git",
-        url="https://github.com/stratoweave/acton-yang/archive/819d3204328331854fb4ec4912443a776629aec7.zip",
-        hash="N-V-__8AAG_nJACQ5F_-15AW3lbZ9p2XFqH4Fi8Cq3qdXFFO"
+        url="https://github.com/stratoweave/acton-yang/archive/b4987b15e7656be1955dbdf138e187549b79f8ed.zip",
+        hash="N-V-__8AAPHlJADZNJpTvoiEs_Xuamc0CLbwTp-j7xTAW1iJ"
     )
 }
 zig_dependencies = {}

--- a/gen_adata/Build.act
+++ b/gen_adata/Build.act
@@ -3,8 +3,8 @@ fingerprint = 0x7d1c1e932a731ef0
 dependencies = {
     "yang": (
         repo_url="https://github.com/stratoweave/acton-yang.git",
-        url="https://github.com/stratoweave/acton-yang/archive/819d3204328331854fb4ec4912443a776629aec7.zip",
-        hash="N-V-__8AAG_nJACQ5F_-15AW3lbZ9p2XFqH4Fi8Cq3qdXFFO"
+        url="https://github.com/stratoweave/acton-yang/archive/b4987b15e7656be1955dbdf138e187549b79f8ed.zip",
+        hash="N-V-__8AAPHlJADZNJpTvoiEs_Xuamc0CLbwTp-j7xTAW1iJ"
     )
 }
 zig_dependencies = {}

--- a/minisys/Build.act
+++ b/minisys/Build.act
@@ -6,8 +6,8 @@ dependencies = {
     ),
     "yang": (
         repo_url="https://github.com/stratoweave/acton-yang.git",
-        url="https://github.com/stratoweave/acton-yang/archive/819d3204328331854fb4ec4912443a776629aec7.zip",
-        hash="N-V-__8AAG_nJACQ5F_-15AW3lbZ9p2XFqH4Fi8Cq3qdXFFO"
+        url="https://github.com/stratoweave/acton-yang/archive/b4987b15e7656be1955dbdf138e187549b79f8ed.zip",
+        hash="N-V-__8AAPHlJADZNJpTvoiEs_Xuamc0CLbwTp-j7xTAW1iJ"
     )
 }
 zig_dependencies = {}

--- a/minisys/gen/Build.act
+++ b/minisys/gen/Build.act
@@ -6,8 +6,8 @@ dependencies = {
     ),
     "yang": (
         repo_url="https://github.com/stratoweave/acton-yang.git",
-        url="https://github.com/stratoweave/acton-yang/archive/819d3204328331854fb4ec4912443a776629aec7.zip",
-        hash="N-V-__8AAG_nJACQ5F_-15AW3lbZ9p2XFqH4Fi8Cq3qdXFFO"
+        url="https://github.com/stratoweave/acton-yang/archive/b4987b15e7656be1955dbdf138e187549b79f8ed.zip",
+        hash="N-V-__8AAPHlJADZNJpTvoiEs_Xuamc0CLbwTp-j7xTAW1iJ"
     )
 }
 zig_dependencies = {}

--- a/minisys/src/mini/devices/ietf.act
+++ b/minisys/src/mini/devices/ietf.act
@@ -2717,9 +2717,7 @@ SRC_DNODE = DRoot(
     module_metadata={'urn:ietf:params:xml:ns:yang:ietf-yang-types':('ietf-yang-types', '2013-07-15'), 'urn:ietf:params:xml:ns:yang:iana-crypt-hash':('iana-crypt-hash', '2014-08-06'), 'urn:ietf:params:xml:ns:yang:ietf-netconf-acm':('ietf-netconf-acm', '2018-02-14'), 'urn:ietf:params:xml:ns:yang:ietf-inet-types':('ietf-inet-types', '2013-07-15'), 'urn:ietf:params:xml:ns:yang:ietf-system':('ietf-system', '2014-08-06'), 'urn:ietf:params:xml:ns:yang:ietf-interfaces':('ietf-interfaces', '2018-02-20'), 'urn:ietf:params:xml:ns:yang:ietf-ip':('ietf-ip', '2018-02-22'), 'urn:ietf:params:xml:ns:yang:iana-if-type':('iana-if-type', '2014-05-08')},
 )
 
-def src_yang():
-    res = []
-    res.append(r"""module iana-crypt-hash {
+SRC_YANG_0 = r"""module iana-crypt-hash {
   namespace "urn:ietf:params:xml:ns:yang:iana-crypt-hash";
   prefix ianach;
 
@@ -2839,8 +2837,9 @@ def src_yang():
   }
 
 }
-""")
-    res.append(r"""module iana-if-type {
+"""
+
+SRC_YANG_1 = r"""module iana-if-type {
   namespace "urn:ietf:params:xml:ns:yang:iana-if-type";
   prefix ianaift;
 
@@ -4363,8 +4362,9 @@ def src_yang():
       "VMware NIC Team.";
   }
 }
-""")
-    res.append(r"""module ietf-inet-types {
+"""
+
+SRC_YANG_2 = r"""module ietf-inet-types {
 
   namespace "urn:ietf:params:xml:ns:yang:ietf-inet-types";
   prefix "inet";
@@ -4822,8 +4822,9 @@ def src_yang():
   }
 
 }
-""")
-    res.append(r"""module ietf-interfaces {
+"""
+
+SRC_YANG_3 = r"""module ietf-interfaces {
   yang-version 1.1;
   namespace "urn:ietf:params:xml:ns:yang:ietf-interfaces";
   prefix if;
@@ -5946,8 +5947,9 @@ def src_yang():
     }
   }
 }
-""")
-    res.append(r"""module ietf-ip {
+"""
+
+SRC_YANG_4 = r"""module ietf-ip {
   yang-version 1.1;
   namespace "urn:ietf:params:xml:ns:yang:ietf-ip";
   prefix ip;
@@ -6823,8 +6825,9 @@ def src_yang():
     }
   }
 }
-""")
-    res.append(r"""module ietf-netconf-acm {
+"""
+
+SRC_YANG_5 = r"""module ietf-netconf-acm {
 
   namespace "urn:ietf:params:xml:ns:yang:ietf-netconf-acm";
 
@@ -7288,8 +7291,9 @@ def src_yang():
     }
   }
 }
-""")
-    res.append(r"""module ietf-system {
+"""
+
+SRC_YANG_6 = r"""module ietf-system {
   namespace "urn:ietf:params:xml:ns:yang:ietf-system";
   prefix "sys";
 
@@ -8089,8 +8093,9 @@ def src_yang():
   }
 
 }
-""")
-    res.append(r"""module ietf-yang-types {
+"""
+
+SRC_YANG_7 = r"""module ietf-yang-types {
 
   namespace "urn:ietf:params:xml:ns:yang:ietf-yang-types";
   prefix "yang";
@@ -8564,8 +8569,19 @@ def src_yang():
        and separated with the '.' (full stop) character.";
   }
 }
-""")
-    return res
+"""
+
+def src_yang():
+    return [
+        SRC_YANG_0,
+        SRC_YANG_1,
+        SRC_YANG_2,
+        SRC_YANG_3,
+        SRC_YANG_4,
+        SRC_YANG_5,
+        SRC_YANG_6,
+        SRC_YANG_7,
+    ]
 
 
 NS_iana_crypt_hash = 'urn:ietf:params:xml:ns:yang:iana-crypt-hash'

--- a/minisys/src/mini/devices/ietf_oper.act
+++ b/minisys/src/mini/devices/ietf_oper.act
@@ -2860,9 +2860,7 @@ SRC_DNODE = DRoot(
     module_metadata={'urn:ietf:params:xml:ns:yang:ietf-yang-types':('ietf-yang-types', '2013-07-15'), 'urn:ietf:params:xml:ns:yang:iana-crypt-hash':('iana-crypt-hash', '2014-08-06'), 'urn:ietf:params:xml:ns:yang:ietf-netconf-acm':('ietf-netconf-acm', '2018-02-14'), 'urn:ietf:params:xml:ns:yang:ietf-inet-types':('ietf-inet-types', '2013-07-15'), 'urn:ietf:params:xml:ns:yang:ietf-system':('ietf-system', '2014-08-06'), 'urn:ietf:params:xml:ns:yang:ietf-interfaces':('ietf-interfaces', '2018-02-20'), 'urn:ietf:params:xml:ns:yang:ietf-ip':('ietf-ip', '2018-02-22'), 'urn:ietf:params:xml:ns:yang:iana-if-type':('iana-if-type', '2014-05-08')},
 )
 
-def src_yang():
-    res = []
-    res.append(r"""module iana-crypt-hash {
+SRC_YANG_0 = r"""module iana-crypt-hash {
   namespace "urn:ietf:params:xml:ns:yang:iana-crypt-hash";
   prefix ianach;
 
@@ -2982,8 +2980,9 @@ def src_yang():
   }
 
 }
-""")
-    res.append(r"""module iana-if-type {
+"""
+
+SRC_YANG_1 = r"""module iana-if-type {
   namespace "urn:ietf:params:xml:ns:yang:iana-if-type";
   prefix ianaift;
 
@@ -4506,8 +4505,9 @@ def src_yang():
       "VMware NIC Team.";
   }
 }
-""")
-    res.append(r"""module ietf-inet-types {
+"""
+
+SRC_YANG_2 = r"""module ietf-inet-types {
 
   namespace "urn:ietf:params:xml:ns:yang:ietf-inet-types";
   prefix "inet";
@@ -4965,8 +4965,9 @@ def src_yang():
   }
 
 }
-""")
-    res.append(r"""module ietf-interfaces {
+"""
+
+SRC_YANG_3 = r"""module ietf-interfaces {
   yang-version 1.1;
   namespace "urn:ietf:params:xml:ns:yang:ietf-interfaces";
   prefix if;
@@ -6089,8 +6090,9 @@ def src_yang():
     }
   }
 }
-""")
-    res.append(r"""module ietf-ip {
+"""
+
+SRC_YANG_4 = r"""module ietf-ip {
   yang-version 1.1;
   namespace "urn:ietf:params:xml:ns:yang:ietf-ip";
   prefix ip;
@@ -6966,8 +6968,9 @@ def src_yang():
     }
   }
 }
-""")
-    res.append(r"""module ietf-netconf-acm {
+"""
+
+SRC_YANG_5 = r"""module ietf-netconf-acm {
 
   namespace "urn:ietf:params:xml:ns:yang:ietf-netconf-acm";
 
@@ -7431,8 +7434,9 @@ def src_yang():
     }
   }
 }
-""")
-    res.append(r"""module ietf-system {
+"""
+
+SRC_YANG_6 = r"""module ietf-system {
   namespace "urn:ietf:params:xml:ns:yang:ietf-system";
   prefix "sys";
 
@@ -8232,8 +8236,9 @@ def src_yang():
   }
 
 }
-""")
-    res.append(r"""module ietf-yang-types {
+"""
+
+SRC_YANG_7 = r"""module ietf-yang-types {
 
   namespace "urn:ietf:params:xml:ns:yang:ietf-yang-types";
   prefix "yang";
@@ -8707,8 +8712,19 @@ def src_yang():
        and separated with the '.' (full stop) character.";
   }
 }
-""")
-    return res
+"""
+
+def src_yang():
+    return [
+        SRC_YANG_0,
+        SRC_YANG_1,
+        SRC_YANG_2,
+        SRC_YANG_3,
+        SRC_YANG_4,
+        SRC_YANG_5,
+        SRC_YANG_6,
+        SRC_YANG_7,
+    ]
 
 
 NS_iana_crypt_hash = 'urn:ietf:params:xml:ns:yang:iana-crypt-hash'

--- a/minisys/src/mini/layers/y_0.act
+++ b/minisys/src/mini/layers/y_0.act
@@ -76,9 +76,7 @@ SRC_DNODE = DRoot(
     module_metadata={'urn:ietf:params:xml:ns:yang:ietf-inet-types':('ietf-inet-types', '2013-07-15'), 'http://stratoweave.org/yang/stratoweave.yang':('stratoweave', '2026-04-01'), 'http://example.com/netinfra':('netinfra', '2019-01-01'), 'http://example.com/l3vpn':('l3vpn', '2019-01-01')},
 )
 
-def src_yang():
-    res = []
-    res.append(r"""module l3vpn {
+SRC_YANG_0 = r"""module l3vpn {
   yang-version "1.1";
   namespace "http://example.com/l3vpn";
   prefix "l3vpn";
@@ -184,8 +182,9 @@ def src_yang():
     }
   }
 }
-""")
-    res.append(r"""module netinfra {
+"""
+
+SRC_YANG_1 = r"""module netinfra {
   yang-version "1.1";
   namespace "http://example.com/netinfra";
   prefix "netinfra";
@@ -246,8 +245,9 @@ def src_yang():
 
   }
 }
-""")
-    res.append(r"""module stratoweave {
+"""
+
+SRC_YANG_2 = r"""module stratoweave {
   yang-version "1.1";
   namespace "http://stratoweave.org/yang/stratoweave.yang";
   prefix "sw";
@@ -308,8 +308,9 @@ def src_yang():
       to the linked transform target.";
     argument "path";
   }
-}""")
-    res.append(r"""module ietf-inet-types {
+}"""
+
+SRC_YANG_3 = r"""module ietf-inet-types {
 
   namespace "urn:ietf:params:xml:ns:yang:ietf-inet-types";
   prefix "inet";
@@ -767,8 +768,15 @@ def src_yang():
   }
 
 }
-""")
-    return res
+"""
+
+def src_yang():
+    return [
+        SRC_YANG_0,
+        SRC_YANG_1,
+        SRC_YANG_2,
+        SRC_YANG_3,
+    ]
 
 
 NS_l3vpn = 'http://example.com/l3vpn'

--- a/minisys/src/mini/layers/y_0_loose.act
+++ b/minisys/src/mini/layers/y_0_loose.act
@@ -76,9 +76,7 @@ SRC_DNODE = DRoot(
     module_metadata={'urn:ietf:params:xml:ns:yang:ietf-inet-types':('ietf-inet-types', '2013-07-15'), 'http://stratoweave.org/yang/stratoweave.yang':('stratoweave', '2026-04-01'), 'http://example.com/netinfra':('netinfra', '2019-01-01'), 'http://example.com/l3vpn':('l3vpn', '2019-01-01')},
 )
 
-def src_yang():
-    res = []
-    res.append(r"""module l3vpn {
+SRC_YANG_0 = r"""module l3vpn {
   yang-version "1.1";
   namespace "http://example.com/l3vpn";
   prefix "l3vpn";
@@ -184,8 +182,9 @@ def src_yang():
     }
   }
 }
-""")
-    res.append(r"""module netinfra {
+"""
+
+SRC_YANG_1 = r"""module netinfra {
   yang-version "1.1";
   namespace "http://example.com/netinfra";
   prefix "netinfra";
@@ -246,8 +245,9 @@ def src_yang():
 
   }
 }
-""")
-    res.append(r"""module stratoweave {
+"""
+
+SRC_YANG_2 = r"""module stratoweave {
   yang-version "1.1";
   namespace "http://stratoweave.org/yang/stratoweave.yang";
   prefix "sw";
@@ -308,8 +308,9 @@ def src_yang():
       to the linked transform target.";
     argument "path";
   }
-}""")
-    res.append(r"""module ietf-inet-types {
+}"""
+
+SRC_YANG_3 = r"""module ietf-inet-types {
 
   namespace "urn:ietf:params:xml:ns:yang:ietf-inet-types";
   prefix "inet";
@@ -767,8 +768,15 @@ def src_yang():
   }
 
 }
-""")
-    return res
+"""
+
+def src_yang():
+    return [
+        SRC_YANG_0,
+        SRC_YANG_1,
+        SRC_YANG_2,
+        SRC_YANG_3,
+    ]
 
 
 NS_l3vpn = 'http://example.com/l3vpn'

--- a/minisys/src/mini/layers/y_0_oper.act
+++ b/minisys/src/mini/layers/y_0_oper.act
@@ -80,9 +80,7 @@ SRC_DNODE = DRoot(
     module_metadata={'urn:ietf:params:xml:ns:yang:ietf-inet-types':('ietf-inet-types', '2013-07-15'), 'http://stratoweave.org/yang/stratoweave.yang':('stratoweave', '2026-04-01'), 'http://example.com/netinfra':('netinfra', '2019-01-01'), 'http://example.com/l3vpn':('l3vpn', '2019-01-01')},
 )
 
-def src_yang():
-    res = []
-    res.append(r"""module l3vpn {
+SRC_YANG_0 = r"""module l3vpn {
   yang-version "1.1";
   namespace "http://example.com/l3vpn";
   prefix "l3vpn";
@@ -188,8 +186,9 @@ def src_yang():
     }
   }
 }
-""")
-    res.append(r"""module netinfra {
+"""
+
+SRC_YANG_1 = r"""module netinfra {
   yang-version "1.1";
   namespace "http://example.com/netinfra";
   prefix "netinfra";
@@ -250,8 +249,9 @@ def src_yang():
 
   }
 }
-""")
-    res.append(r"""module stratoweave {
+"""
+
+SRC_YANG_2 = r"""module stratoweave {
   yang-version "1.1";
   namespace "http://stratoweave.org/yang/stratoweave.yang";
   prefix "sw";
@@ -312,8 +312,9 @@ def src_yang():
       to the linked transform target.";
     argument "path";
   }
-}""")
-    res.append(r"""module ietf-inet-types {
+}"""
+
+SRC_YANG_3 = r"""module ietf-inet-types {
 
   namespace "urn:ietf:params:xml:ns:yang:ietf-inet-types";
   prefix "inet";
@@ -771,8 +772,15 @@ def src_yang():
   }
 
 }
-""")
-    return res
+"""
+
+def src_yang():
+    return [
+        SRC_YANG_0,
+        SRC_YANG_1,
+        SRC_YANG_2,
+        SRC_YANG_3,
+    ]
 
 
 NS_l3vpn = 'http://example.com/l3vpn'

--- a/minisys/src/mini/layers/y_1.act
+++ b/minisys/src/mini/layers/y_1.act
@@ -125,9 +125,7 @@ SRC_DNODE = DRoot(
     module_metadata={'urn:ietf:params:xml:ns:yang:ietf-inet-types':('ietf-inet-types', '2013-07-15'), 'http://stratoweave.org/yang/stratoweave.yang':('stratoweave', '2026-04-01'), 'http://stratoweave.org/yang/stratoweave-rfs.yang':('stratoweave-rfs', None), 'http://example.com/mini-rfs':('mini-rfs', None)},
 )
 
-def src_yang():
-    res = []
-    res.append(r"""module mini-rfs {
+SRC_YANG_0 = r"""module mini-rfs {
     yang-version "1.1";
     namespace "http://example.com/mini-rfs";
     prefix "mini-rfs";
@@ -242,8 +240,9 @@ def src_yang():
         }
     }
 }
-""")
-    res.append(r"""module stratoweave {
+"""
+
+SRC_YANG_1 = r"""module stratoweave {
   yang-version "1.1";
   namespace "http://stratoweave.org/yang/stratoweave.yang";
   prefix "sw";
@@ -304,8 +303,9 @@ def src_yang():
       to the linked transform target.";
     argument "path";
   }
-}""")
-    res.append(r"""module stratoweave-rfs {
+}"""
+
+SRC_YANG_2 = r"""module stratoweave-rfs {
   yang-version "1.1";
   namespace "http://stratoweave.org/yang/stratoweave-rfs.yang";
   prefix "sw-rfs";
@@ -460,8 +460,9 @@ def src_yang():
     // Augment
   }
 }
-""")
-    res.append(r"""module ietf-inet-types {
+"""
+
+SRC_YANG_3 = r"""module ietf-inet-types {
 
   namespace "urn:ietf:params:xml:ns:yang:ietf-inet-types";
   prefix "inet";
@@ -919,8 +920,15 @@ def src_yang():
   }
 
 }
-""")
-    return res
+"""
+
+def src_yang():
+    return [
+        SRC_YANG_0,
+        SRC_YANG_1,
+        SRC_YANG_2,
+        SRC_YANG_3,
+    ]
 
 
 NS_mini_rfs = 'http://example.com/mini-rfs'

--- a/minisys/src/mini/layers/y_1_loose.act
+++ b/minisys/src/mini/layers/y_1_loose.act
@@ -125,9 +125,7 @@ SRC_DNODE = DRoot(
     module_metadata={'urn:ietf:params:xml:ns:yang:ietf-inet-types':('ietf-inet-types', '2013-07-15'), 'http://stratoweave.org/yang/stratoweave.yang':('stratoweave', '2026-04-01'), 'http://stratoweave.org/yang/stratoweave-rfs.yang':('stratoweave-rfs', None), 'http://example.com/mini-rfs':('mini-rfs', None)},
 )
 
-def src_yang():
-    res = []
-    res.append(r"""module mini-rfs {
+SRC_YANG_0 = r"""module mini-rfs {
     yang-version "1.1";
     namespace "http://example.com/mini-rfs";
     prefix "mini-rfs";
@@ -242,8 +240,9 @@ def src_yang():
         }
     }
 }
-""")
-    res.append(r"""module stratoweave {
+"""
+
+SRC_YANG_1 = r"""module stratoweave {
   yang-version "1.1";
   namespace "http://stratoweave.org/yang/stratoweave.yang";
   prefix "sw";
@@ -304,8 +303,9 @@ def src_yang():
       to the linked transform target.";
     argument "path";
   }
-}""")
-    res.append(r"""module stratoweave-rfs {
+}"""
+
+SRC_YANG_2 = r"""module stratoweave-rfs {
   yang-version "1.1";
   namespace "http://stratoweave.org/yang/stratoweave-rfs.yang";
   prefix "sw-rfs";
@@ -460,8 +460,9 @@ def src_yang():
     // Augment
   }
 }
-""")
-    res.append(r"""module ietf-inet-types {
+"""
+
+SRC_YANG_3 = r"""module ietf-inet-types {
 
   namespace "urn:ietf:params:xml:ns:yang:ietf-inet-types";
   prefix "inet";
@@ -919,8 +920,15 @@ def src_yang():
   }
 
 }
-""")
-    return res
+"""
+
+def src_yang():
+    return [
+        SRC_YANG_0,
+        SRC_YANG_1,
+        SRC_YANG_2,
+        SRC_YANG_3,
+    ]
 
 
 NS_mini_rfs = 'http://example.com/mini-rfs'

--- a/minisys/src/mini/layers/y_1_oper.act
+++ b/minisys/src/mini/layers/y_1_oper.act
@@ -131,9 +131,7 @@ SRC_DNODE = DRoot(
     module_metadata={'urn:ietf:params:xml:ns:yang:ietf-inet-types':('ietf-inet-types', '2013-07-15'), 'http://stratoweave.org/yang/stratoweave.yang':('stratoweave', '2026-04-01'), 'http://stratoweave.org/yang/stratoweave-rfs.yang':('stratoweave-rfs', None), 'http://example.com/mini-rfs':('mini-rfs', None)},
 )
 
-def src_yang():
-    res = []
-    res.append(r"""module mini-rfs {
+SRC_YANG_0 = r"""module mini-rfs {
     yang-version "1.1";
     namespace "http://example.com/mini-rfs";
     prefix "mini-rfs";
@@ -248,8 +246,9 @@ def src_yang():
         }
     }
 }
-""")
-    res.append(r"""module stratoweave {
+"""
+
+SRC_YANG_1 = r"""module stratoweave {
   yang-version "1.1";
   namespace "http://stratoweave.org/yang/stratoweave.yang";
   prefix "sw";
@@ -310,8 +309,9 @@ def src_yang():
       to the linked transform target.";
     argument "path";
   }
-}""")
-    res.append(r"""module stratoweave-rfs {
+}"""
+
+SRC_YANG_2 = r"""module stratoweave-rfs {
   yang-version "1.1";
   namespace "http://stratoweave.org/yang/stratoweave-rfs.yang";
   prefix "sw-rfs";
@@ -466,8 +466,9 @@ def src_yang():
     // Augment
   }
 }
-""")
-    res.append(r"""module ietf-inet-types {
+"""
+
+SRC_YANG_3 = r"""module ietf-inet-types {
 
   namespace "urn:ietf:params:xml:ns:yang:ietf-inet-types";
   prefix "inet";
@@ -925,8 +926,15 @@ def src_yang():
   }
 
 }
-""")
-    return res
+"""
+
+def src_yang():
+    return [
+        SRC_YANG_0,
+        SRC_YANG_1,
+        SRC_YANG_2,
+        SRC_YANG_3,
+    ]
 
 
 NS_mini_rfs = 'http://example.com/mini-rfs'

--- a/minisys/src/mini/layers/y_2.act
+++ b/minisys/src/mini/layers/y_2.act
@@ -35,9 +35,7 @@ SRC_DNODE = DRoot(
     module_metadata={'http://stratoweave.org/yang/stratoweave.yang':('stratoweave', '2026-04-01'), 'http://stratoweave.org/yang/stratoweave-device.yang':('stratoweave-device', None)},
 )
 
-def src_yang():
-    res = []
-    res.append(r"""module stratoweave {
+SRC_YANG_0 = r"""module stratoweave {
   yang-version "1.1";
   namespace "http://stratoweave.org/yang/stratoweave.yang";
   prefix "sw";
@@ -98,8 +96,9 @@ def src_yang():
       to the linked transform target.";
     argument "path";
   }
-}""")
-    res.append(r"""module stratoweave-device {
+}"""
+
+SRC_YANG_1 = r"""module stratoweave-device {
   yang-version "1.1";
   namespace "http://stratoweave.org/yang/stratoweave-device.yang";
   prefix "sw-dev";
@@ -129,8 +128,13 @@ def src_yang():
     }
   }
 }
-""")
-    return res
+"""
+
+def src_yang():
+    return [
+        SRC_YANG_0,
+        SRC_YANG_1,
+    ]
 
 
 NS_stratoweave_device = 'http://stratoweave.org/yang/stratoweave-device.yang'

--- a/minisys/src/mini/layers/y_2_loose.act
+++ b/minisys/src/mini/layers/y_2_loose.act
@@ -35,9 +35,7 @@ SRC_DNODE = DRoot(
     module_metadata={'http://stratoweave.org/yang/stratoweave.yang':('stratoweave', '2026-04-01'), 'http://stratoweave.org/yang/stratoweave-device.yang':('stratoweave-device', None)},
 )
 
-def src_yang():
-    res = []
-    res.append(r"""module stratoweave {
+SRC_YANG_0 = r"""module stratoweave {
   yang-version "1.1";
   namespace "http://stratoweave.org/yang/stratoweave.yang";
   prefix "sw";
@@ -98,8 +96,9 @@ def src_yang():
       to the linked transform target.";
     argument "path";
   }
-}""")
-    res.append(r"""module stratoweave-device {
+}"""
+
+SRC_YANG_1 = r"""module stratoweave-device {
   yang-version "1.1";
   namespace "http://stratoweave.org/yang/stratoweave-device.yang";
   prefix "sw-dev";
@@ -129,8 +128,13 @@ def src_yang():
     }
   }
 }
-""")
-    return res
+"""
+
+def src_yang():
+    return [
+        SRC_YANG_0,
+        SRC_YANG_1,
+    ]
 
 
 NS_stratoweave_device = 'http://stratoweave.org/yang/stratoweave-device.yang'

--- a/minisys/src/mini/layers/y_2_oper.act
+++ b/minisys/src/mini/layers/y_2_oper.act
@@ -36,9 +36,7 @@ SRC_DNODE = DRoot(
     module_metadata={'http://stratoweave.org/yang/stratoweave.yang':('stratoweave', '2026-04-01'), 'http://stratoweave.org/yang/stratoweave-device.yang':('stratoweave-device', None)},
 )
 
-def src_yang():
-    res = []
-    res.append(r"""module stratoweave {
+SRC_YANG_0 = r"""module stratoweave {
   yang-version "1.1";
   namespace "http://stratoweave.org/yang/stratoweave.yang";
   prefix "sw";
@@ -99,8 +97,9 @@ def src_yang():
       to the linked transform target.";
     argument "path";
   }
-}""")
-    res.append(r"""module stratoweave-device {
+}"""
+
+SRC_YANG_1 = r"""module stratoweave-device {
   yang-version "1.1";
   namespace "http://stratoweave.org/yang/stratoweave-device.yang";
   prefix "sw-dev";
@@ -130,8 +129,13 @@ def src_yang():
     }
   }
 }
-""")
-    return res
+"""
+
+def src_yang():
+    return [
+        SRC_YANG_0,
+        SRC_YANG_1,
+    ]
 
 
 NS_stratoweave_device = 'http://stratoweave.org/yang/stratoweave-device.yang'

--- a/src/stratoweave/device_meta_config.act
+++ b/src/stratoweave/device_meta_config.act
@@ -95,9 +95,7 @@ SRC_DNODE = DRoot(
     module_metadata={'urn:ietf:params:xml:ns:yang:ietf-inet-types':('ietf-inet-types', '2013-07-15'), 'http://stratoweave.org/yang/stratoweave.yang':('stratoweave', '2026-04-01'), 'http://stratoweave.org/yang/stratoweave-rfs.yang':('stratoweave-rfs', None)},
 )
 
-def src_yang():
-    res = []
-    res.append(r"""module stratoweave-rfs {
+SRC_YANG_0 = r"""module stratoweave-rfs {
   yang-version "1.1";
   namespace "http://stratoweave.org/yang/stratoweave-rfs.yang";
   prefix "sw-rfs";
@@ -252,8 +250,9 @@ def src_yang():
     // Augment
   }
 }
-""")
-    res.append(r"""module stratoweave {
+"""
+
+SRC_YANG_1 = r"""module stratoweave {
   yang-version "1.1";
   namespace "http://stratoweave.org/yang/stratoweave.yang";
   prefix "sw";
@@ -314,8 +313,9 @@ def src_yang():
       to the linked transform target.";
     argument "path";
   }
-}""")
-    res.append(r"""module ietf-inet-types {
+}"""
+
+SRC_YANG_2 = r"""module ietf-inet-types {
 
   namespace "urn:ietf:params:xml:ns:yang:ietf-inet-types";
   prefix "inet";
@@ -773,8 +773,14 @@ def src_yang():
   }
 
 }
-""")
-    return res
+"""
+
+def src_yang():
+    return [
+        SRC_YANG_0,
+        SRC_YANG_1,
+        SRC_YANG_2,
+    ]
 
 
 NS_stratoweave_rfs = 'http://stratoweave.org/yang/stratoweave-rfs.yang'

--- a/src/stratoweave/ietf_restconf_monitoring.act
+++ b/src/stratoweave/ietf_restconf_monitoring.act
@@ -44,9 +44,7 @@ SRC_DNODE = DRoot(
     module_metadata={'urn:ietf:params:xml:ns:yang:ietf-inet-types':('ietf-inet-types', '2013-07-15'), 'urn:ietf:params:xml:ns:yang:ietf-yang-types':('ietf-yang-types', '2025-12-22'), 'urn:ietf:params:xml:ns:yang:ietf-restconf-monitoring':('ietf-restconf-monitoring', '2017-01-26')},
 )
 
-def src_yang():
-    res = []
-    res.append(r"""module ietf-restconf-monitoring {
+SRC_YANG_0 = r"""module ietf-restconf-monitoring {
   namespace "urn:ietf:params:xml:ns:yang:ietf-restconf-monitoring";
   prefix "rcmon";
 
@@ -196,8 +194,9 @@ def src_yang():
   }
 
 }
-""")
-    res.append(r"""module ietf-yang-types {
+"""
+
+SRC_YANG_1 = r"""module ietf-yang-types {
   namespace "urn:ietf:params:xml:ns:yang:ietf-yang-types";
   prefix yang;
 
@@ -961,8 +960,9 @@ def src_yang():
                  Network Configuration Protocol (NETCONF)";
   }
 }
-""")
-    res.append(r"""module ietf-inet-types {
+"""
+
+SRC_YANG_2 = r"""module ietf-inet-types {
 
   namespace "urn:ietf:params:xml:ns:yang:ietf-inet-types";
   prefix "inet";
@@ -1420,8 +1420,14 @@ def src_yang():
   }
 
 }
-""")
-    return res
+"""
+
+def src_yang():
+    return [
+        SRC_YANG_0,
+        SRC_YANG_1,
+        SRC_YANG_2,
+    ]
 
 
 NS_ietf_inet_types = 'urn:ietf:params:xml:ns:yang:ietf-inet-types'

--- a/src/stratoweave/ietf_yang_library.act
+++ b/src/stratoweave/ietf_yang_library.act
@@ -139,9 +139,7 @@ SRC_DNODE = DRoot(
     module_metadata={'urn:ietf:params:xml:ns:yang:ietf-inet-types':('ietf-inet-types', '2013-07-15'), 'urn:ietf:params:xml:ns:yang:ietf-yang-types':('ietf-yang-types', '2025-12-22'), 'urn:ietf:params:xml:ns:yang:ietf-datastores':('ietf-datastores', '2018-02-14'), 'urn:ietf:params:xml:ns:yang:ietf-yang-library':('ietf-yang-library', '2019-01-04')},
 )
 
-def src_yang():
-    res = []
-    res.append(r"""module ietf-yang-library {
+SRC_YANG_0 = r"""module ietf-yang-library {
   yang-version 1.1;
   namespace "urn:ietf:params:xml:ns:yang:ietf-yang-library";
   prefix yanglib;
@@ -685,8 +683,9 @@ def src_yang():
     }
   }
 }
-""")
-    res.append(r"""module ietf-datastores {
+"""
+
+SRC_YANG_1 = r"""module ietf-datastores {
   yang-version 1.1;
   namespace "urn:ietf:params:xml:ns:yang:ietf-datastores";
   prefix ds;
@@ -803,8 +802,9 @@ def src_yang():
       "A datastore identity reference.";
   }
 }
-""")
-    res.append(r"""module ietf-yang-types {
+"""
+
+SRC_YANG_2 = r"""module ietf-yang-types {
   namespace "urn:ietf:params:xml:ns:yang:ietf-yang-types";
   prefix yang;
 
@@ -1568,8 +1568,9 @@ def src_yang():
                  Network Configuration Protocol (NETCONF)";
   }
 }
-""")
-    res.append(r"""module ietf-inet-types {
+"""
+
+SRC_YANG_3 = r"""module ietf-inet-types {
 
   namespace "urn:ietf:params:xml:ns:yang:ietf-inet-types";
   prefix "inet";
@@ -2027,8 +2028,15 @@ def src_yang():
   }
 
 }
-""")
-    return res
+"""
+
+def src_yang():
+    return [
+        SRC_YANG_0,
+        SRC_YANG_1,
+        SRC_YANG_2,
+        SRC_YANG_3,
+    ]
 
 
 NS_ietf_datastores = 'urn:ietf:params:xml:ns:yang:ietf-datastores'


### PR DESCRIPTION
- Split YANG source into a list of per-module strings.
-  Accept None as old tree in gdata.patch.