### PR TITLE
Use yang.gdata.patch to normalize non-declarative ops

### DIFF
--- a/src/stratoweave/ttt.act
+++ b/src/stratoweave/ttt.act
@@ -65,12 +65,9 @@ def difference(a: ?gdata.Node, b: gdata.Node) -> ?gdata.Node:
 def patch(conf: dict[str,gdata.Node], diff: dict[str,gdata.Node]) -> dict[str,gdata.Node]:
     res = {}
     for s,d in diff.items():
-        if s in conf:
-            p = gdata.patch(conf[s], d)
-            if p is not None:
-                res[s] = p
-        elif not isinstance(d, gdata.Absent):
-            res[s] = d
+        p = gdata.patch(conf.get(s), d)
+        if p is not None:
+            res[s] = p
     for s,c in conf.items():
         if s not in diff:
             res[s] = c


### PR DESCRIPTION
The input config to TTT may also include non-declarative nodes (like Create, Replace, Delete, ...) that map to NETCONF / RESTCONF operations. yang.gdata.patch already handles all of these and also validates operations (like Create on an existing node is not allowed). If no data is present in "conf", then the result is the patch data, but still normalized to remove non-declarative nodes.