### PR TITLE
Fix RESTCONF for PUT, POST and PATCH

### DIFF
--- a/Build.act
+++ b/Build.act
@@ -3,8 +3,8 @@ fingerprint = 0x9ad673637ba15f05
 dependencies = {
     "actmf": (
         repo_url="https://github.com/stratoweave/actmf",
-        url="https://github.com/stratoweave/actmf/archive/656342ae35c52b28bd11ef936f94ee4a1497211a.zip",
-        hash="N-V-__8AAOPnBQBKOWHU1Df_Rb3bzTdj6lMSaTWWV57l0Poc"
+        url="https://github.com/stratoweave/actmf/archive/c7faf86d44bc86125973275378013a4e62c530dc.zip",
+        hash="N-V-__8AAOPnBQBxJM64VJP106YNtQtwsZUvKn0M67XJjDU0"
     ),
     "http_router": (
         repo_url="https://github.com/stratoweave/http-router.git",
@@ -23,8 +23,8 @@ dependencies = {
     ),
     "yang": (
         repo_url="https://github.com/stratoweave/acton-yang.git",
-        url="https://github.com/stratoweave/acton-yang/archive/b4987b15e7656be1955dbdf138e187549b79f8ed.zip",
-        hash="N-V-__8AAPHlJADZNJpTvoiEs_Xuamc0CLbwTp-j7xTAW1iJ"
+        url="https://github.com/stratoweave/acton-yang/archive/695b4f20c65828702ba0a68ee08a3061bfa00449.zip",
+        hash="N-V-__8AAD4mJQD9qAKKVXj86BQ6BDd8Dcv0Iy76YSdNFwGb"
     )
 }
 zig_dependencies = {}

--- a/gen_adata/Build.act
+++ b/gen_adata/Build.act
@@ -3,8 +3,8 @@ fingerprint = 0x7d1c1e932a731ef0
 dependencies = {
     "yang": (
         repo_url="https://github.com/stratoweave/acton-yang.git",
-        url="https://github.com/stratoweave/acton-yang/archive/b4987b15e7656be1955dbdf138e187549b79f8ed.zip",
-        hash="N-V-__8AAPHlJADZNJpTvoiEs_Xuamc0CLbwTp-j7xTAW1iJ"
+        url="https://github.com/stratoweave/acton-yang/archive/695b4f20c65828702ba0a68ee08a3061bfa00449.zip",
+        hash="N-V-__8AAD4mJQD9qAKKVXj86BQ6BDd8Dcv0Iy76YSdNFwGb"
     )
 }
 zig_dependencies = {}

--- a/minisys/Build.act
+++ b/minisys/Build.act
@@ -6,8 +6,8 @@ dependencies = {
     ),
     "yang": (
         repo_url="https://github.com/stratoweave/acton-yang.git",
-        url="https://github.com/stratoweave/acton-yang/archive/b4987b15e7656be1955dbdf138e187549b79f8ed.zip",
-        hash="N-V-__8AAPHlJADZNJpTvoiEs_Xuamc0CLbwTp-j7xTAW1iJ"
+        url="https://github.com/stratoweave/acton-yang/archive/695b4f20c65828702ba0a68ee08a3061bfa00449.zip",
+        hash="N-V-__8AAD4mJQD9qAKKVXj86BQ6BDd8Dcv0Iy76YSdNFwGb"
     )
 }
 zig_dependencies = {}

--- a/minisys/gen/Build.act
+++ b/minisys/gen/Build.act
@@ -6,8 +6,8 @@ dependencies = {
     ),
     "yang": (
         repo_url="https://github.com/stratoweave/acton-yang.git",
-        url="https://github.com/stratoweave/acton-yang/archive/b4987b15e7656be1955dbdf138e187549b79f8ed.zip",
-        hash="N-V-__8AAPHlJADZNJpTvoiEs_Xuamc0CLbwTp-j7xTAW1iJ"
+        url="https://github.com/stratoweave/acton-yang/archive/695b4f20c65828702ba0a68ee08a3061bfa00449.zip",
+        hash="N-V-__8AAD4mJQD9qAKKVXj86BQ6BDd8Dcv0Iy76YSdNFwGb"
     )
 }
 zig_dependencies = {}

--- a/minisys/test/common/quicklab.mk
+++ b/minisys/test/common/quicklab.mk
@@ -70,11 +70,11 @@ RESTCONF_PORT=$(shell docker inspect -f '{{(index (index .NetworkSettings.Ports 
 
 .PHONY: send-config-async
 send-config-async:
-	curl -X PUT -H "Content-Type: application/yang-data+xml" -H "Async: true" -d @$(FILE) http://localhost:$(RESTCONF_PORT)/restconf/data
+	curl -X PATCH -H "Content-Type: application/yang-data+xml" -H "Async: true" -d @$(FILE) http://localhost:$(RESTCONF_PORT)/restconf/data
 
 .PHONY: send-config-wait
 send-config-wait:
-	curl -X PUT -H "Content-Type: application/yang-data+xml" -d @$(FILE) http://localhost:$(RESTCONF_PORT)/restconf/data
+	curl -X PATCH -H "Content-Type: application/yang-data+xml" -d @$(FILE) http://localhost:$(RESTCONF_PORT)/restconf/data
 
 .PHONY: get-data get-router get-telemetry
 get-data:

--- a/minisys/test/test_persistence_restart.sh
+++ b/minisys/test/test_persistence_restart.sh
@@ -79,7 +79,7 @@ elif [[ ! -x "$BIN_FILE" ]]; then
 fi
 
 start_mini
-"$CURL_BIN" -fsS -X PUT \
+"$CURL_BIN" -fsS -X PATCH \
     --connect-timeout 1 \
     --max-time 5 \
     -H "Content-Type: application/yang-data+json" \

--- a/src/stratoweave/restconf.act
+++ b/src/stratoweave/restconf.act
@@ -218,23 +218,16 @@ def _respond_restconf_subtree(path_elements: list[yang.data.PathElement], data: 
         return
 
     fnode = _path_elements_to_fnode(path_elements)
-    node = yang.gdata.filter(data, fnode)
-    if node is not None:
-        # Walk down the filtered tree to the target node because we only return the subtree
-        for i in range(1, len(path_elements)):
-            elem = path_elements[i]
-            maybe_list = node  # avoids widening a narrowed loop var (node)
-            if isinstance(maybe_list, yang.gdata.List):
-                # We already filtered the list to the matching entry;
-                # descend into that entry before looking for the next child.
-                if len(maybe_list.elements) == 0:
-                    respond(404, {}, "No data at path")
-                    return
-                node = maybe_list.elements[0]
-            child_id = yang.gdata.Id(elem.node.namespace, elem.node.name)
-            child = node.children.get(child_id)
-            if child is not None:
-                node = child
+    filtered = yang.gdata.filter(data, fnode)
+    if filtered is not None:
+        node = _walk_to_target(filtered, path_elements)
+        if node is not None:
+            # Ensure top-level node gdata node in the filtered subtree always has namespace qualifiers
+            target_snode = path_elements[-1].node
+            target_id = yang.gdata.Id(target_snode.namespace, target_snode.name)
+            result = yang.gdata.Container({target_id: _node_with_ns(node, target_snode)})
+            if accept == "application/yang-data+xml":
+                respond(200, {"Content-Type": "application/yang-data+xml"}, result.to_xmlstr())
             else:
                 respond(404, {}, "No data at path")
                 return
@@ -247,10 +240,16 @@ def _respond_restconf_subtree(path_elements: list[yang.data.PathElement], data: 
             respond(200, {"Content-Type": "application/yang-data+xml"}, result.to_xmlstr())
         else:
             respond(200, {"Content-Type": "application/yang-data+json"}, result.to_yang_jsonstr())
-    else:
-        respond(404, {}, "No data at path")
+        return
+    respond(404, {}, "No data at path")
 
 
+def _path_exists(current_config: yang.gdata.Node, path_elements: list[yang.data.PathElement]) -> bool:
+    """Whether the resource identified by path_elements exists in current_config."""
+    if len(path_elements) <= 1:
+        return True
+    fnode = _path_elements_to_fnode(path_elements)
+    return yang.gdata.filter(current_config, fnode) is not None
 
 
 actor RestconfServer(
@@ -274,14 +273,16 @@ actor RestconfServer(
     ]
     _restconf_view_by_module = _build_restconf_view_by_module(_restconf_views)
 
-    def _router_make_edit_done(respond, success_status: int):
+    def _router_make_edit_done(respond, success_status: int, headers: ?dict[str, str] = None):
+        response_headers: dict[str, str] = {}
+        if headers is not None:
+            response_headers = headers
         def on_done(result):
             if isinstance(result, Exception):
                 # TODO: extract more context from error
                 respond(500, {}, str(result))
             else:
-                # TODO: location redirect?
-                respond(success_status, {}, "")
+                respond(success_status, response_headers, "")
         return on_done
 
     def _router_handle_restconf_get(ctx: http_router.Context, respond: proc(int, dict[str, str], str) -> None):
@@ -355,10 +356,14 @@ actor RestconfServer(
 
     def _router_handle_restconf_put(ctx: http_router.Context, respond: proc(int, dict[str, str], str) -> None):
         input_config = _router_parse_write_body(ctx, respond)
-        # TODO: per RFC 8040 §4.5, distinguish create (201 + Location) from
-        # replace (204) — currently always returns 204.
         if input_config is not None:
-            _router_apply_write(ctx, input_config, _router_make_edit_done(respond, 204))
+            # Per RFC 8040 §4.5: PUT creates (201 + Location) if the target did
+            # not exist, replaces (204) otherwise.
+            path_elements = yang.json.resolve_json_path(top_schema, _split_restconf_path(ctx.param("rest_path")))
+            if _path_exists(cfs.newsession().get(), path_elements):
+                _router_apply_write(ctx, input_config, _router_make_edit_done(respond, 204))
+            else:
+                _router_apply_write(ctx, input_config, _router_make_edit_done(respond, 201, {"Location": ctx.path}))
 
     def _router_handle_yang_library_version(ctx: http_router.Context, respond: proc(int, dict[str, str], str) -> None):
         yl_meta = yl.SRC_DNODE.module_metadata["urn:ietf:params:xml:ns:yang:ietf-yang-library"]

--- a/src/stratoweave/restconf.act
+++ b/src/stratoweave/restconf.act
@@ -274,13 +274,15 @@ actor RestconfServer(
     ]
     _restconf_view_by_module = _build_restconf_view_by_module(_restconf_views)
 
-    def _router_make_config_done(respond):
-        def config_done(result):
+    def _router_make_edit_done(respond, success_status: int):
+        def on_done(result):
             if isinstance(result, Exception):
-                respond(400, {}, json.encode({"status": "error", "message": str(result)}))
-                return
-            respond(200, {}, json.encode({"status": "ok"}))
-        return config_done
+                # TODO: extract more context from error
+                respond(500, {}, str(result))
+            else:
+                # TODO: location redirect?
+                respond(success_status, {}, "")
+        return on_done
 
     def _router_handle_restconf_get(ctx: http_router.Context, respond: proc(int, dict[str, str], str) -> None):
         accept = ctx.request.headers.get("accept")
@@ -315,37 +317,48 @@ actor RestconfServer(
     def _router_handle_restconf_delete(ctx: http_router.Context, respond: proc(int, dict[str, str], str) -> None):
         input_config = yang.json.from_json_path(top_schema, {}, _split_restconf_path(ctx.param("rest_path")), "remove", loose=True)
         session = cfs.newsession()
-        session.edit_config(input_config, _router_make_config_done(respond))
+        session.edit_config(input_config, _router_make_edit_done(respond, 204))
 
-    def _router_handle_restconf_write(ctx: http_router.Context, respond: proc(int, dict[str, str], str) -> None):
-        input_config = None
+    def _router_parse_write_body(ctx: http_router.Context, respond: proc(int, dict[str, str], str) -> None) -> ?yang.gdata.Container:
         content_type = ctx.request.headers.get("content-type")
-
         if content_type == "application/yang-data+json":
             try:
                 json_in = json.decode(ctx.request.body.decode())
-                input_config = yang.json.from_json_path(top_schema, json_in, _split_restconf_path(ctx.param("rest_path")), loose=True)
+                return yang.json.from_json_path(top_schema, json_in, _split_restconf_path(ctx.param("rest_path")), loose=True)
             except Exception as e:
                 respond(400, {}, "Error parsing JSON: {e}")
-                return
-        elif content_type == "application/yang-data+xml":
+                return None
+        if content_type == "application/yang-data+xml":
             try:
                 xml_in = xml.decode(ctx.request.body.decode())
-                input_config = yang.xml.from_xml(top_schema, xml_in, loose=True)
+                return yang.xml.from_xml(top_schema, xml_in, loose=True)
             except Exception as e:
                 respond(400, {}, "Error parsing XML: {e}")
-                return
-        else:
-            respond(415, {}, "Unsupported media type")
-            return
+                return None
+        respond(415, {}, "Unsupported media type")
+        return None
 
+    def _router_apply_write(ctx: http_router.Context, input_config: yang.gdata.Node, on_done: action(value) -> None):
+        session = cfs.newsession()
+        if ctx.request.headers.get("async") == "true":
+            http_log.info("Client requests async behavior")
+            session.edit_config(input_config, on_done)
+        else:
+            session.edit_config(input_config, None, on_done)
+
+    def _router_handle_restconf_post(ctx: http_router.Context, respond: proc(int, dict[str, str], str) -> None):
+        input_config = _router_parse_write_body(ctx, respond)
+        # TODO: per RFC 8040 §4.4.1, set Location header pointing to the new
+        # resource (parent path + new child id, including any list keys).
         if input_config is not None:
-            session = cfs.newsession()
-            if ctx.request.headers.get("async") == "true":
-                http_log.info("Client requests async behavior")
-                session.edit_config(input_config, _router_make_config_done(respond))
-            else:
-                session.edit_config(input_config, None, _router_make_config_done(respond))
+            _router_apply_write(ctx, input_config, _router_make_edit_done(respond, 201))
+
+    def _router_handle_restconf_put(ctx: http_router.Context, respond: proc(int, dict[str, str], str) -> None):
+        input_config = _router_parse_write_body(ctx, respond)
+        # TODO: per RFC 8040 §4.5, distinguish create (201 + Location) from
+        # replace (204) — currently always returns 204.
+        if input_config is not None:
+            _router_apply_write(ctx, input_config, _router_make_edit_done(respond, 204))
 
     def _router_handle_yang_library_version(ctx: http_router.Context, respond: proc(int, dict[str, str], str) -> None):
         yl_meta = yl.SRC_DNODE.module_metadata["urn:ietf:params:xml:ns:yang:ietf-yang-library"]
@@ -370,8 +383,8 @@ actor RestconfServer(
 
     def _router_build_restconf_routes(g: http_router.RouteGroup):
         g.get("/*rest_path", _router_handle_restconf_get)
-        g.post("/*rest_path", _router_handle_restconf_write)
-        g.put("/*rest_path", _router_handle_restconf_write)
+        g.post("/*rest_path", _router_handle_restconf_post)
+        g.put("/*rest_path", _router_handle_restconf_put)
         g.delete("/*rest_path", _router_handle_restconf_delete)
 
     root.get("/.well-known/host-meta", _router_handle_host_meta)

--- a/src/stratoweave/restconf.act
+++ b/src/stratoweave/restconf.act
@@ -31,7 +31,7 @@ def _split_restconf_path(text: str) -> list[str]:
 # Workaround for Acton compiled issues with named tuples as dict values in the
 # module-to-view dispatch map.
 class _RestconfView(value):
-    def __init__(self, schema: yang.schema.DRoot, data: proc() -> yang.gdata.Node):
+    def __init__(self, schema: yang.schema.DRoot, data: proc(?yang.gdata.FNode) -> ?yang.gdata.Node):
         self.schema = schema
         self.data = data
 
@@ -208,26 +208,31 @@ def _node_with_ns(node: yang.gdata.Node, snode: yang.schema.DNode) -> yang.gdata
     raise ValueError("Unexpected node type for RESTCONF GET serialization: {type(node)}")
 
 
-def _respond_restconf_subtree(path_elements: list[yang.data.PathElement], data: yang.gdata.Node, accept: ?str, respond: proc(int, dict[str, str], str) -> None,
+def _respond_restconf_subtree(path_elements: list[yang.data.PathElement], data: ?yang.gdata.Node, accept: ?str, respond: proc(int, dict[str, str], str) -> None,
 ) -> None:
-    if len(path_elements) <= 1:
-        if accept == "application/yang-data+xml":
-            respond(200, {"Content-Type": "application/yang-data+xml"}, data.to_xmlstr())
-        else:
-            respond(200, {"Content-Type": "application/yang-data+json"}, data.to_yang_jsonstr())
-        return
-
-    fnode = _path_elements_to_fnode(path_elements)
-    filtered = yang.gdata.filter(data, fnode)
-    if filtered is not None:
-        node = _walk_to_target(filtered, path_elements)
-        if node is not None:
-            # Ensure top-level node gdata node in the filtered subtree always has namespace qualifiers
-            target_snode = path_elements[-1].node
-            target_id = yang.gdata.Id(target_snode.namespace, target_snode.name)
-            result = yang.gdata.Container({target_id: _node_with_ns(node, target_snode)})
+    if data is not None:
+        if len(path_elements) <= 1:
             if accept == "application/yang-data+xml":
-                respond(200, {"Content-Type": "application/yang-data+xml"}, result.to_xmlstr())
+                respond(200, {"Content-Type": "application/yang-data+xml"}, data.to_xmlstr())
+            else:
+                respond(200, {"Content-Type": "application/yang-data+json"}, data.to_yang_jsonstr())
+            return
+
+        # Walk the (already filtered) tree to the target node so we only return its subtree.
+        node = data
+        for elem in path_elements[1:]:
+            maybe_list = node  # avoids widening a narrowed loop var (node)
+            if isinstance(maybe_list, yang.gdata.List):
+                # We already filtered the list to the matching entry;
+                # descend into that entry before looking for the next child.
+                if len(maybe_list.elements) == 0:
+                    respond(404, {}, "No data at path")
+                    return
+                node = maybe_list.elements[0]
+            child_id = yang.gdata.Id(elem.node.namespace, elem.node.name)
+            child = node.children.get(child_id)
+            if child is not None:
+                node = child
             else:
                 respond(404, {}, "No data at path")
                 return
@@ -262,13 +267,12 @@ actor RestconfServer(
     # Use an actor method because a lambda whose body is an actor action call
     # `lambda: cfs.newsession().get_data()` gets the action effect and yields a
     # Msg[gdata.Node] at runtime, which must be awaited on
-    def _top_data() -> yang.gdata.Node:
-        data = cfs.newsession().get_data()
-        return data if data is not None else yang.gdata.Container()
+    def _top_data(filt: ?yang.gdata.FNode) -> ?yang.gdata.Node:
+        return cfs.newsession().get_data(filt)
 
     _restconf_views = [
-        _RestconfView(rcmon.SRC_DNODE, lambda: _build_restconf_monitoring_gdata([top_schema, rcmon.SRC_DNODE, yl.SRC_DNODE])),
-        _RestconfView(yl.SRC_DNODE, lambda: _build_yang_library_gdata([top_schema, rcmon.SRC_DNODE, yl.SRC_DNODE])),
+        _RestconfView(rcmon.SRC_DNODE, lambda filt: yang.gdata.filter(_build_restconf_monitoring_gdata([top_schema, rcmon.SRC_DNODE, yl.SRC_DNODE]), filt)),
+        _RestconfView(yl.SRC_DNODE, lambda filt: yang.gdata.filter(_build_yang_library_gdata([top_schema, rcmon.SRC_DNODE, yl.SRC_DNODE]), filt)),
         _RestconfView(top_schema, _top_data)
     ]
     _restconf_view_by_module = _build_restconf_view_by_module(_restconf_views)
@@ -296,7 +300,9 @@ actor RestconfServer(
         if len(path_segments) == 0:
             merged = yang.gdata.Container()
             for i, view in enumerate(_restconf_views):
-                merged = yang.gdata.merge(merged, view.data())
+                data = view.data()
+                if data is not None:
+                    merged = yang.gdata.merge(merged, data)
             _respond_restconf_subtree([], merged, accept, respond)
             return
 
@@ -309,11 +315,12 @@ actor RestconfServer(
                 raise ValueError("No RESTCONF view for top-level module {top_level_module}")
             view = _restconf_view_by_module[top_level_module]
             path_elements = yang.restconf.resolve_path(view.schema, path_segments)
+            filter = _path_elements_to_fnode(path_elements)
         except ValueError as e:
             respond(404, {}, str(e))
             return
         else:
-            _respond_restconf_subtree(path_elements, view.data(), accept, respond)
+            _respond_restconf_subtree(path_elements, view.data(filter), accept, respond)
 
     def _router_handle_restconf_delete(ctx: http_router.Context, respond: proc(int, dict[str, str], str) -> None):
         input_config = yang.restconf.from_json_path(top_schema, None, _split_restconf_path(ctx.param("rest_path")), yang.data.OP_REMOVE, loose=True)

--- a/src/stratoweave/restconf.act
+++ b/src/stratoweave/restconf.act
@@ -9,7 +9,7 @@ import stratoweave.ietf_yang_library as yl
 import stratoweave.ttt as ttt
 import yang.data
 import yang.gdata
-import yang.json
+import yang.restconf
 import yang.schema
 import yang.xml
 
@@ -308,7 +308,7 @@ actor RestconfServer(
             if top_level_module not in _restconf_view_by_module:
                 raise ValueError("No RESTCONF view for top-level module {top_level_module}")
             view = _restconf_view_by_module[top_level_module]
-            path_elements = yang.json.resolve_json_path(view.schema, path_segments)
+            path_elements = yang.restconf.resolve_path(view.schema, path_segments)
         except ValueError as e:
             respond(404, {}, str(e))
             return
@@ -316,23 +316,23 @@ actor RestconfServer(
             _respond_restconf_subtree(path_elements, view.data(), accept, respond)
 
     def _router_handle_restconf_delete(ctx: http_router.Context, respond: proc(int, dict[str, str], str) -> None):
-        input_config = yang.json.from_json_path(top_schema, {}, _split_restconf_path(ctx.param("rest_path")), "remove", loose=True)
+        input_config = yang.restconf.from_json_path(top_schema, None, _split_restconf_path(ctx.param("rest_path")), yang.data.OP_REMOVE, loose=True)
         session = cfs.newsession()
         session.edit_config(input_config, _router_make_edit_done(respond, 204))
 
-    def _router_parse_write_body(ctx: http_router.Context, respond: proc(int, dict[str, str], str) -> None) -> ?yang.gdata.Container:
+    def _router_parse_write_body(ctx: http_router.Context, respond: proc(int, dict[str, str], str) -> None, op: str) -> ?yang.gdata.Container:
         content_type = ctx.request.headers.get("content-type")
         if content_type == "application/yang-data+json":
             try:
                 json_in = json.decode(ctx.request.body.decode())
-                return yang.json.from_json_path(top_schema, json_in, _split_restconf_path(ctx.param("rest_path")), loose=True)
+                return yang.restconf.from_json_path(top_schema, json_in, _split_restconf_path(ctx.param("rest_path")), op, loose=True)
             except Exception as e:
                 respond(400, {}, "Error parsing JSON: {e}")
                 return None
         if content_type == "application/yang-data+xml":
             try:
                 xml_in = xml.decode(ctx.request.body.decode())
-                return yang.xml.from_xml(top_schema, xml_in, loose=True)
+                return yang.restconf.from_xml_path(top_schema, xml_in, _split_restconf_path(ctx.param("rest_path")), op, loose=True)
             except Exception as e:
                 respond(400, {}, "Error parsing XML: {e}")
                 return None
@@ -348,18 +348,18 @@ actor RestconfServer(
             session.edit_config(input_config, None, on_done)
 
     def _router_handle_restconf_post(ctx: http_router.Context, respond: proc(int, dict[str, str], str) -> None):
-        input_config = _router_parse_write_body(ctx, respond)
+        input_config = _router_parse_write_body(ctx, respond, yang.data.OP_MERGE)
         # TODO: per RFC 8040 §4.4.1, set Location header pointing to the new
         # resource (parent path + new child id, including any list keys).
         if input_config is not None:
             _router_apply_write(ctx, input_config, _router_make_edit_done(respond, 201))
 
     def _router_handle_restconf_put(ctx: http_router.Context, respond: proc(int, dict[str, str], str) -> None):
-        input_config = _router_parse_write_body(ctx, respond)
+        input_config = _router_parse_write_body(ctx, respond, yang.data.OP_REPLACE)
         if input_config is not None:
             # Per RFC 8040 §4.5: PUT creates (201 + Location) if the target did
             # not exist, replaces (204) otherwise.
-            path_elements = yang.json.resolve_json_path(top_schema, _split_restconf_path(ctx.param("rest_path")))
+            path_elements = yang.restconf.resolve_path(top_schema, _split_restconf_path(ctx.param("rest_path")))
             if _path_exists(cfs.newsession().get(), path_elements):
                 _router_apply_write(ctx, input_config, _router_make_edit_done(respond, 204))
             else:

--- a/src/stratoweave/restconf.act
+++ b/src/stratoweave/restconf.act
@@ -372,6 +372,22 @@ actor RestconfServer(
             else:
                 _router_apply_write(ctx, input_config, _router_make_edit_done(respond, 201, {"Location": ctx.path}))
 
+    def _router_handle_restconf_patch(ctx: http_router.Context, respond: proc(int, dict[str, str], str) -> None):
+        try:
+            path_elements = yang.restconf.resolve_path(top_schema, _split_restconf_path(ctx.param("rest_path")))
+        except ValueError as e:
+            respond(404, {}, str(e))
+            return
+        else:
+            # RFC 8040 PATCH must not create the target resource instance.
+            if not _path_exists(cfs.newsession().get(), path_elements):
+                respond(404, {}, "No data at path")
+                return
+
+            input_config = _router_parse_write_body(ctx, respond, yang.data.OP_MERGE)
+            if input_config is not None:
+                _router_apply_write(ctx, input_config, _router_make_edit_done(respond, 204))
+
     def _router_handle_yang_library_version(ctx: http_router.Context, respond: proc(int, dict[str, str], str) -> None):
         yl_meta = yl.SRC_DNODE.module_metadata["urn:ietf:params:xml:ns:yang:ietf-yang-library"]
         rev_opt = yl_meta.revision
@@ -397,6 +413,7 @@ actor RestconfServer(
         g.get("/*rest_path", _router_handle_restconf_get)
         g.post("/*rest_path", _router_handle_restconf_post)
         g.put("/*rest_path", _router_handle_restconf_put)
+        g.patch("/*rest_path", _router_handle_restconf_patch)
         g.delete("/*rest_path", _router_handle_restconf_delete)
 
     root.get("/.well-known/host-meta", _router_handle_host_meta)


### PR DESCRIPTION
The existing RESTCONF implementation incorrectly relied on using PUT on the root (datastore) resource for config updates. This was incorrect - PUT is a _replace_ operation. This is now correctly reflected in the parsed gdata payload (uses `gdata.Replace` nodes). We use PATCH for partial updates.

Closes #371