### PR TITLE
Add TransformTester actor

### DIFF
--- a/minisys/src/test_mini.act
+++ b/minisys/src/test_mini.act
@@ -4,6 +4,7 @@ import mini.layers.y_0 as cfs_layer
 import mini.layers.y_0_oper as cfs_oper
 import mini.sysspec
 import stratoweave
+import stratoweave.testing as swts
 
 actor _test_netinfra1(t: testing.AsyncT):
     # Test input config
@@ -12,18 +13,7 @@ actor _test_netinfra1(t: testing.AsyncT):
     router = root.netinfra.router.create("rtr1", 1, "ietf")
     router.mock = True
 
-    input_config = root.to_gdata()
-
-    tr = stratoweave.test_main(mini.sysspec.SYSSPEC, t.log_handler)
-
-    def cont(_r: value):
-        t.success(tr.device_adata_snapshot())
-
-    tr.edit_config(input_config, cont)
-
-    def fail():
-        t.failure(ValueError())
-    after 2.5: fail()
+    swts.TransformTester(t, mini.sysspec.SYSSPEC, root.to_gdata())
 
 
 actor _test_netinfra_router_oper(t: testing.AsyncT):
@@ -90,15 +80,4 @@ actor _test_l3vpn1(t: testing.AsyncT):
         site_code="gbg1",
     )
 
-    input_config = root.to_gdata()
-
-    tr = stratoweave.test_main(mini.sysspec.SYSSPEC, t.log_handler)
-
-    def cont(_r: value):
-        t.success(tr.device_adata_snapshot())
-
-    tr.edit_config(input_config, cont)
-
-    def fail():
-        t.failure(ValueError())
-    after 2.5: fail()
+    swts.TransformTester(t, mini.sysspec.SYSSPEC, root.to_gdata())

--- a/src/stratoweave.act
+++ b/src/stratoweave.act
@@ -109,7 +109,4 @@ def test_main(sysspec: swapp.SysSpec, log_handler: logging.Handler) -> swts.Test
                 t.success(tr.device_adata_snapshot())
             tr.edit_config(input_config, cont)
     """
-    dev_registry = swdev.DeviceRegistry(sysspec.device_types, None, log_handler)
-    cfs = sysspec.get_layers(dev_registry, log_handler, None)
-    swapp.RfsReconf(dev_registry, cfs)
-    return swts.TestRig(cfs, dev_registry, sysspec)
+    return swts.TestRig.build(sysspec, log_handler)

--- a/src/stratoweave/testing.act
+++ b/src/stratoweave/testing.act
@@ -1,4 +1,5 @@
 import logging
+import testing
 import xml
 
 import yang.data
@@ -69,14 +70,17 @@ class TestRig(object):
         self.dev_registry = dev_registry
         self.sysspec = sysspec
 
-    proc def edit_config(self, input_config: gdata.Node, cont: action(value) -> None):
-        session = self.cfs.newsession()
+    proc def edit_config(self, input_config: gdata.Node, cont: action(value) -> None, layer_depth: int=0):
+        layer = self.cfs
+        for _ in range(layer_depth):
+            layer = layer.below()
+        session = layer.newsession()
         session.edit_config(input_config, complete=cont)
 
-    def edit_config_xml(self, input_xml: str, cont: action(value) -> None):
-        top_schema = self.sysspec.schema_for_layer(0)
-        input_gdata = yang.xml.from_xml(top_schema, xml.decode(input_xml), loose=False)
-        self.edit_config(input_gdata, cont)
+    def edit_config_xml(self, input_xml: str, cont: action(value) -> None, layer_depth: int=0):
+        schema = self.sysspec.schema_for_layer(layer_depth)
+        input_gdata = yang.xml.from_xml(schema, xml.decode(input_xml), loose=False)
+        self.edit_config(input_gdata, cont, layer_depth)
 
     def layer_config(self, depth: int=0) -> gdata.Node:
         session = self.cfs.newsession()
@@ -86,3 +90,24 @@ class TestRig(object):
 
     def device_adata_snapshot(self):
         return device_config_adata_snapshot(self.dev_registry, self.sysspec.device_types)
+
+    @staticmethod
+    def build(sysspec: swapp.SysSpec, log_handler: logging.Handler) -> TestRig:
+        dev_registry = swdev.DeviceRegistry(sysspec.device_types, log_handler=log_handler)
+        cfs = sysspec.get_layers(dev_registry, log_handler, None)
+        swapp.RfsReconf(dev_registry, cfs)
+        return TestRig(cfs, dev_registry, sysspec)
+
+
+actor TransformTester(t: testing.AsyncT, sysspec: swapp.SysSpec, input_config: gdata.Node, layer_depth: int=0):
+    """Drive a transform test from a pre-built `input_config` gdata tree.
+
+    The input config is applied at `layer_depth` (0 = CFS layer).
+    The combined device config is captured in adata format.
+    """
+    tr = TestRig.build(sysspec, t.log_handler)
+
+    def cont(_r: value):
+        t.success(tr.device_adata_snapshot())
+
+    tr.edit_config(input_config, cont, layer_depth)


### PR DESCRIPTION
Replaces transform test boilerplate (build rig, apply config, snapshot device adata on completion) with a helper actor.

Also parameterizes TestRig.edit_config / edit_config_xml on layer_depth so tests can target a specific TTT layer instead of always the top.