### PR TITLE
Fix cand_linked, linked pruning

### DIFF
--- a/src/stratoweave/ttt.act
+++ b/src/stratoweave/ttt.act
@@ -89,8 +89,9 @@ def merge(cfg_per_src: dict[str,gdata.Node]):
     else:
         raise ValueError("Nothing to merge")
 
-def prune(data: gdata.Node, filt: gdata.FNode):
-    return expect(gdata.prune(data, filt), "ttt.prune")
+def prune(data: gdata.Node, filt: gdata.FNode) -> gdata.Node:
+    res =  gdata.prune(data, gdata.FNode(children=[filt]))
+    return res if res is not None else gdata.Container()
 
 class TaggedPath():
     def __init__(self, tag: str, path: gdata.FNode):
@@ -1719,14 +1720,13 @@ class _TransformTransactionBase(_Transaction):
             cand_linked = self.candidate_linked.get_def(tid, self.linked)
             cand_subs = self.candidate_subscriptions.get_def(tid, self.subscriptions)
             latest_subs = build_links(merged)
-            linked = self.linked
             for s in latest_subs:
                 if s not in cand_subs:
                     req.append(LinkRequest(s.tag, s.path, self.fpath, True))
             for s in cand_subs:
                 if s not in latest_subs:
                     req.append(LinkRequest(s.tag, s.path, self.fpath, False))
-                    cand_linked = prune(linked, s.path)
+                    cand_linked = prune(cand_linked, s.path)
             self.candidate_subscriptions[tid] = latest_subs
             self.candidate_linked[tid] = cand_linked
         #print('####', tid, '(Transform)', _format_path(self.path), 'link_requests:', len(req), err=True)
@@ -1757,7 +1757,9 @@ class _TransformTransactionBase(_Transaction):
             subscriptions = self.candidate_subscriptions.get_def(tid, self.subscriptions)
             for u in updates:
                 if TaggedPath(u.tag, u.publisher) in subscriptions:
-                    linked = gdata.merge(linked, u.config)
+                    # The publisher resends its full state on every change, so
+                    # prune the existing config subtree at its path and merge the new one
+                    linked = gdata.merge(prune(linked, u.publisher), u.config)
             self.candidate_linked[tid] = linked
         return self.configure(tid, {}, out, True, dbuf)
 


### PR DESCRIPTION
The publisher resends its full config on update, we must effectively replace the config in linked, not merge.
Fix cand_linked update when removing subscribers.
Where pruning, wrap the pub / sub path with an empty FNode to ensure gdata.prune correctly prunes at the root.

@nordlander PTAL, in particular the way linked input is updated in `linkage`.