### PR TITLE
Fix linkage

### DIFF
--- a/src/stratoweave/ttt.act
+++ b/src/stratoweave/ttt.act
@@ -200,19 +200,18 @@ def _format_path(p: Path):
     else:
         return [p.name]
 
-# Reverse the given Path and construct a linear FNode with value-matching key leaves
+# Reverse the given Path and construct a linear FNode chain. List entries
+# become a single FNode whose value_match is the compound key string already
+# computed by key_str on PathKey construction
 def fnode(p: Path, tails: list[gdata.FNode]=[]) -> gdata.FNode:
-    name = gdata.Id("",p.name)
     if isinstance(p, PathElem):
-        name = gdata.Id(p.ns, p.name)
-        return fnode(p.parent, [gdata.FNode(name, children=tails)])
+        return fnode(p.parent, [gdata.FNode(gdata.Id(p.ns, p.name), children=tails)])
     elif isinstance(p, PathKey):
-        keys = [ gdata.FNode(k, value_match=v.val) for k,v in p.keyvals.items() if isinstance(v, gdata.Leaf) ]
-        return fnode(p.parent, tails+keys)
+        return fnode(p.parent, [gdata.FNode(value_match=p.name, children=tails)])
     elif tails:
         return tails[0]
     else:
-        return gdata.FNode(name)
+        return gdata.FNode(gdata.Id("", p.name))
 
 def make_rooted(p: Path, tree: gdata.Node):
     if isinstance(p, PathKey):
@@ -1331,6 +1330,14 @@ actor ListState(path, template: proc(Path, ?Layer) -> Node, ns: ?str, module: ?s
 
         return {k: elems[k] for k in keys1}
 
+    def acquire_existing(tid: str, keys: set[str]) -> dict[str, Node]:
+        keys1 = {k for k in keys if k in elems}
+        if tid in active:
+            active[tid] |= keys1
+        else:
+            active[tid] = keys1
+        return {k: elems[k] for k in keys1}
+
     def release(tid: str, ok: bool, deletes: set[str]):
         #print('====', tid, path, 'release', ok, 'deletes:', deletes, 'provisional:', provisional, err=True)
         if ok:
@@ -1457,6 +1464,30 @@ class _ListTransaction(_Transaction):
 
     def linkage(self, tid, requests, updates, out, dbuf):
         #print('####', tid, '(List)', _format_path(self.path), 'linkage', len(requests), len(updates), err=True)
+        # linkage can now be a transaction entry point, so like configure()
+        # it must clear the previous transaction stale state
+        if self.reset:
+            self.elems = {}
+            self.accum = {}
+            self.reset = False
+
+        # linkage may target list entries committed by an earlier tx and not
+        # configured in this one. Acquire those existing entries so we can
+        # dispatch linkage to them
+        keys_needed = set()
+        for r in requests:
+            vm = r.publisher.value_match
+            if isinstance(vm, str):
+                keys_needed.add(vm)
+        for u in updates:
+            vm = u.subscriber.value_match
+            if isinstance(vm, str):
+                keys_needed.add(vm)
+        existing = self.liststate.acquire_existing(tid, keys_needed)
+        for k,node in existing.items():
+            if k not in self.elems:
+                self.elems[k] = node.newtrans()
+
         results = {}
         for key,elem in self.elems.items():
             reqs = [ r.tail() for r in requests if r.vequal(key) ]

--- a/src/test_ttt_transform.act
+++ b/src/test_ttt_transform.act
@@ -866,3 +866,84 @@ actor transform_dynstate(t: testing.AsyncT):
     s1.edit_config(gdata.Container({q("leaf"): gdata.Leaf(39)}))
 
 ########################
+# Link regression tests
+########################
+
+class LinkedAsnSubscriber(ttt.TransformFunction):
+    def transform_wrapper(self, cfg: gdata.Node, linked: gdata.Node, memory: ?gdata.Node, dynstate: ?gdata.Node):
+        out_children: dict[gdata.Id, gdata.Node] = {}
+        if isinstance(cfg, gdata.Container):
+            for k, v in cfg.children.items():
+                out_children[k] = v
+        network_node = linked.get_opt_cnt(q("network"))
+        if network_node is not None:
+            gs_node = network_node.get_opt_cnt(q("global-settings"))
+            if gs_node is not None:
+                asn_leaf = gs_node.get_opt_leaf(q("asn"))
+                if asn_leaf is not None:
+                    out_children[q("seen_asn")] = asn_leaf
+        return gdata.Container(out_children), None
+
+def _link_to_global_settings(conf: gdata.Node) -> list[ttt.TaggedPath]:
+    return [ttt.TaggedPath('global', gdata.FNode(q("network"), children=[
+        gdata.FNode(q("global-settings")),
+    ]))]
+
+
+# When the subscriber lives in a list and a later tx touches only the
+# publisher, the list element transactions are not configured in that tx.
+# Linkage still has to reach the existing list entry and the resulting
+# commit must release the ListState cleanly. The compound key (string + int)
+# also covers per-type and multi-key value_match rendering in one shot.
+actor link_subscriber_in_list_re_runs_on_publisher_update(t: testing.AsyncT):
+    stack = ttt.Layer("top",
+        ttt.Container({
+            q("network"): ttt.Container({
+                q("global-settings"): ttt.Transform(ttt.PassThrough),
+                q("router"): ttt.List(
+                    ttt.Transform(LinkedAsnSubscriber, None, _link_to_global_settings),
+                    [q("name"), q("id")],
+                ),
+            }),
+        }),
+        ttt.Sink())
+
+    cfg_init = gdata.Container({
+        q("network"): gdata.Container({
+            q("global-settings"): gdata.Container({q("asn"): gdata.Leaf(11)}),
+            q("router"): gdata.List([q("name"), q("id")], [
+                gdata.Container({
+                    q("name"): gdata.Leaf("r1"),
+                    q("id"): gdata.Leaf(1),
+                }),
+            ]),
+        }),
+    })
+    cfg_bump_asn = gdata.Container({
+        q("network"): gdata.Container({
+            q("global-settings"): gdata.Container({q("asn"): gdata.Leaf(22)}),
+        }),
+    })
+
+    expected_after_bump = gdata.Container({
+        q("asn"): gdata.Leaf(22),
+        q("id"): gdata.Leaf(1),
+        q("name"): gdata.Leaf("r1"),
+        q("seen_asn"): gdata.Leaf(22),
+    })
+
+    sess1 = stack.newsession()
+
+    def cont2(_r: value):
+        testing.assertEqual(
+            sess1.below().get(),
+            expected_after_bump,
+        )
+        t.success()
+
+    def cont1(_r: value):
+        sess2 = stack.newsession()
+        sess2.edit_config(cfg_bump_asn, complete=cont2)
+
+    sess1.edit_config(cfg_init, cont1)
+########################


### PR DESCRIPTION
fnode() emits the list entry computed key (key_str) single value_match on the linkage FNode chain. This is now aligned with LinkRequest/LinkUpdate vequal() and tail() functions. It may be optimized in the future once tuples (containing list keys) become hashable.

The second fix ensures transforms not touched in this tx are still triggered when their linked input is updated. _ListTransaction.linkage gathers the entry keys targeted by incoming requests/updates and brings the corresponding committed entries into the tx via ListState.acquire_existing().