### PR TITLE
Decouple *TransformCtor emission from sw:dynstate

### DIFF
--- a/minisys/src/mini/layers/base_0.act
+++ b/minisys/src/mini/layers/base_0.act
@@ -10,13 +10,10 @@ import yang.gdata
 import yang.xml
 
 from mini.layers.y_0 import netinfra__netinfra__global_settings
-from mini.layers.y_0_oper import netinfra__netinfra__global_settings as netinfra__netinfra__global_settings__oper
 from mini.layers.y_0 import netinfra__netinfra__router_entry
-from mini.layers.y_0_oper import netinfra__netinfra__router_entry as netinfra__netinfra__router_entry__oper
 from mini.layers.y_0 import netinfra__netinfra__router__dynstate
-from mini.layers.y_0_oper import netinfra__netinfra__router__dynstate as netinfra__netinfra__router__dynstate__oper
 from mini.layers.y_0 import l3vpn__l3vpn_entry
-from mini.layers.y_0_oper import l3vpn__l3vpn_entry as l3vpn__l3vpn_entry__oper
+from mini.layers.y_0_oper import netinfra__netinfra__router_entry as netinfra__netinfra__router_entry__oper
 from mini.layers.y_0 import SRC_DNODE
 from mini.layers.y_1_loose import root as output_root
 
@@ -31,16 +28,6 @@ class GlobalSettings(ttt.TransformFunction):
     def input_type():
         """Return the modeled input type for this transform"""
         return netinfra__netinfra__global_settings
-
-    @staticmethod
-    def state_type():
-        """Return the modeled operational state type for this transform"""
-        return netinfra__netinfra__global_settings__oper
-
-    @staticmethod
-    def new_state(path: ttt.Path):
-        """Create modeled operational state for this transform path"""
-        return netinfra__netinfra__global_settings__oper.from_gdata(ttt.path_key_data(path))
 
     mut def transform_wrapper(self, i: yang.gdata.Node, linked: yang.gdata.Node, memory: ?yang.gdata.Node, dynstate: ?yang.gdata.Node) -> (yang.gdata.Node, ?yang.gdata.Node):
         """Wrap the user provided transform method to convert from gdata to
@@ -108,16 +95,6 @@ class L3vpn(ttt.TransformFunction):
     def input_type():
         """Return the modeled input type for this transform"""
         return l3vpn__l3vpn_entry
-
-    @staticmethod
-    def state_type():
-        """Return the modeled operational state type for this transform"""
-        return l3vpn__l3vpn_entry__oper
-
-    @staticmethod
-    def new_state(path: ttt.Path):
-        """Create modeled operational state for this transform path"""
-        return l3vpn__l3vpn_entry__oper.from_gdata(ttt.path_key_data(path))
 
     mut def transform_wrapper(self, i: yang.gdata.Node, linked: yang.gdata.Node, memory: ?yang.gdata.Node, dynstate: ?yang.gdata.Node) -> (yang.gdata.Node, ?yang.gdata.Node):
         """Wrap the user provided transform method to convert from gdata to

--- a/minisys/src/mini/layers/base_1.act
+++ b/minisys/src/mini/layers/base_1.act
@@ -10,11 +10,9 @@ import yang.gdata
 import yang.xml
 
 from mini.layers.y_1 import stratoweave_rfs__rfs__base_config
-from mini.layers.y_1_oper import stratoweave_rfs__rfs__base_config as stratoweave_rfs__rfs__base_config__oper
 from mini.layers.y_1 import stratoweave_rfs__rfs__base_config__dynstate
-from mini.layers.y_1_oper import stratoweave_rfs__rfs__base_config__dynstate as stratoweave_rfs__rfs__base_config__dynstate__oper
 from mini.layers.y_1 import stratoweave_rfs__rfs__l3vpn_endpoint_entry
-from mini.layers.y_1_oper import stratoweave_rfs__rfs__l3vpn_endpoint_entry as stratoweave_rfs__rfs__l3vpn_endpoint_entry__oper
+from mini.layers.y_1_oper import stratoweave_rfs__rfs__base_config as stratoweave_rfs__rfs__base_config__oper
 from mini.layers.y_1 import SRC_DNODE
 from mini.layers.y_2_loose import root as output_root
 
@@ -71,16 +69,6 @@ class L3vpnEndpoint(ttt.RFSFunction):
     def input_type():
         """Return the modeled input type for this transform"""
         return stratoweave_rfs__rfs__l3vpn_endpoint_entry
-
-    @staticmethod
-    def state_type():
-        """Return the modeled operational state type for this transform"""
-        return stratoweave_rfs__rfs__l3vpn_endpoint_entry__oper
-
-    @staticmethod
-    def new_state(path: ttt.Path):
-        """Create modeled operational state for this transform path"""
-        return stratoweave_rfs__rfs__l3vpn_endpoint_entry__oper.from_gdata(ttt.path_key_data(path))
 
     mut def transform_wrapper(self, i: yang.gdata.Node, device_info: ttt.DeviceInfo, memory: ?yang.gdata.Node, dynstate: ?yang.gdata.Node) -> (yang.gdata.Node, ?yang.gdata.Node):
         """Wrap the user provided transform method to convert from gdata to

--- a/minisys/src/mini/layers/t_0.act
+++ b/minisys/src/mini/layers/t_0.act
@@ -11,8 +11,8 @@ import mini.layers.y_0_oper
 
 import mini.cfs
 
-from mini.layers.y_0 import netinfra__netinfra__router_entry
 from mini.layers.y_0 import netinfra__netinfra__router__dynstate
+from mini.layers.y_0 import netinfra__netinfra__router_entry
 
 def get_ttt(lower: ?ttt.Layer, dev_registry: swdev.DeviceRegistry, log_handler: ?logging.Handler=None) -> proc(ttt.Path,?ttt.Layer)->ttt.Node:
     r = ttt.Container({yang.gdata.Id("http://example.com/netinfra", "netinfra"): ttt.Container({yang.gdata.Id("http://example.com/netinfra", "global-settings"): ttt.Transform(mini.cfs.GlobalSettings, None, None, lower, log_handler), yang.gdata.Id("http://example.com/netinfra", "router"): ttt.List(ttt.Transform(mini.cfs.Router, RouterTransformCtor, _build_target_links_netinfra__netinfra__router_entry, lower, log_handler), [yang.gdata.Id("http://example.com/netinfra", "name")])}, ns='http://example.com/netinfra', module='netinfra'), yang.gdata.Id("http://example.com/l3vpn", "l3vpn"): ttt.List(ttt.Transform(mini.cfs.L3vpn, None, _build_target_links_l3vpn__l3vpn_entry, lower, log_handler), [yang.gdata.Id("http://example.com/l3vpn", "name")], ns='http://example.com/l3vpn', module='l3vpn')})

--- a/minisys/src/mini/layers/t_1.act
+++ b/minisys/src/mini/layers/t_1.act
@@ -11,8 +11,8 @@ import mini.layers.y_1_oper
 
 import mini.rfs
 
-from mini.layers.y_1 import stratoweave_rfs__rfs__base_config
 from mini.layers.y_1 import stratoweave_rfs__rfs__base_config__dynstate
+from mini.layers.y_1 import stratoweave_rfs__rfs__base_config
 
 def get_ttt(lower: ?ttt.Layer, dev_registry: swdev.DeviceRegistry, log_handler: ?logging.Handler=None) -> proc(ttt.Path,?ttt.Layer)->ttt.Node:
     r = ttt.Container({yang.gdata.Id("http://stratoweave.org/yang/stratoweave-rfs", "device"): ttt.List(ttt.Device(dev_registry, log_handler), [yang.gdata.Id("http://stratoweave.org/yang/stratoweave-rfs", "name")], ns='http://stratoweave.org/yang/stratoweave-rfs', module='stratoweave-rfs'), yang.gdata.Id("http://stratoweave.org/yang/stratoweave-rfs", "rfs"): ttt.List(ttt.Container({yang.gdata.Id("http://example.com/mini-rfs", "base-config"): ttt.RFSTransform(mini.rfs.BaseConfig, dev_registry, BaseConfigTransformCtor, lower, log_handler), yang.gdata.Id("http://example.com/mini-rfs", "l3vpn-endpoint"): ttt.List(ttt.RFSTransform(mini.rfs.L3vpnEndpoint, dev_registry, None, lower, log_handler), [yang.gdata.Id("http://example.com/mini-rfs", "interface-name")], ns='http://example.com/mini-rfs', module='mini-rfs')}), [yang.gdata.Id("http://stratoweave.org/yang/stratoweave-rfs", "name")], ns='http://stratoweave.org/yang/stratoweave-rfs', module='stratoweave-rfs')})

--- a/snapshots/expected/test_ttt_gen/ttt_gen_oper_only_base
+++ b/snapshots/expected/test_ttt_gen/ttt_gen_oper_only_base
@@ -1,0 +1,54 @@
+# WARNING WARNING WARNING WARNING WARNING
+# DO NOT MODIFY THIS FILE!! This file is generated!
+# WARNING WARNING WARNING WARNING WARNING
+
+import logging
+import xml
+import stratoweave.ttt as ttt
+import yang.adata
+import yang.gdata
+import yang.xml
+
+from respnet.layers.y_0 import foo__netinfra__router_entry
+from respnet.layers.y_0_oper import foo__netinfra__router_entry as foo__netinfra__router_entry__oper
+from respnet.layers.y_0 import SRC_DNODE
+from respnet.layers.y_1_loose import root as output_root
+
+def o_root():
+    return output_root()
+
+
+class OperOnly(ttt.TransformFunction):
+    transform: mut(foo__netinfra__router_entry) -> yang.adata.MNode
+
+    @staticmethod
+    def input_type():
+        """Return the modeled input type for this transform"""
+        return foo__netinfra__router_entry
+
+    @staticmethod
+    def state_type():
+        """Return the modeled operational state type for this transform"""
+        return foo__netinfra__router_entry__oper
+
+    @staticmethod
+    def new_state(path: ttt.Path):
+        """Create modeled operational state for this transform path"""
+        return foo__netinfra__router_entry__oper.from_gdata(ttt.path_key_data(path))
+
+    mut def transform_wrapper(self, i: yang.gdata.Node, linked: yang.gdata.Node, memory: ?yang.gdata.Node, dynstate: ?yang.gdata.Node) -> (yang.gdata.Node, ?yang.gdata.Node):
+        """Wrap the user provided transform method to convert from gdata to
+        modeled input and back to gdata
+        """
+        modeled_input = foo__netinfra__router_entry.from_gdata(i)
+
+        return self.transform(modeled_input).to_gdata(), None
+
+    mut def transform_xml(self, i: xml.Node, linked: yang.gdata.Node, memory: ?yang.gdata.Node, dynstate: ?yang.gdata.Node) -> (yang.gdata.Node, ?yang.gdata.Node):
+        """Wrap the user provided transform method to convert from XML to
+        modeled input and return gdata
+        """
+        gdata_input = yang.xml.from_xml(SRC_DNODE, i, loose=False, root_path=['foo:netinfra', 'router'])
+        modeled_input = foo__netinfra__router_entry.from_gdata(gdata_input)
+
+        return self.transform(modeled_input).to_gdata(), None

--- a/snapshots/expected/test_ttt_gen/ttt_gen_oper_only_ttt
+++ b/snapshots/expected/test_ttt_gen/ttt_gen_oper_only_ttt
@@ -1,0 +1,24 @@
+# WARNING WARNING WARNING WARNING WARNING
+# DO NOT MODIFY THIS FILE!! This file is generated!
+# WARNING WARNING WARNING WARNING WARNING
+
+import logging
+
+import stratoweave.device as swdev
+import stratoweave.ttt as ttt
+import yang.gdata
+import respnet.layers.y_0_oper
+
+import respnet.cfs
+
+from respnet.layers.y_0 import foo__netinfra__router_entry
+
+def get_ttt(lower: ?ttt.Layer, dev_registry: swdev.DeviceRegistry, log_handler: ?logging.Handler=None) -> proc(ttt.Path,?ttt.Layer)->ttt.Node:
+    r = ttt.Container({yang.gdata.Id("http://example.com/foo", "netinfra"): ttt.Container({yang.gdata.Id("http://example.com/foo", "router"): ttt.List(ttt.Transform(respnet.cfs.OperOnly, OperOnlyTransformCtor, None, lower, log_handler), [yang.gdata.Id("http://example.com/foo", "name")])}, ns='http://example.com/foo', module='foo')})
+    return r
+
+def OperOnlyTransformCtor(params: ttt.TransformActorParams) -> ?proc(yang.gdata.Node, ?yang.gdata.Node) -> None:
+    def update_oper_type_wrapper(oper: ?respnet.layers.y_0_oper.foo__netinfra__router_entry):
+        params.update_oper(oper.to_gdata() if oper is not None else None)
+    act = respnet.cfs.OperOnlyTransform(params.path, update_oper_type_wrapper, params.lower_tree_provider)
+    return proc lambda c, m: act.on_conf(foo__netinfra__router_entry.from_gdata(c))

--- a/snapshots/expected/test_ttt_gen/ttt_gen_rfs_ttt
+++ b/snapshots/expected/test_ttt_gen/ttt_gen_rfs_ttt
@@ -10,9 +10,9 @@ import yang.gdata
 
 import respnet.rfs
 
-from respnet.layers.y_1 import stratoweave_rfs__rfs__backbone_interface_entry
 from respnet.layers.y_1 import stratoweave_rfs__rfs__backbone_interface__dynstate
 from respnet.layers.y_1 import stratoweave_rfs__rfs__backbone_interface__memory
+from respnet.layers.y_1 import stratoweave_rfs__rfs__backbone_interface_entry
 
 def get_ttt(lower: ?ttt.Layer, dev_registry: swdev.DeviceRegistry, log_handler: ?logging.Handler=None) -> proc(ttt.Path,?ttt.Layer)->ttt.Node:
     r = ttt.Container({yang.gdata.Id("http://stratoweave.org/yang/stratoweave-rfs", "device"): ttt.List(ttt.Device(dev_registry, log_handler), [yang.gdata.Id("http://stratoweave.org/yang/stratoweave-rfs", "name")], ns='http://stratoweave.org/yang/stratoweave-rfs', module='stratoweave-rfs'), yang.gdata.Id("http://stratoweave.org/yang/stratoweave-rfs", "rfs"): ttt.List(ttt.Container({yang.gdata.Id("http://example.com/foo", "backbone-interface"): ttt.List(ttt.RFSTransform(respnet.rfs.BBInterface, dev_registry, BBInterfaceTransformCtor, lower, log_handler), [yang.gdata.Id("http://example.com/foo", "name")], ns='http://example.com/foo', module='foo')}), [yang.gdata.Id("http://stratoweave.org/yang/stratoweave-rfs", "name")], ns='http://stratoweave.org/yang/stratoweave-rfs', module='stratoweave-rfs')})
@@ -21,5 +21,5 @@ def get_ttt(lower: ?ttt.Layer, dev_registry: swdev.DeviceRegistry, log_handler: 
 def BBInterfaceTransformCtor(params: ttt.TransformActorParams) -> ?proc(yang.gdata.Node, ?yang.gdata.Node) -> None:
     def update_dynstate_type_wrapper(dynstate: ?stratoweave_rfs__rfs__backbone_interface__dynstate):
         params.update_dynstate(dynstate.to_gdata() if dynstate is not None else None)
-    act = respnet.rfs.BBInterfaceTransform(params.path, update_dynstate_type_wrapper, params.update_oper, ttt.expect(params.dev, "Missing expected DeviceMgr param to respnet.rfs.BBInterfaceTransform."))
+    act = respnet.rfs.BBInterfaceTransform(params.path, update_dynstate_type_wrapper, ttt.expect(params.dev, "Missing expected DeviceMgr param to respnet.rfs.BBInterfaceTransform."))
     return proc lambda c, m: act.on_conf(stratoweave_rfs__rfs__backbone_interface_entry.from_gdata(c), stratoweave_rfs__rfs__backbone_interface__memory.from_gdata(m) if m is not None else None)

--- a/src/stratoweave/build.act
+++ b/src/stratoweave/build.act
@@ -112,16 +112,16 @@ class CompiledSysSpec(object):
             modname = "{self.name}.layers.y_{lname}"
             oper_modname = "{self.name}.layers.y_{lname}_oper"
 
+            # schema.prdaclass mutates the compiled tree when it strips
+            # config-false nodes (see the comment in the device-type loop
+            # below). Emit the oper view first and run ttt_gen before any
+            # config-only print, so ttt_gen can detect config-false oper state
+            # per-transform.
             oper_name = "{output_dir}/{self.name}/layers/y_{lname}_oper.act"
             if _maybe_write_file(fc, oper_name, layer.print(loose=True, gen_json=False, include_state=True, exclude_ext=_SW_EXCLUDE_EXT, include_subs=True)):
                 print("+ Layer {idx} oper adata changed")
             else:
                 print("+ Layer {idx} oper adata unchanged")
-
-            if _maybe_write_file(fc, y_name, layer.print(exclude_ext=_SW_EXCLUDE_EXT)):
-                print("+ Layer {idx} adata changed")
-            else:
-                print("+ Layer {idx} adata unchanged")
 
             syssrc += "import {self.name}.layers.t_{idx}\n"
             syssrc += "import {self.name}.layers.y_{idx}\n"
@@ -133,6 +133,11 @@ class CompiledSysSpec(object):
                 out_layer_modname = "{self.name}.layers.y_{idx+1}_loose"
 
             tttl = ttt_gen.ttt_prsrc(layer.root, modname, out_layer_modname, oper_modname)
+
+            if _maybe_write_file(fc, y_name, layer.print(exclude_ext=_SW_EXCLUDE_EXT)):
+                print("+ Layer {idx} adata changed")
+            else:
+                print("+ Layer {idx} adata unchanged")
 
             base_name = "{output_dir}/{self.name}/layers/base_{idx}.act"
             if _maybe_write_file(fc, base_name, tttl.base):

--- a/src/stratoweave/ttt.act
+++ b/src/stratoweave/ttt.act
@@ -558,8 +558,8 @@ actor Transaction(impl: _Transaction):
     def is_empty():
         return impl.is_empty()
 
-    def init_dynstate(node: Node, act: proc(TransformActorParams) -> ?proc(gdata.Node, ?gdata.Node) -> None):
-        impl.init_dynstate(node, act, update_dynstate, update_oper)
+    def init_actor(node: Node, act: proc(TransformActorParams) -> ?proc(gdata.Node, ?gdata.Node) -> None):
+        impl.init_actor(node, act, update_dynstate, update_oper)
 
     def update_dynstate(dynstate: ?gdata.Node):
         impl.update_dynstate(dynstate)
@@ -590,7 +590,7 @@ class _Transaction(object):
     def is_empty(self) -> bool:
         return True
 
-    proc def init_dynstate(self, node: Node, act: proc(TransformActorParams) -> ?proc(gdata.Node, ?gdata.Node) -> None, update_dynstate: proc(?gdata.Node)->None, update_oper: proc(?gdata.Node)->None):
+    proc def init_actor(self, node: Node, act: proc(TransformActorParams) -> ?proc(gdata.Node, ?gdata.Node) -> None, update_dynstate: proc(?gdata.Node)->None, update_oper: proc(?gdata.Node)->None):
         pass
 
     proc def update_dynstate(self, dynstate: ?gdata.Node) -> None:
@@ -1942,7 +1942,7 @@ def Transform(function, act: ?(proc(TransformActorParams) -> ?proc(gdata.Node, ?
         transform = _Transform(path, function, build_links, lower, log_handler)
         node = Node(transform)
         if act is not None:
-            transform.init_dynstate(node, act)
+            transform.init_actor(node, act)
         return node
     return _create_transform_node
 
@@ -1951,8 +1951,8 @@ class _Transform(_TransformBase):
         self.path = path
         self.transaction = TransformTransaction(path, function, build_links, lower, log_handler)
 
-    proc def init_dynstate(self, node, act: proc(TransformActorParams) -> ?proc(gdata.Node, ?gdata.Node) -> None):
-        self.transaction.init_dynstate(node, act)
+    proc def init_actor(self, node, act: proc(TransformActorParams) -> ?proc(gdata.Node, ?gdata.Node) -> None):
+        self.transaction.init_actor(node, act)
 
 def TransformTransaction(path, function, build_links, lower, log_handler):
     return Transaction(_TransformTransaction(path, function, build_links, lower, log_handler))
@@ -2007,9 +2007,9 @@ class _TransformTransaction(_TransformTransactionBase):
             return
         _TransformTransactionBase.restore(self, attr, qualifier, raw)
 
-    proc def init_dynstate(self, node, act: proc(TransformActorParams) -> ?proc(gdata.Node, ?gdata.Node) -> None, update_dynstate, update_oper):
+    proc def init_actor(self, node, act: proc(TransformActorParams) -> ?proc(gdata.Node, ?gdata.Node) -> None, update_dynstate, update_oper):
         self.node = node
-        self.function.init_dynstate(act, update_dynstate, update_oper, unwrap(self.path), self.lower)
+        self.function.init_actor(act, update_dynstate, update_oper, unwrap(self.path), self.lower)
 
     proc def update_dynstate(self, dynstate):
         if self.dynstate == dynstate:
@@ -2041,7 +2041,7 @@ class TransformFunction(object):
     def transform_xml(self, cfg, linked, memory, dynstate):
         return gdata.Container(), None
 
-    proc def init_dynstate(self, act: proc(TransformActorParams) -> ?proc(gdata.Node, ?gdata.Node) -> None, update_dynstate: proc(?gdata.Node)->None, update_oper: proc(?gdata.Node)->None, path: Path, lower: ?Layer=None):
+    proc def init_actor(self, act: proc(TransformActorParams) -> ?proc(gdata.Node, ?gdata.Node) -> None, update_dynstate: proc(?gdata.Node)->None, update_oper: proc(?gdata.Node)->None, path: Path, lower: ?Layer=None):
         self._on_conf = act(TransformActorParams(path, update_dynstate, update_oper, None, lower))
 
     proc def on_conf(self, conf: gdata.Node, memory: ?gdata.Node):
@@ -2056,7 +2056,7 @@ def RFSTransform(function, dev_registry: swdev.DeviceRegistry, act: ?(proc(Trans
         rfs_transform = _RFSTransform(path, function, dev_registry, lower, log_handler)
         node = Node(rfs_transform)
         if act is not None:
-            rfs_transform.init_dynstate(node, act)
+            rfs_transform.init_actor(node, act)
         return node
     return _create_rfs_transform_node
 
@@ -2066,8 +2066,8 @@ class _RFSTransform(_TransformBase):
         self.path = path
         self.transaction = RFSTransaction(path, function, dev_registry, lower, log_handler)
 
-    proc def init_dynstate(self, node, act: proc(TransformActorParams) -> ?proc(gdata.Node, ?gdata.Node) -> None):
-        self.transaction.init_dynstate(node, act)
+    proc def init_actor(self, node, act: proc(TransformActorParams) -> ?proc(gdata.Node, ?gdata.Node) -> None):
+        self.transaction.init_actor(node, act)
 
 def RFSTransaction(path, function, dev_registry, lower, log_handler):
     return Transaction(_RFSTransaction(path, function, dev_registry, lower, log_handler))
@@ -2169,9 +2169,9 @@ class _RFSTransaction(_TransformTransactionBase):
             return
         _TransformTransactionBase.restore(self, attr, qualifier, raw)
 
-    proc def init_dynstate(self, node, act: proc(TransformActorParams) -> ?proc(gdata.Node, ?gdata.Node) -> None, update_dynstate, update_oper):
+    proc def init_actor(self, node, act: proc(TransformActorParams) -> ?proc(gdata.Node, ?gdata.Node) -> None, update_dynstate, update_oper):
         self.node = node
-        self.function.init_dynstate(act, update_dynstate, update_oper, unwrap(self.path), self.dev)
+        self.function.init_actor(act, update_dynstate, update_oper, unwrap(self.path), self.dev)
 
     proc def update_dynstate(self, dynstate):
         if self.dynstate == dynstate:
@@ -2214,7 +2214,7 @@ class RFSFunction(object):
     def transform_xml(self, cfg, di, memory, dynstate):
         return (gdata.Container(), None)
 
-    proc def init_dynstate(self, act: proc(TransformActorParams) -> ?proc(gdata.Node, ?gdata.Node) -> None, update_dynstate: proc(?gdata.Node)->None, update_oper: proc(?gdata.Node)->None, path: Path, dev: swdev.DeviceMgr):
+    proc def init_actor(self, act: proc(TransformActorParams) -> ?proc(gdata.Node, ?gdata.Node) -> None, update_dynstate: proc(?gdata.Node)->None, update_oper: proc(?gdata.Node)->None, path: Path, dev: swdev.DeviceMgr):
         self._on_conf = act(TransformActorParams(path, update_dynstate, update_oper, dev))
 
     proc def on_conf(self, conf: gdata.Node, memory: ?gdata.Node):

--- a/src/stratoweave/ttt_gen.act
+++ b/src/stratoweave/ttt_gen.act
@@ -38,11 +38,20 @@ def _parse_transform_ref(ext: schema.DExt) -> (fqname: str, module: str, name: s
 
     raise ValueError("Missing argument to {ext.prefix}:{ext.name}. Add a fully qualified transform reference, for example app.cfs.Transform.")
 
+def _has_oper_state(sn: schema.DNodeInner) -> bool:
+    for child in sn.children:
+        if not child.config:
+            return True
+        if isinstance(child, schema.DNodeInner) and _has_oper_state(child):
+            return True
+    return False
+
 class TTTSrc(object):
-    def __init__(self, src: str, input_classes: list[str], state_classes: list[str], imports: list[str], defs: list[str], base_defs: list[str], act_defs: list[str]):
+    def __init__(self, src: str, input_classes: list[str], state_classes: list[str], oper_classes: list[str], imports: list[str], defs: list[str], base_defs: list[str], act_defs: list[str]):
         self.src = src
         self.input_classes = input_classes
         self.state_classes = state_classes
+        self.oper_classes = oper_classes
         self.imports = imports
         self.defs = defs
         self.base_defs = base_defs
@@ -51,6 +60,7 @@ class TTTSrc(object):
 def children_to_tttsrc(sn: schema.DNodeInner, spath: list[schema.DNode], root: schema.DRoot, oper_yang_module: ?str=None) -> TTTSrc:
     input_classes = []
     state_classes = []
+    oper_classes = []
     imports = []
     defs = []
     base_defs = []
@@ -59,20 +69,24 @@ def children_to_tttsrc(sn: schema.DNodeInner, spath: list[schema.DNode], root: s
     for child in sn.children:
         if isinstance(child, schema.DLeaf):
             continue
+        if not child.config:
+            continue
         res = dschema_to_tttsrc(child, spath + [child], root, oper_yang_module, set_ns=child.namespace!=sn.namespace)
         input_classes.extend(res.input_classes)
         state_classes.extend(res.state_classes)
+        oper_classes.extend(res.oper_classes)
         imports.extend(res.imports)
         defs.extend(res.defs)
         base_defs.extend(res.base_defs)
         act_defs.extend(res.act_defs)
         elems.append('yang.gdata.Id("{child.namespace}", "{child.name}"): {res.src}')
     children_src = ", ".join(elems)
-    return TTTSrc(src=children_src, input_classes=input_classes, state_classes=state_classes, imports=imports, defs=defs, base_defs=base_defs, act_defs=act_defs)
+    return TTTSrc(src=children_src, input_classes=input_classes, state_classes=state_classes, oper_classes=oper_classes, imports=imports, defs=defs, base_defs=base_defs, act_defs=act_defs)
 
 def dschema_to_tttsrc(sn: schema.DNode, spath: list[schema.DNode], root: schema.DRoot, oper_yang_module: ?str=None, indent=0, set_ns=True) -> TTTSrc:
     input_classes = []
     state_classes = []
+    oper_classes = []
     imports = []
     defs = []
     base_defs = []
@@ -104,7 +118,6 @@ def dschema_to_tttsrc(sn: schema.DNode, spath: list[schema.DNode], root: schema.
                             memory_class = _memory_class
                         elif subext.name == "dynstate":
                             _dynstate_class: str = schema.get_path_name(spath + [child])
-                            state_classes.append(input_class)
                             state_classes.append(_dynstate_class)
                             input_classes.append(_dynstate_class)
                             dynstate_class = _dynstate_class
@@ -125,13 +138,21 @@ def dschema_to_tttsrc(sn: schema.DNode, spath: list[schema.DNode], root: schema.
             transform_output = "(yang.adata.MNode, ?yang.adata.MNode)"
         else:
             transform_output = "yang.adata.MNode"
+        has_oper_state = _has_oper_state(sn)
+        # An actor needs the typed update_oper wrapper iff the transform has
+        # operational state AND the oper YANG module is available to type it.
+        emit_update_oper = has_oper_state and oper_yang_module is not None
+
         type_helpers = """
     @staticmethod
     def input_type():
         \"\"\"Return the modeled input type for this transform\"\"\"
         return {input_class}
 """
-        if oper_yang_module is not None:
+        if emit_update_oper:
+            # input_class is referenced as {input_class}__oper below, so its
+            # oper-module import is needed in the base file.
+            oper_classes.append(input_class)
             type_helpers += """
     @staticmethod
     def state_type():
@@ -153,21 +174,36 @@ def dschema_to_tttsrc(sn: schema.DNode, spath: list[schema.DNode], root: schema.
         \"\"\"Return the modeled dynstate type for this transform\"\"\"
         return {dynstate_class}
 """
+
+        # Emit the *TransformCtor when the transform has reason to own an actor:
+        # sw:dynstate or config false oper state in the transform model.
+        # The (user-provider) transform actor only accepts the update callbacks
+        # it needs: update_dynstate (iff sw:dynstate) / update_oper (iff config false).
+        if dynstate_class is not None or has_oper_state:
+            state_classes.append(input_class)
             transform_actor_fq = transform.fqname + "Transform"
             transform_actor_ctor = transform.name + "TransformCtor"
-            transform_actor_extra_params = ", ttt.expect(params.dev, \"Missing expected DeviceMgr param to {transform_actor_fq}.\")" if ext.name == "rfs-transform" else ", params.lower_tree_provider"
+            transform_actor_handle = "ttt.expect(params.dev, \"Missing expected DeviceMgr param to {transform_actor_fq}.\")" if ext.name == "rfs-transform" else "params.lower_tree_provider"
             memory_conv = ", {memory_class}.from_gdata(m) if m is not None else None" if memory_class is not None else ""
-            oper_update_wrapper = ""
-            oper_update_arg = "params.update_oper"
-            if oper_yang_module is not None:
-                oper_update_wrapper = """    def update_oper_type_wrapper(oper: ?{oper_yang_module}.{input_class}):
+
+            wrappers = ""
+            actor_args = ["params.path"]
+            if dynstate_class is not None:
+                wrappers += """    def update_dynstate_type_wrapper(dynstate: ?{dynstate_class}):
+        params.update_dynstate(dynstate.to_gdata() if dynstate is not None else None)
+"""
+                actor_args.append("update_dynstate_type_wrapper")
+            if emit_update_oper:
+                wrappers += """    def update_oper_type_wrapper(oper: ?{oper_yang_module}.{input_class}):
         params.update_oper(oper.to_gdata() if oper is not None else None)
 """
-                oper_update_arg = "update_oper_type_wrapper"
+                actor_args.append("update_oper_type_wrapper")
+            elif has_oper_state:
+                actor_args.append("params.update_oper")
+            actor_args.append(transform_actor_handle)
+            actor_args_s = ", ".join(actor_args)
             act_defs.append("""def {transform_actor_ctor}(params: ttt.TransformActorParams) -> ?proc(yang.gdata.Node, ?yang.gdata.Node) -> None:
-    def update_dynstate_type_wrapper(dynstate: ?{dynstate_class}):
-        params.update_dynstate(dynstate.to_gdata() if dynstate is not None else None)
-{oper_update_wrapper}    act = {transform_actor_fq}(params.path, update_dynstate_type_wrapper, {oper_update_arg}{transform_actor_extra_params})
+{wrappers}    act = {transform_actor_fq}({actor_args_s})
     return proc lambda c, m: act.on_conf({input_class}.from_gdata(c){memory_conv})
 """)
         else:
@@ -210,7 +246,7 @@ def dschema_to_tttsrc(sn: schema.DNode, spath: list[schema.DNode], root: schema.
                 src = "ttt.List(ttt.Transform({transform.fqname}, {transform_actor_ctor}, {build_links_fn}, lower, log_handler), {_fq_list_keys(sn)}{nsq(sn)})"
             else:
                 src = "ttt.Transform({transform.fqname}, {transform_actor_ctor}, {build_links_fn}, lower, log_handler)"
-            return TTTSrc(src=src, input_classes=input_classes, state_classes=state_classes, imports=imports, defs=defs, base_defs=base_defs, act_defs=act_defs)
+            return TTTSrc(src=src, input_classes=input_classes, state_classes=state_classes, oper_classes=oper_classes, imports=imports, defs=defs, base_defs=base_defs, act_defs=act_defs)
 
         elif ext.name == "rfs-transform":
             base_defs.append("""class {transform.name}(ttt.RFSFunction):
@@ -235,7 +271,7 @@ def dschema_to_tttsrc(sn: schema.DNode, spath: list[schema.DNode], root: schema.
                 src = "ttt.List(ttt.RFSTransform({transform.fqname}, dev_registry, {transform_actor_ctor}, lower, log_handler), {_fq_list_keys(sn)}{nsq(sn)})"
             else:
                 src = "ttt.RFSTransform({transform.fqname}, dev_registry, {transform_actor_ctor}, lower, log_handler)"
-            return TTTSrc(src=src, input_classes=input_classes, state_classes=state_classes, imports=imports, defs=defs, base_defs=base_defs, act_defs=act_defs)
+            return TTTSrc(src=src, input_classes=input_classes, state_classes=state_classes, oper_classes=oper_classes, imports=imports, defs=defs, base_defs=base_defs, act_defs=act_defs)
         raise ValueError("Unknown extension name: {ext.name}")
 
     if isinstance(sn, schema.DList):
@@ -247,21 +283,22 @@ def dschema_to_tttsrc(sn: schema.DNode, spath: list[schema.DNode], root: schema.
                 elif ext.name == "device":
                     if extarg is not None:
                         raise ValueError("Extraneous argument to {ext.prefix}:device. Remove argument.")
-                    return TTTSrc(src="ttt.List(ttt.Device(dev_registry, log_handler), {_fq_list_keys(sn)}{nsq(sn)})", input_classes=input_classes, state_classes=state_classes, imports=imports, defs=defs, base_defs=base_defs, act_defs=act_defs)
+                    return TTTSrc(src="ttt.List(ttt.Device(dev_registry, log_handler), {_fq_list_keys(sn)}{nsq(sn)})", input_classes=input_classes, state_classes=state_classes, oper_classes=oper_classes, imports=imports, defs=defs, base_defs=base_defs, act_defs=act_defs)
                 elif ext.name == "device-config":
                     if extarg is not None:
                         raise ValueError("Extraneous argument to {ext.prefix}:device-config. Remove argument.")
-                    return TTTSrc(src="ttt.List(ttt.DeviceConfig(dev_registry, log_handler), {_fq_list_keys(sn)}{nsq(sn)})", input_classes=input_classes, state_classes=state_classes, imports=imports, defs=defs, base_defs=base_defs, act_defs=act_defs)
+                    return TTTSrc(src="ttt.List(ttt.DeviceConfig(dev_registry, log_handler), {_fq_list_keys(sn)}{nsq(sn)})", input_classes=input_classes, state_classes=state_classes, oper_classes=oper_classes, imports=imports, defs=defs, base_defs=base_defs, act_defs=act_defs)
 
         # List without an extension
         children_res = children_to_tttsrc(sn, spath, root, oper_yang_module)
         input_classes.extend(children_res.input_classes)
         state_classes.extend(children_res.state_classes)
+        oper_classes.extend(children_res.oper_classes)
         imports.extend(children_res.imports)
         defs.extend(children_res.defs)
         base_defs.extend(children_res.base_defs)
         act_defs.extend(children_res.act_defs)
-        return TTTSrc(src="ttt.List(ttt.Container({{{children_res.src}}}), {_fq_list_keys(sn)}{nsq(sn)})", input_classes=input_classes, state_classes=state_classes, imports=imports, defs=defs, base_defs=base_defs, act_defs=act_defs)
+        return TTTSrc(src="ttt.List(ttt.Container({{{children_res.src}}}), {_fq_list_keys(sn)}{nsq(sn)})", input_classes=input_classes, state_classes=state_classes, oper_classes=oper_classes, imports=imports, defs=defs, base_defs=base_defs, act_defs=act_defs)
 
     elif isinstance(sn, schema.DNodeInner):
         for ext in sn.exts:
@@ -272,11 +309,12 @@ def dschema_to_tttsrc(sn: schema.DNode, spath: list[schema.DNode], root: schema.
         children_res = children_to_tttsrc(sn, spath, root, oper_yang_module)
         input_classes.extend(children_res.input_classes)
         state_classes.extend(children_res.state_classes)
+        oper_classes.extend(children_res.oper_classes)
         imports.extend(children_res.imports)
         defs.extend(children_res.defs)
         base_defs.extend(children_res.base_defs)
         act_defs.extend(children_res.act_defs)
-        return TTTSrc(src="ttt.Container({{{children_res.src}}}{nsq(sn)})", input_classes=input_classes, state_classes=state_classes, imports=imports, defs=defs, base_defs=base_defs, act_defs=act_defs)
+        return TTTSrc(src="ttt.Container({{{children_res.src}}}{nsq(sn)})", input_classes=input_classes, state_classes=state_classes, oper_classes=oper_classes, imports=imports, defs=defs, base_defs=base_defs, act_defs=act_defs)
 
     raise NotImplementedError("Unhandled schema type: {type(sn)}: {schema.get_path_name(spath)}")
 
@@ -289,8 +327,11 @@ def ttt_prsrc(root: schema.DRoot, input_yang_module: str, output_yang_module: ?s
     base_src += "import logging\nimport xml\nimport stratoweave.ttt as ttt\nimport yang.adata\nimport yang.gdata\nimport yang.xml\n\n"
     for ic in ts.input_classes:
         base_src += "from {input_yang_module} import {ic}\n"
-        if oper_yang_module is not None:
-            base_src += "from {oper_yang_module} import {ic} as {ic}__oper\n"
+    # Only transforms with operational state reference {ic}__oper (in
+    # state_type/new_state), so import the oper module only for those classes.
+    if oper_yang_module is not None:
+        for oc in ts.oper_classes:
+            base_src += "from {oper_yang_module} import {oc} as {oc}__oper\n"
     base_src += "from {input_yang_module} import SRC_DNODE\n"
 
     if output_yang_module is not None:

--- a/src/test_ttt_gen.act
+++ b/src/test_ttt_gen.act
@@ -43,6 +43,54 @@ def _test_ttt_gen_cfs_ttt():
     r = ttt_gen.ttt_prsrc(y, 'respnet.layers.y_0', 'respnet.layers.y_1_loose')
     return r.ttt
 
+# Transform that has config-false oper state but no sw:dynstate. Exercises the
+# decoupled actor emission: *TransformCtor must be emitted (so the actor can
+# call update_oper and subscribe to the lower layer), with the typed
+# update_oper wrapper but no update_dynstate wrapper.
+ys_oper_only = r"""module foo {
+  yang-version "1.1";
+  namespace "http://example.com/foo";
+  prefix "foo";
+  import stratoweave {
+    prefix sw;
+  }
+  container netinfra {
+    list router {
+      key name;
+
+      sw:transform respnet.cfs.OperOnly;
+
+      leaf name {
+        type string;
+      }
+
+      container state {
+        config false;
+        leaf datetime {
+          type string;
+        }
+      }
+    }
+  }
+}
+"""
+
+def _test_ttt_gen_oper_only_base():
+    y = yang.compile([ys_oper_only, swyang.stratoweave])
+    r = ttt_gen.ttt_prsrc(y, 'respnet.layers.y_0', 'respnet.layers.y_1_loose', 'respnet.layers.y_0_oper')
+    return r.base
+
+def _test_ttt_gen_oper_only_ttt():
+    y = yang.compile([ys_oper_only, swyang.stratoweave])
+    r = ttt_gen.ttt_prsrc(y, 'respnet.layers.y_0', 'respnet.layers.y_1_loose', 'respnet.layers.y_0_oper')
+    return r.ttt
+
+def _test_ttt_gen_oper_only_ttt_untyped_update_oper():
+    y = yang.compile([ys_oper_only, swyang.stratoweave])
+    r = ttt_gen.ttt_prsrc(y, 'respnet.layers.y_0', 'respnet.layers.y_1_loose')
+    testing.assertTrue("params.update_oper" in r.ttt)
+    testing.assertFalse("update_oper_type_wrapper" in r.ttt)
+
 ys_rfs = r"""module foo {
   yang-version "1.1";
   namespace "http://example.com/foo";


### PR DESCRIPTION
Emit the *TransformCtor when the transform has sw:dynstate or config-false oper state. The user actor receives only the wrappers that match present features: path, optional update_dynstate, optional update_oper, and the subscription handle (lower_tree_provider for cfs, dev for rfs).

In the generated base file, import the oper module only for transforms with oper state, tracked via a new TTTSrc.oper_classes field, instead of for every input class.

Rename init_dynstate → init_actor in ttt.act since it now spins the actor for oper-only transforms too.

Run ttt_prsrc before layer.print(..., include_state=False) so the schema still contains config false descendants (prdaclass mutates).

Closes #413 