### PR TITLE
Report config rejection to wait_complete

### DIFF
--- a/src/stratoweave/device.act
+++ b/src/stratoweave/device.act
@@ -854,6 +854,11 @@ actor DeviceMgr(dev_types: dict[str, DeviceType]={}, pcap: ?process.ProcessCap=N
             # though, otherwise it is too confusing that an approved item suddenly
             # goes back to unapproved.
             _log.debug("DeviceMgr.set_confq_approval: rejecting configuration", {"id": id})
+            # Notify synchronous requests (wait_complete)
+            cb = callbacks.get(first_key)
+            if cb is not None:
+                cb(Exception("configuration rejected"))
+                del callbacks[first_key]
             del confq[first_key]
         _update_approval_state()
         if approved:


### PR DESCRIPTION
A synchronous request (wait_complete) is notified of config rejection via its registered callback.