### PR TITLE
Deliver leafref-linked list entries to transforms

### DIFF
--- a/minisys/snapshots/expected/test_mini/l3vpn1
+++ b/minisys/snapshots/expected/test_mini/l3vpn1
@@ -6,7 +6,7 @@ rtr1 = root()
 rtr1.system.hostname = 'rtr1'
 
 # List /interfaces/interface element: ge-0/0/0.101
-interface_element = rtr1.interfaces.interface.create('ge-0/0/0.101', description='Stockholm CE', type=Identityref('l3ipvlan', ns='urn:ietf:params:xml:ns:yang:iana-if-type', mod='iana-if-type', pfx='ianaift'), enabled=True)
+interface_element = rtr1.interfaces.interface.create('ge-0/0/0.101', description='Stockholm CE rd 1:100', type=Identityref('l3ipvlan', ns='urn:ietf:params:xml:ns:yang:iana-if-type', mod='iana-if-type', pfx='ianaift'), enabled=True)
 
 # P-container: /interfaces/interface[name='ge-0/0/0.101']/ipv4
 ipv4 = interface_element.create_ipv4(enabled=True, forwarding=True, mtu=u64(1580))
@@ -22,7 +22,7 @@ rtr2 = root()
 rtr2.system.hostname = 'rtr2'
 
 # List /interfaces/interface element: ge-0/0/0.202
-interface_element = rtr2.interfaces.interface.create('ge-0/0/0.202', description='acme vpn blue site gbg1 vlan 202', type=Identityref('l3ipvlan', ns='urn:ietf:params:xml:ns:yang:iana-if-type', mod='iana-if-type', pfx='ianaift'), enabled=True)
+interface_element = rtr2.interfaces.interface.create('ge-0/0/0.202', description='acme vpn blue site gbg1 vlan 202 rd 2:100', type=Identityref('l3ipvlan', ns='urn:ietf:params:xml:ns:yang:iana-if-type', mod='iana-if-type', pfx='ianaift'), enabled=True)
 
 # P-container: /interfaces/interface[name='ge-0/0/0.202']/ipv4
 ipv4 = interface_element.create_ipv4(enabled=True, forwarding=True, mtu=u64(1600))

--- a/minisys/src/mini/cfs.act
+++ b/minisys/src/mini/cfs.act
@@ -5,9 +5,10 @@ import yang.gdata # required for linked input parameter to transform function
 import stratoweave.ttt
 
 import mini.layers.base_0 as base
+import mini.layers.y_0 as y_0
 # TODO: this import is required by the compiler, maybe related to
 # https://github.com/actonlang/acton/issues/2390
-import yang.identityref, mini.layers.y_0
+import yang.identityref
 import mini.layers.y_0_oper as y0_oper
 import mini.layers.y_1_oper as y1_oper
 
@@ -16,10 +17,7 @@ class GlobalSettings(base.GlobalSettings):
         o = base.o_root()
         return o
 
-def q(n):
-    return yang.gdata.Id("http://example.com/netinfra", n)
-
-actor RouterTransform(path: stratoweave.ttt.Path, update_dynstate: proc(?mini.layers.y_0.netinfra__netinfra__router__dynstate)->None, update_oper: proc(?y0_oper.netinfra__netinfra__router_entry)->None, lower_tree_provider: ?yang.gdata.TreeProvider):
+actor RouterTransform(path: stratoweave.ttt.Path, update_dynstate: proc(?y_0.netinfra__netinfra__router__dynstate)->None, update_oper: proc(?y0_oper.netinfra__netinfra__router_entry)->None, lower_tree_provider: ?yang.gdata.TreeProvider):
     oper = base.Router.new_state(path)
     _subs = yang.gdata.SubscriptionManager(stratoweave.ttt.expect(lower_tree_provider, "Missing lower tree provider for CFS router telemetry"), str(path))
 
@@ -42,13 +40,12 @@ actor RouterTransform(path: stratoweave.ttt.Path, update_dynstate: proc(?mini.la
         }))
         _subs.declare(want)
 
-    def on_conf(conf: mini.layers.y_0.netinfra__netinfra__router_entry):
+    def on_conf(conf: y_0.netinfra__netinfra__router_entry):
         subscribe(conf.name)
 
 class Router(base.Router):
     def transform(self, i, linked, dynstate):
-        #print("###### linked:", linked.prsrc(), err=True)
-        asn = linked.get_cnt(q("netinfra")).get_cnt(q("global-settings")).get_leaf(q("asn")).val
+        asn = y_0.root.from_gdata(linked).netinfra.global_settings.asn
 
         o = base.o_root()
         print("CFS router transform running", i.name)
@@ -71,15 +68,16 @@ class Router(base.Router):
 
 class L3vpn(base.L3vpn):
     def transform(self, i, linked):
-        #print("###### linked:", linked.prsrc(), err=True)
-        asn = linked.get_cnt(q("netinfra")).get_cnt(q("global-settings")).get_leaf(q("asn")).val
+        linked_adata = y_0.root.from_gdata(linked)
+        asn = linked_adata.netinfra.global_settings.asn
 
         o = base.o_root()
         print("CFS l3vpn transform running", i.name, "asn:", asn)
-        rd = "65000:{i.vpn_id}"
         rt = "target:65000:{i.vpn_id}"
 
         for endpoint in i.endpoint:
+            router = linked_adata.netinfra.router.get(endpoint.device)!
+            rd = "{router.id}:{i.vpn_id}"
             rfs_dev = o.rfs.create(endpoint.device)
             description = endpoint.description
             if description is None:

--- a/minisys/src/mini/rfs.act
+++ b/minisys/src/mini/rfs.act
@@ -84,6 +84,7 @@ class L3vpnEndpoint(base.L3vpnEndpoint):
                     description += " interface {i.interface_name}"
                 if i.vlan_id is not None:
                     description += " vlan {i.vlan_id}"
+            description += " rd {i.route_distinguisher}"
 
             iface = dev.interfaces.interface.create(
                 i.interface_name,

--- a/src/stratoweave/ttt.act
+++ b/src/stratoweave/ttt.act
@@ -184,7 +184,7 @@ class PathElem(Path):
         return self.ns
 
 class PathKey(Path):
-    def __init__(self, keystr: str, parent: Path, keyvals: dict[gdata.Id, gdata.Node], ):
+    def __init__(self, keystr: str, parent: Path, keyvals: dict[gdata.Id, gdata.Node]):
         self.name = keystr
         self.parent = parent
         self.keyvals = keyvals
@@ -200,14 +200,35 @@ def _format_path(p: Path):
     else:
         return [p.name]
 
-# Reverse the given Path and construct a linear FNode chain. List entries
-# become a single FNode whose value_match is the compound key string already
-# computed by key_str on PathKey construction
-def fnode(p: Path, tails: list[gdata.FNode]=[]) -> gdata.FNode:
+# Reverse a Path into a linear gdata.FNode chain in *routing* form: a list
+# entry collapses to a single unnamed FNode whose value_match is the compound
+# key string (PathKey.name, precomputed by key_str). A transform names itself
+# as a link subscriber with this (route_fpath); List.linkage routes messages
+# back to it by matching that value_match against each element's key_str.
+# Sibling path_filter() renders the same Path in gdata *filter* form.
+def path_route(p: Path, tails: list[gdata.FNode]=[]) -> gdata.FNode:
     if isinstance(p, PathElem):
-        return fnode(p.parent, [gdata.FNode(gdata.Id(p.ns, p.name), children=tails)])
+        return path_route(p.parent, [gdata.FNode(gdata.Id(p.ns, p.name), children=tails)])
     elif isinstance(p, PathKey):
-        return fnode(p.parent, [gdata.FNode(value_match=p.name, children=tails)])
+        return path_route(p.parent, [gdata.FNode(value_match=p.name, children=tails)])
+    elif tails:
+        return tails[0]
+    else:
+        return gdata.FNode(gdata.Id("", p.name))
+
+# Reverse a Path into a linear gdata.FNode chain in gdata *filter* form: each
+# list key becomes a named key-leaf predicate FNode(keyId, value_match=val) --
+# the convention used by build_target_links, gdata.filter and gdata.prune,
+# which reject the unnamed-entry form (they require named children). A transform
+# advertises itself as a link publisher with this (filter_fpath) so it matches
+# the subscriber's generated demand and can be pruned from the linked tree.
+# Sibling path_route() renders the same Path in routing form.
+def path_filter(p: Path, tails: list[gdata.FNode]=[]) -> gdata.FNode:
+    if isinstance(p, PathElem):
+        return path_filter(p.parent, [gdata.FNode(gdata.Id(p.ns, p.name), children=tails)])
+    elif isinstance(p, PathKey):
+        key_preds = [gdata.FNode(kid, value_match=(kv.val if isinstance(kv, gdata.Leaf) else None)!) for kid, kv in p.keyvals.items()]
+        return path_filter(p.parent, key_preds + tails)
     elif tails:
         return tails[0]
     else:
@@ -1668,7 +1689,8 @@ class _TransformTransactionBase(_Transaction):
     candidate_subscribers: dict[str, list[TaggedPath]]          # As above, per ongoing transaction
     @property
     build_links: ?proc(gdata.Node) -> list[TaggedPath]
-    fpath: gdata.FNode
+    route_fpath: gdata.FNode
+    filter_fpath: gdata.FNode
 
     me: str
     db: ?lmdb.Db
@@ -1694,7 +1716,8 @@ class _TransformTransactionBase(_Transaction):
         self.subscribers = []
         self.candidate_subscribers = {}
         self.build_links = build_links
-        self.fpath = fnode(path)
+        self.route_fpath = path_route(path)
+        self.filter_fpath = path_filter(path)
 
         self.db = None
         self.me = ''  # Initialize first before any self reference
@@ -1720,7 +1743,7 @@ class _TransformTransactionBase(_Transaction):
             #print('   #', tid, '(Transform)', _format_path(self.path), 'EMPTY CONFIG', err=True)
             self.clear(tid, out)
             self.stage_db_state(tid, dbuf)
-            req = [ LinkRequest(s.tag,s.path,self.fpath,False) for s in self.subscriptions ]
+            req = [ LinkRequest(s.tag,s.path,self.route_fpath,False) for s in self.subscriptions ]
             upd = self.link_updates(tid, gdata.Container())
             return CfgOk(empty=True, requests=req, updates=upd)
         else:
@@ -1753,10 +1776,10 @@ class _TransformTransactionBase(_Transaction):
             latest_subs = build_links(merged)
             for s in latest_subs:
                 if s not in cand_subs:
-                    req.append(LinkRequest(s.tag, s.path, self.fpath, True))
+                    req.append(LinkRequest(s.tag, s.path, self.route_fpath, True))
             for s in cand_subs:
                 if s not in latest_subs:
-                    req.append(LinkRequest(s.tag, s.path, self.fpath, False))
+                    req.append(LinkRequest(s.tag, s.path, self.route_fpath, False))
                     cand_linked = prune(cand_linked, s.path)
             self.candidate_subscriptions[tid] = latest_subs
             self.candidate_linked[tid] = cand_linked
@@ -1768,7 +1791,7 @@ class _TransformTransactionBase(_Transaction):
         rooted = make_rooted(self.path, merged)
         upd = []
         for u in cand_subscribers:
-            upd.append(LinkUpdate(u.tag, self.fpath, u.path, rooted))
+            upd.append(LinkUpdate(u.tag, self.filter_fpath, u.path, rooted))
         #print('####', tid, '(Transform)', _format_path(self.path), 'link_updates:', len(upd), err=True)
         return upd
 

--- a/src/test_ttt_transform.act
+++ b/src/test_ttt_transform.act
@@ -947,3 +947,152 @@ actor link_subscriber_in_list_re_runs_on_publisher_update(t: testing.AsyncT):
 
     sess1.edit_config(cfg_init, cont1)
 ########################
+
+
+# Subscriber transform for the test below: it reflects each linked
+# /netinfra/router entry as seen_<name> = <id>, so the test can assert which
+# router entries were delivered as linked input.
+class LinkedRouterSubscriber(ttt.TransformFunction):
+    def transform_wrapper(self, cfg, linked, memory, dynstate):
+        out_children: dict[gdata.Id, gdata.Node] = {}
+        netinfra_node = linked.get_opt_cnt(q("netinfra"))
+        if netinfra_node is not None:
+            router_list = netinfra_node.get_opt_list(q("router"))
+            if router_list is not None:
+                for entry in router_list.elements:
+                    rname = entry.get_opt_value(q("name"))
+                    id_leaf = entry.get_opt_leaf(q("id"))
+                    if rname is not None and id_leaf is not None:
+                        out_children[q("seen_{rname}")] = id_leaf
+        return gdata.Container(out_children), None
+
+# A linkable publisher whose own downstream output is irrelevant to the link,
+# so it emits nothing. (A PassThrough here would echo each entry's flat
+# {name,id} to the shared sink root, where two list entries collide on those
+# leaves and abort the commit.)
+class RouterPublisher(ttt.TransformFunction):
+    def transform_wrapper(self, cfg, linked, memory, dynstate):
+        return gdata.Container(), None
+
+# A faithful copy of the router leafref portion of the generated
+# _build_target_links_l3vpn__l3vpn_entry: it reads the 'conf' parameter,
+# walking the endpoint list and rendering one router demand per device value.
+def _build_target_links_l3vpn(conf: gdata.Node) -> list[ttt.TaggedPath]:
+    res = []
+    # leafref link: router
+    _l0 = conf.get_opt_list(q("endpoint"))
+    if _l0 is not None:
+        for _e0 in _l0.elements:
+            _v1 = _e0.get_opt_value(q("device"))
+            if _v1 is not None:
+                res.append(ttt.TaggedPath('router', gdata.FNode(q("netinfra"), children=[gdata.FNode(q("router"), children=[gdata.FNode(q("name"), value_match=_v1)])])))
+    return res
+
+
+# Linking via leafref into a single-key list entry: the l3vpn endpoint/device
+# leaf is a leafref to /netinfra/router/name (`sw:link router`). Two routers
+# exist but the only endpoint references r1, so r1's entry must be delivered to
+# the subscriber transform and r2 must be filtered out.
+actor link_into_list_delivers_only_referenced_entry(t: testing.AsyncT):
+    stack = ttt.Layer("top",
+        ttt.Container({
+            q("netinfra"): ttt.Container({
+                q("router"): ttt.List(
+                    ttt.Transform(RouterPublisher),
+                    [q("name")],
+                ),
+            }),
+            q("l3vpn"): ttt.Transform(LinkedRouterSubscriber, None, _build_target_links_l3vpn),
+        }),
+        ttt.Sink())
+
+    cfg = gdata.Container({
+        q("netinfra"): gdata.Container({
+            q("router"): gdata.List([q("name")], [
+                gdata.Container({
+                    q("name"): gdata.Leaf("r1"),
+                    q("id"): gdata.Leaf(1),
+                }),
+                gdata.Container({
+                    q("name"): gdata.Leaf("r2"),
+                    q("id"): gdata.Leaf(2),
+                }),
+            ]),
+        }),
+        q("l3vpn"): gdata.Container({
+            q("endpoint"): gdata.List([q("device")], [
+                gdata.Container({
+                    q("device"): gdata.Leaf("r1"),
+                }),
+            ]),
+        }),
+    })
+
+    expected = gdata.Container({
+        q("seen_r1"): gdata.Leaf(1),
+    })
+
+    sess = stack.newsession()
+
+    def cont(_r: value):
+        testing.assertEqual(sess.below().get().prsrc(deterministic=True), expected.prsrc(deterministic=True))
+        t.success()
+
+    sess.edit_config(cfg, complete=cont)
+########################
+
+
+# Both list entries referenced: two endpoints reference r1 and r2, so
+# build_target_links emits a demand per device and both /netinfra/router
+# entries must be delivered to the subscriber transform.
+actor link_into_list_delivers_all_referenced_entries(t: testing.AsyncT):
+    stack = ttt.Layer("top",
+        ttt.Container({
+            q("netinfra"): ttt.Container({
+                q("router"): ttt.List(
+                    ttt.Transform(RouterPublisher),
+                    [q("name")],
+                ),
+            }),
+            q("l3vpn"): ttt.Transform(LinkedRouterSubscriber, None, _build_target_links_l3vpn),
+        }),
+        ttt.Sink())
+
+    cfg = gdata.Container({
+        q("netinfra"): gdata.Container({
+            q("router"): gdata.List([q("name")], [
+                gdata.Container({
+                    q("name"): gdata.Leaf("r1"),
+                    q("id"): gdata.Leaf(1),
+                }),
+                gdata.Container({
+                    q("name"): gdata.Leaf("r2"),
+                    q("id"): gdata.Leaf(2),
+                }),
+            ]),
+        }),
+        q("l3vpn"): gdata.Container({
+            q("endpoint"): gdata.List([q("device")], [
+                gdata.Container({
+                    q("device"): gdata.Leaf("r1"),
+                }),
+                gdata.Container({
+                    q("device"): gdata.Leaf("r2"),
+                }),
+            ]),
+        }),
+    })
+
+    expected = gdata.Container({
+        q("seen_r1"): gdata.Leaf(1),
+        q("seen_r2"): gdata.Leaf(2),
+    })
+
+    sess = stack.newsession()
+
+    def cont(_r: value):
+        testing.assertEqual(sess.below().get().prsrc(deterministic=True), expected.prsrc(deterministic=True))
+        t.success()
+
+    sess.edit_config(cfg, complete=cont)
+########################


### PR DESCRIPTION
route_fpath (former fpath), the FNode a transform uses to identify itself, is in routing form: a list entry collapses to an unnamed FNode carrying the compound key string, the shape List.linkage routes by. A publisher reused it to advertise itself in LinkUpdate, but that identity is then matched against the subscription build_target_links emits (canonical FNode for list entries) and used to prune. The two shapes diverge at list keys, so a leafref sw:link into a list entry (like in minisys l3vpn/site/endpoint/device -> /netinfra/router/name) never matched.

We now advertise the publisher identity in that same filter form instead, so that it is aligned with the subscriptions (link demands). This behavior is now also pinned down with unit tests as well as shown to work in minisys.