### PR TITLE
Upgrade netconf to the in-process SSH transport

### DIFF
--- a/Build.act
+++ b/Build.act
@@ -18,8 +18,8 @@ dependencies = {
     ),
     "netconf": (
         repo_url="https://github.com/stratoweave/netconf.git",
-        url="https://github.com/stratoweave/netconf/archive/ad457b8d1abb938756f65055b4915df614afb0ed.zip",
-        hash="N-V-__8AAByqAgC6Y8lDGfI-_elZBgVWe02AOKjJgivpjTnS"
+        url="https://github.com/stratoweave/netconf/archive/b5631509fd4f3fa66618b29ac485b5a29507a561.zip",
+        hash="N-V-__8AAKW2AgAt-Poh8ravHC7Dl9CLRRPmktZ2PIF6hfZI"
     ),
     "yang": (
         repo_url="https://github.com/stratoweave/acton-yang.git",

--- a/src/stratoweave.act
+++ b/src/stratoweave.act
@@ -2,7 +2,6 @@ import file
 import logging
 import lmdb
 import net
-import process
 
 import tmf.cfs
 
@@ -64,7 +63,7 @@ def main(sysspec: swapp.SysSpec, env: Env, http: bool=True):
     else:
         db = None
 
-    dev_registry = swdev.DeviceRegistry(sysspec.device_types, process.ProcessCap(env.cap), logh_dev)
+    dev_registry = swdev.DeviceRegistry(sysspec.device_types, net.TCPConnectCap(net.TCPCap(net.NetCap(env.cap))), logh_dev)
     cfs = sysspec.get_layers(dev_registry, logh_ttt, db)
     swapp.RfsReconf(dev_registry, cfs)
 

--- a/src/stratoweave/adapters/adapter.act
+++ b/src/stratoweave/adapters/adapter.act
@@ -1,5 +1,5 @@
 import logging
-import process
+import net
 import testing
 import xml
 
@@ -222,7 +222,7 @@ class DeviceAdapter(object):
     """Abstract base class for Device Adapters
     """
     _log_handler: logging.Handler
-    _pcap: ?process.ProcessCap
+    _connect_cap: ?net.TCPConnectCap
 
     def supports_mocking(self) -> bool:
         return False
@@ -257,10 +257,10 @@ class DeviceAdapter(object):
 
 
 class NoAdapter(DeviceAdapter):
-    def __init__(self, bundled_schema: object, log_handler, pcap):
+    def __init__(self, bundled_schema: object, log_handler, connect_cap):
         self._bundled_schema = bundled_schema
         self._log_handler = log_handler
-        self._pcap = pcap
+        self._connect_cap = connect_cap
         self._log = logging.Logger(self._log_handler)
 
     def set_dmc(self, new_dmc):
@@ -294,15 +294,15 @@ class NoAdapter(DeviceAdapter):
 class MockAdapter(DeviceAdapter):
     """Mock device adapter
     """
-    def __init__(self, on_connect: action(dict[str, ModCap], ?u64) -> None, bundled_schema: object, log_handler, pcap: ?process.ProcessCap):
+    def __init__(self, on_connect: action(dict[str, ModCap], ?u64) -> None, bundled_schema: object, log_handler, connect_cap: ?net.TCPConnectCap):
         self._on_connect = on_connect
         self._bundled_schema = bundled_schema
         self._log_handler = log_handler
-        self._pcap = pcap
+        self._connect_cap = connect_cap
         self._log = logging.Logger(self._log_handler)
         self._modset = {}
         self._dmc = None
-        self._driver = MockDriver(self._on_connect, self._bundled_schema, self._log_handler, self._pcap)
+        self._driver = MockDriver(self._on_connect, self._bundled_schema, self._log_handler, self._connect_cap)
 
     def set_dmc(self, new_dmc: DeviceMetaConfig):
         self._driver.set_dmc(new_dmc)
@@ -332,7 +332,7 @@ class MockAdapter(DeviceAdapter):
     def remove_subscriptions(self, owner_id: str):
         pass
 
-actor MockDriver(on_connect: action(dict[str, ModCap], ?u64) -> None, bundled_schema: object, log_handler: logging.Handler, pcap: ?process.ProcessCap):
+actor MockDriver(on_connect: action(dict[str, ModCap], ?u64) -> None, bundled_schema: object, log_handler: logging.Handler, connect_cap: ?net.TCPConnectCap):
     _log = logging.Logger(log_handler)
     _log.info("MockDriver starting up")
 

--- a/src/stratoweave/adapters/netconf.act
+++ b/src/stratoweave/adapters/netconf.act
@@ -1,6 +1,6 @@
 import hash.wyhash as wyhash
 import logging
-import process
+import net
 import time
 import xml
 
@@ -246,7 +246,7 @@ actor NetconfMockServer(pipe, log_handler: logging.Handler, capabilities: ?list[
             conf_schema = schema
 
 
-actor NetconfDriver(dev: swdev.DeviceMgr, bundled_schema: swdev.DeviceSchema, init_dmc: DeviceMetaConfig, schema_registry: swdev.SchemaRegistry, log_handler: logging.Handler, pcap: ?process.ProcessCap):
+actor NetconfDriver(dev: swdev.DeviceMgr, bundled_schema: swdev.DeviceSchema, init_dmc: DeviceMetaConfig, schema_registry: swdev.SchemaRegistry, log_handler: logging.Handler, connect_cap: ?net.TCPConnectCap):
     """NETCONF device adapter
 
     It is possible to configure a device using different transaction commit
@@ -295,7 +295,7 @@ actor NetconfDriver(dev: swdev.DeviceMgr, bundled_schema: swdev.DeviceSchema, in
     _con_log_handler.set_handler(log_handler)
     _con_log_handler.set_output_level(logging.TRACE if init_dmc.debug.connection else logging.WARNING)
 
-    system_mock = True if pcap is None else False
+    system_mock = True if connect_cap is None else False
 
     # The currently running configuration on the device (which in NMDA lingo is
     # the "intended configuration" of the device)
@@ -500,7 +500,7 @@ actor NetconfDriver(dev: swdev.DeviceMgr, bundled_schema: swdev.DeviceSchema, in
             ms = NetconfMockServer(pipes.server, _con_log_handler, _mock_capabilities_from_dmc(new_dmc) + bundled_caps, bundled_schema.src_dnode)
             mock_server = ms
             ms.set_oper_ds(_netconf_mock_default_oper_ds(), bundled_schema.oper_src_dnode)
-            client = netconf.Client(pcap,
+            client = netconf.Client(connect_cap,
                                     "dummy-address",
                                     0,
                                     username,
@@ -526,10 +526,10 @@ actor NetconfDriver(dev: swdev.DeviceMgr, bundled_schema: swdev.DeviceSchema, in
         # TODO: we only need o use a new client if connection parameters have
         # changed, other settings don't require a new client
 
-        if pcap is not None and password is not None:
+        if connect_cap is not None and password is not None:
             state = CONNECTING
             _log.debug(f"Setting up NETCONF client... {address} {port} {username} {password}")
-            c = netconf.Client(pcap, address, int(port), username, password,
+            c = netconf.Client(connect_cap, address, int(port), username, password,
                                skip_host_key_check=True,
                                on_connect=_on_connect,
                                on_notif=_on_notif,
@@ -1182,13 +1182,13 @@ class NetconfAdapter(DeviceAdapter):
     def supports_mocking(self) -> bool:
         return True
 
-    def __init__(self, dev: swdev.DeviceMgr, bundled_schema: swdev.DeviceSchema, init_dmc: DeviceMetaConfig, schema_registry: swdev.SchemaRegistry, log_handler, pcap: ?process.ProcessCap):
+    def __init__(self, dev: swdev.DeviceMgr, bundled_schema: swdev.DeviceSchema, init_dmc: DeviceMetaConfig, schema_registry: swdev.SchemaRegistry, log_handler, connect_cap: ?net.TCPConnectCap):
         self._dev = dev
         self._bundled_schema = bundled_schema
         self._schema_registry = schema_registry
         self._log_handler = log_handler
-        self._pcap = pcap
-        self._driver = NetconfDriver(self._dev, self._bundled_schema, init_dmc, self._schema_registry, self._log_handler, self._pcap)
+        self._connect_cap = connect_cap
+        self._driver = NetconfDriver(self._dev, self._bundled_schema, init_dmc, self._schema_registry, self._log_handler, self._connect_cap)
 
     def set_dmc(self, new_dmc: DeviceMetaConfig):
         self._driver.set_dmc(new_dmc)

--- a/src/stratoweave/device.act
+++ b/src/stratoweave/device.act
@@ -1,6 +1,7 @@
 import diff
 import json
 import logging
+import net
 import process
 import time
 import xml
@@ -46,7 +47,7 @@ class DeviceType(object):
     ## Adapter type, i.e. the DeviceAdapter subclass to use
     # TODO: why is @property needed here?
     @property
-    adapter_type: proc(DeviceMgr, DeviceSchema, DeviceMetaConfig, SchemaRegistry, logging.Handler, ?process.ProcessCap) -> DeviceAdapter
+    adapter_type: proc(DeviceMgr, DeviceSchema, DeviceMetaConfig, SchemaRegistry, logging.Handler, ?net.TCPConnectCap) -> DeviceAdapter
 
     bundled_schema: DeviceSchema
 
@@ -55,7 +56,7 @@ class DeviceType(object):
         self.adapter_type = adapter_type
         self.bundled_schema = DeviceSchema(name, src_dnode, oper_src_dnode)
 
-actor DeviceRegistry(dev_types: dict[str, DeviceType]={}, pcap: ?process.ProcessCap=None, log_handler: logging.Handler):
+actor DeviceRegistry(dev_types: dict[str, DeviceType]={}, connect_cap: ?net.TCPConnectCap=None, log_handler: logging.Handler):
     """Device Registry keeps track of all devices and hands out references to
     them based on name.
 
@@ -79,7 +80,7 @@ actor DeviceRegistry(dev_types: dict[str, DeviceType]={}, pcap: ?process.Process
 
     def get_or_create(name: str) -> DeviceMgr:
         if name not in devices:
-            devices[name] = DeviceMgr(dev_types, pcap, name, log_handler, reconf_cb, schema_registry, self)
+            devices[name] = DeviceMgr(dev_types, connect_cap, name, log_handler, reconf_cb, schema_registry, self)
         dev = devices[name]
         return dev
 
@@ -229,7 +230,7 @@ class DeviceTreeProvider(yang.gdata.TreeProvider):
 
 
 
-actor DeviceMgr(dev_types: dict[str, DeviceType]={}, pcap: ?process.ProcessCap=None, name: str, log_handler: logging.Handler, on_reconf: action(str) -> None, schema_registry: SchemaRegistry, device_registry: ?DeviceRegistry=None):
+actor DeviceMgr(dev_types: dict[str, DeviceType]={}, connect_cap: ?net.TCPConnectCap=None, name: str, log_handler: logging.Handler, on_reconf: action(str) -> None, schema_registry: SchemaRegistry, device_registry: ?DeviceRegistry=None):
     """Device Manager manages a device and represents that device, as an
     abstract device, in the system. Platform specific handling is implemented in
     the DeviceAdapter, i.e.  in subclasses of DeviceAdapter, like NetconfAdapter
@@ -284,7 +285,7 @@ actor DeviceMgr(dev_types: dict[str, DeviceType]={}, pcap: ?process.ProcessCap=N
     _log_handler.set_output_level(logging.DEBUG)
     _log = logging.Logger(_log_handler)
 
-    system_mock = True if pcap is None else False
+    system_mock = True if connect_cap is None else False
     _log.debug("DeviceMgr starting up", {"name": name, "system_mock": system_mock})
 
     # The device's meta configuration, like address, credentials, etc.
@@ -292,7 +293,7 @@ actor DeviceMgr(dev_types: dict[str, DeviceType]={}, pcap: ?process.ProcessCap=N
 
     # The bundled schema is compiled at build time and bundled with stratoweave
     var bundled_schema: DeviceSchema = DeviceSchema.mock()
-    var adapter: DeviceAdapter = MockAdapter(self.on_connect, bundled_schema, _log_handler, pcap) if system_mock else NoAdapter(bundled_schema, _log_handler, pcap)
+    var adapter: DeviceAdapter = MockAdapter(self.on_connect, bundled_schema, _log_handler, connect_cap) if system_mock else NoAdapter(bundled_schema, _log_handler, connect_cap)
 
     # The modules supported by the device.
     var modset: dict[str, ModCap] = {}
@@ -438,9 +439,9 @@ actor DeviceMgr(dev_types: dict[str, DeviceType]={}, pcap: ?process.ProcessCap=N
             return False
 
         def build_adapter(device_type: DeviceType, new_dmc: DeviceMetaConfig, effective_mock: bool) -> DeviceAdapter:
-            candidate = device_type.adapter_type(self, device_type.bundled_schema, new_dmc, schema_registry, _log_handler, pcap)
+            candidate = device_type.adapter_type(self, device_type.bundled_schema, new_dmc, schema_registry, _log_handler, connect_cap)
             if effective_mock and not candidate.supports_mocking():
-                return MockAdapter(self.on_connect, device_type.bundled_schema, _log_handler, pcap)
+                return MockAdapter(self.on_connect, device_type.bundled_schema, _log_handler, connect_cap)
             return candidate
 
         old_type = str(dmc.type) if dmc is not None else str(None)
@@ -457,9 +458,9 @@ actor DeviceMgr(dev_types: dict[str, DeviceType]={}, pcap: ?process.ProcessCap=N
                 if not need_new_adapter:
                     if effective_mock:
                         if isinstance(adapter, MockAdapter):
-                            need_new_adapter = pcap is not None
+                            need_new_adapter = connect_cap is not None
                         else:
-                            need_new_adapter = pcap is None or not adapter.supports_mocking()
+                            need_new_adapter = connect_cap is None or not adapter.supports_mocking()
                     else:
                         need_new_adapter = isinstance(adapter, MockAdapter)
 

--- a/src/stratoweave/test_device.act
+++ b/src/stratoweave/test_device.act
@@ -1,7 +1,7 @@
 """StratoWeave Device tests"""
 
 import logging
-import process
+import net
 import testing
 import xml
 import yang.adata
@@ -210,7 +210,7 @@ actor _test_netconf_double_commit(t: testing.EnvT):
         # Create DeviceMgr and NetconfAdapter
         dev_types = {}
         schema_registry = stratoweave.device.SchemaRegistry()
-        dev = stratoweave.device.DeviceMgr(dev_types, process.ProcessCap(t.env.auth), "test-device", t.log_handler, on_reconf, schema_registry)
+        dev = stratoweave.device.DeviceMgr(dev_types, net.TCPConnectCap(net.TCPCap(net.NetCap(t.env.cap))), "test-device", t.log_handler, on_reconf, schema_registry)
 
         # Create a simple device schema
         schema = stratoweave.device.DeviceSchema.mock()
@@ -219,7 +219,7 @@ actor _test_netconf_double_commit(t: testing.EnvT):
         test_dmc = create_test_dmc()
 
         # Create the NetconfAdapter - this will trigger connection
-        adapter = swna.NetconfAdapter(dev, schema, test_dmc, schema_registry, t.log_handler, process.ProcessCap(t.env.auth))
+        adapter = swna.NetconfAdapter(dev, schema, test_dmc, schema_registry, t.log_handler, net.TCPConnectCap(net.TCPCap(net.NetCap(t.env.cap))))
         if adapter is not None:
             adapter.set_dmc(test_dmc)
 
@@ -390,7 +390,7 @@ actor _test_netconf_adapter(t: testing.EnvT):
 
         # Create setup client
         setup_client = netconf.Client(
-            process.ProcessCap(t.env.auth),
+            net.TCPConnectCap(net.TCPCap(net.NetCap(t.env.cap))),
             test_address,
             test_port,
             test_username,
@@ -426,7 +426,7 @@ actor _test_netconf_adapter(t: testing.EnvT):
 
         # Create DeviceMgr and NetconfAdapter
         schema_registry = stratoweave.device.SchemaRegistry()
-        dev = stratoweave.device.DeviceMgr(dev_types, process.ProcessCap(t.env.auth), "test-device", t.log_handler, on_reconf, schema_registry)
+        dev = stratoweave.device.DeviceMgr(dev_types, net.TCPConnectCap(net.TCPCap(net.NetCap(t.env.cap))), "test-device", t.log_handler, on_reconf, schema_registry)
 
         # Create a simple device schema
         schema = stratoweave.device.DeviceSchema.mock()
@@ -435,7 +435,7 @@ actor _test_netconf_adapter(t: testing.EnvT):
         test_dmc = create_test_dmc()
 
         # Create the NetconfAdapter - this will trigger connection
-        local_adapter = swna.NetconfAdapter(dev, schema, test_dmc, schema_registry, t.log_handler, process.ProcessCap(t.env.auth))
+        local_adapter = swna.NetconfAdapter(dev, schema, test_dmc, schema_registry, t.log_handler, net.TCPConnectCap(net.TCPCap(net.NetCap(t.env.cap))))
         adapter = local_adapter
         if local_adapter is not None:
             local_adapter.set_dmc(test_dmc)
@@ -487,7 +487,7 @@ actor _test_netconf_adapter(t: testing.EnvT):
 
         # Create the verification client
         verification_client = netconf.Client(
-            process.ProcessCap(t.env.auth),
+            net.TCPConnectCap(net.TCPCap(net.NetCap(t.env.cap))),
             test_address,
             test_port,
             test_username,
@@ -561,7 +561,7 @@ actor _test_netconf_adapter_resync(t: testing.EnvT):
 
         # Create DeviceMgr and NetconfAdapter
         schema_registry = stratoweave.device.SchemaRegistry()
-        dev = stratoweave.device.DeviceMgr(dev_types, process.ProcessCap(t.env.auth), "test-device", t.log_handler, on_reconf, schema_registry)
+        dev = stratoweave.device.DeviceMgr(dev_types, net.TCPConnectCap(net.TCPCap(net.NetCap(t.env.cap))), "test-device", t.log_handler, on_reconf, schema_registry)
 
         # Create a simple device schema
         schema = stratoweave.device.DeviceSchema.mock()
@@ -570,7 +570,7 @@ actor _test_netconf_adapter_resync(t: testing.EnvT):
         test_dmc = create_test_dmc()
 
         # Create the NetconfAdapter - this will trigger connection
-        local_adapter = swna.NetconfAdapter(dev, schema, test_dmc, schema_registry, t.log_handler, process.ProcessCap(t.env.auth))
+        local_adapter = swna.NetconfAdapter(dev, schema, test_dmc, schema_registry, t.log_handler, net.TCPConnectCap(net.TCPCap(net.NetCap(t.env.cap))))
         adapter = local_adapter
         if local_adapter is not None:
             local_adapter.set_dmc(test_dmc)
@@ -597,7 +597,7 @@ actor _test_netconf_adapter_resync(t: testing.EnvT):
 #
 #    # Create a mock DeviceMgr
 #    dev_types = {}
-#    dev_mgr = swdev.DeviceMgr(dev_types, process.ProcessCap(t.env.auth), "test-device", t.log_handler,
+#    dev_mgr = swdev.DeviceMgr(dev_types, net.TCPConnectCap(net.TCPCap(net.NetCap(t.env.cap))), "test-device", t.log_handler,
 #                              lambda name: log.info("Reconf callback", {"name": name}))
 #
 #    # Create a simple device schema
@@ -679,7 +679,7 @@ actor _test_netconf_adapter_resync(t: testing.EnvT):
 #            log.info("Sending configuration to device")
 #            adapter.configure(on_configure_done, test_config)
 #
-#    dev_mgr = swdev.DeviceMgr(dev_types, process.ProcessCap(t.env.auth), "test-device", t.log_handler,
+#    dev_mgr = swdev.DeviceMgr(dev_types, net.TCPConnectCap(net.TCPCap(net.NetCap(t.env.cap))), "test-device", t.log_handler,
 #                              lambda name: log.info("Reconf callback", {"name": name}))
 #
 #    # Override the on_connect callback

--- a/src/stratoweave/test_device_crpd.act
+++ b/src/stratoweave/test_device_crpd.act
@@ -55,7 +55,7 @@ def create_crpd_gdata_config(seq) -> yang.gdata.Node:
 
     system = yang.gdata.Container({
         q("login"): yang.gdata.Container({
-            q("announcement"): yang.gdata.Leaf("string", f"Test banner from StratoWeave, seq: {seq}")
+            q("announcement"): yang.gdata.Leaf(f"Test banner from StratoWeave, seq: {seq}")
         })
     })
     config_children = {
@@ -78,6 +78,11 @@ actor _test_txid(t: testing.EnvT):
     3. Create a NetconfAdapter instance
     4. Send a configuration through the adapter TWICE to test check_txid efficiency
     5. Use a direct netconf.Client to verify the configuration was applied
+
+    JUNOS restarts sshd while committing system{} configuration, so the test
+    needs headroom for connect retries; run it with an extended deadline:
+
+        acton test --tag crpd --jobs 1 --max-time 10000 --module stratoweave.test_device_crpd
     """
     t.require("crpd")
     log = logging.Logger(t.log_handler)
@@ -85,6 +90,7 @@ actor _test_txid(t: testing.EnvT):
 
     var adapter: ?swna.NetconfAdapter = None
     var verification_client: ?netconf.Client = None
+    var verify_connect_attempts = 0
 
     # Create a mock DeviceMgr
     dev_types = {}
@@ -253,8 +259,15 @@ actor _test_txid(t: testing.EnvT):
 
         def on_verify_connect(c: netconf.Client, err: ?Exception):
             if err is not None:
-                log.error("Verification client failed to connect", {"error": str(err)})
-                t.failure(err)
+                # JUNOS restarts sshd as part of committing system{} config, so
+                # a connection right after a commit can land in the restart
+                # window and be dropped. Retry a few times before giving up.
+                if verify_connect_attempts < 5:
+                    log.info("Verification client connect failed, retrying", {"error": str(err)})
+                    after 0.5: start_verification_client()
+                else:
+                    log.error("Verification client failed to connect", {"error": str(err)})
+                    t.failure(err)
             else:
                 log.info("Verification client connected")
                 verification_client = c
@@ -292,17 +305,20 @@ actor _test_txid(t: testing.EnvT):
             else:
                 t.success()
 
-        # Create the verification client
-        verification_client = netconf.Client(
-            net.TCPConnectCap(net.TCPCap(net.NetCap(t.env.cap))),
-            test_address,
-            test_port,
-            test_username,
-            test_password,
-            on_connect=on_verify_connect,
-            log_handler=t.log_handler,
-            skip_host_key_check=True
-        )
+        def start_verification_client():
+            verify_connect_attempts += 1
+            verification_client = netconf.Client(
+                net.TCPConnectCap(net.TCPCap(net.NetCap(t.env.cap))),
+                test_address,
+                test_port,
+                test_username,
+                test_password,
+                on_connect=on_verify_connect,
+                log_handler=t.log_handler,
+                skip_host_key_check=True
+            )
+
+        start_verification_client()
 
     # Start the test by first setting up and verifying the server
     setup_test()

--- a/src/stratoweave/test_device_crpd.act
+++ b/src/stratoweave/test_device_crpd.act
@@ -1,7 +1,7 @@
 """StratoWeave Device tests"""
 
 import logging
-import process
+import net
 import testing
 import xml
 import yang.adata
@@ -176,7 +176,7 @@ actor _test_txid(t: testing.EnvT):
 
         # Create setup client
         setup_client = netconf.Client(
-            process.ProcessCap(t.env.auth),
+            net.TCPConnectCap(net.TCPCap(net.NetCap(t.env.cap))),
             test_address,
             test_port,
             test_username,
@@ -232,7 +232,7 @@ actor _test_txid(t: testing.EnvT):
 
         # Create DeviceMgr and NetconfAdapter
         schema_registry = stratoweave.device.SchemaRegistry()
-        dev = stratoweave.device.DeviceMgr(dev_types, process.ProcessCap(t.env.auth), "test-device", t.log_handler, on_reconf, schema_registry)
+        dev = stratoweave.device.DeviceMgr(dev_types, net.TCPConnectCap(net.TCPCap(net.NetCap(t.env.cap))), "test-device", t.log_handler, on_reconf, schema_registry)
 
         # Create a simple device schema
         schema = stratoweave.device.DeviceSchema.mock()
@@ -241,7 +241,7 @@ actor _test_txid(t: testing.EnvT):
         test_dmc = create_test_dmc()
 
         # Create the NetconfAdapter - this will trigger connection
-        local_adapter = swna.NetconfAdapter(dev, schema, test_dmc, schema_registry, t.log_handler, process.ProcessCap(t.env.auth))
+        local_adapter = swna.NetconfAdapter(dev, schema, test_dmc, schema_registry, t.log_handler, net.TCPConnectCap(net.TCPCap(net.NetCap(t.env.cap))))
         adapter = local_adapter
         if local_adapter is not None:
             local_adapter.set_dmc(test_dmc)
@@ -294,7 +294,7 @@ actor _test_txid(t: testing.EnvT):
 
         # Create the verification client
         verification_client = netconf.Client(
-            process.ProcessCap(t.env.auth),
+            net.TCPConnectCap(net.TCPCap(net.NetCap(t.env.cap))),
             test_address,
             test_port,
             test_username,
@@ -367,7 +367,7 @@ actor _test_direct_get_config_with_filter(t: testing.EnvT):
 
     # Create the client and connect
     client = netconf.Client(
-        process.ProcessCap(t.env.auth),
+        net.TCPConnectCap(net.TCPCap(net.NetCap(t.env.cap))),
         test_address,
         test_port,
         test_username,

--- a/src/stratoweave/test_devicemgr_netconf.act
+++ b/src/stratoweave/test_devicemgr_netconf.act
@@ -1,7 +1,7 @@
 """DeviceMgr tests for adapter-level NETCONF mocking."""
 
 import logging
-import process
+import net
 import testing
 import xml
 import yang
@@ -110,7 +110,7 @@ def new_netconf_mock_device_mgr(t: testing.EnvT, name: str, on_reconf: action(st
     }
 
     schema_registry = stratoweave.device.SchemaRegistry()
-    dev = stratoweave.device.DeviceMgr(dev_types, process.ProcessCap(t.env.auth), name, t.log_handler, on_reconf, schema_registry)
+    dev = stratoweave.device.DeviceMgr(dev_types, net.TCPConnectCap(net.TCPCap(net.NetCap(t.env.cap))), name, t.log_handler, on_reconf, schema_registry)
     dev.set_dmc(make_netconf_mock_dmc(name))
     return dev
 


### PR DESCRIPTION
Upgrades netconf to the version that connects through the acton-ssh package: an in-process libssh client channel behind the shared pipe.Pipe interface, replacing the external ssh binary spawned via process + sshpass. The capability threaded through DeviceRegistry, DeviceMgr and the adapters changes from ?process.ProcessCap to ?net.TCPConnectCap (renamed pcap to connect_cap); None still selects mock mode.

Also fixes the crpd txid test, which was broken in two unrelated ways: the config payload used the old yang.gdata.Leaf(valtype, val) calling convention, putting the banner text in the namespace slot so JUNOS rejected the edit-config as a syntax error, and the verification client connected right after a commit, racing the sshd restart JUNOS performs when committing system{} configuration. The payload is fixed and the verification connect now retries; the test docstring documents running with --max-time headroom.

The full local suite passes, and the crpd-tagged tests pass repeatedly against a live cRPD 24.4r1.9 through the new SSH stack.
