### PR TITLE
Remove redundant TransformFunction test wrapper

### DIFF
--- a/src/test_ttt_transform.act
+++ b/src/test_ttt_transform.act
@@ -966,14 +966,6 @@ class LinkedRouterSubscriber(ttt.TransformFunction):
                         out_children[q("seen_{rname}")] = id_leaf
         return gdata.Container(out_children), None
 
-# A linkable publisher whose own downstream output is irrelevant to the link,
-# so it emits nothing. (A PassThrough here would echo each entry's flat
-# {name,id} to the shared sink root, where two list entries collide on those
-# leaves and abort the commit.)
-class RouterPublisher(ttt.TransformFunction):
-    def transform_wrapper(self, cfg, linked, memory, dynstate):
-        return gdata.Container(), None
-
 # A faithful copy of the router leafref portion of the generated
 # _build_target_links_l3vpn__l3vpn_entry: it reads the 'conf' parameter,
 # walking the endpoint list and rendering one router demand per device value.
@@ -998,7 +990,7 @@ actor link_into_list_delivers_only_referenced_entry(t: testing.AsyncT):
         ttt.Container({
             q("netinfra"): ttt.Container({
                 q("router"): ttt.List(
-                    ttt.Transform(RouterPublisher),
+                    ttt.Transform(ttt.TransformFunction),
                     [q("name")],
                 ),
             }),
@@ -1050,7 +1042,7 @@ actor link_into_list_delivers_all_referenced_entries(t: testing.AsyncT):
         ttt.Container({
             q("netinfra"): ttt.Container({
                 q("router"): ttt.List(
-                    ttt.Transform(RouterPublisher),
+                    ttt.Transform(ttt.TransformFunction),
                     [q("name")],
                 ),
             }),
@@ -1144,7 +1136,7 @@ actor link_subscribe_does_not_rerun_existing_subscribers(t: testing.AsyncT):
     stack = ttt.Layer("top",
         ttt.Container({
             q("network"): ttt.Container({
-                q("global-settings"): ttt.Transform(RouterPublisher),
+                q("global-settings"): ttt.Transform(ttt.TransformFunction),
             }),
             q("service"): ttt.List(
                 ttt.Transform(CountingLinkedSubscriber, None, _link_to_global_settings),


### PR DESCRIPTION
The default behavior of TransformFunction is already "silent" in that it emits an empty container config and no memory.