### PR TITLE
Add a northbound NETCONF server

### DIFF
--- a/Build.act
+++ b/Build.act
@@ -21,6 +21,11 @@ dependencies = {
         url="https://github.com/stratoweave/netconf/archive/66309f280aa8f791c0d0612b845370358424de67.zip",
         hash="N-V-__8AAPi2AgC06C7FAoZ4ZPwlTG9zaVy_To7yEtVAM7Yz"
     ),
+    "ssh": (
+        repo_url="https://github.com/actonlang/acton-ssh",
+        url="https://github.com/actonlang/acton-ssh/archive/cd1c33024e2e424e8bae7836eae6fd29b08572cc.zip",
+        hash="N-V-__8AAApQBABuq3YxmCk3cwwateRArP1geYyWddS1bJCD"
+    ),
     "yang": (
         repo_url="https://github.com/stratoweave/acton-yang.git",
         url="https://github.com/stratoweave/acton-yang/archive/56ff3c3e18512c59ffb4ac7abd6d33d8f338495b.zip",

--- a/src/app.act
+++ b/src/app.act
@@ -29,12 +29,20 @@ class AppArgs(value):
     config_files: list[str]
     db_path: ?str
     http_port: int
+    netconf_port: int
+    netconf_host_key_path: ?str
+    netconf_user: str
+    netconf_password: str
     exit_on_done: bool
 
-    def __init__(self, config_files: list[str]=[], db_path: ?str=None, http_port: int=80, exit_on_done: bool=False):
+    def __init__(self, config_files: list[str]=[], db_path: ?str=None, http_port: int=80, netconf_port: int=830, netconf_host_key_path: ?str=None, netconf_user: str="admin", netconf_password: str="admin", exit_on_done: bool=False):
         self.config_files = config_files
         self.db_path = db_path
         self.http_port = http_port
+        self.netconf_port = netconf_port
+        self.netconf_host_key_path = netconf_host_key_path
+        self.netconf_user = netconf_user
+        self.netconf_password = netconf_password
         self.exit_on_done = exit_on_done
 
 
@@ -44,12 +52,17 @@ class AppArgs(value):
         p.add_arg("file", "Config XML file(s)", False, "+")
         p.add_option("db", "str", default="", help="LMDB directory for TTT persistence")
         p.add_option("http-port", "int", default=80, help="HTTP listen port")
+        p.add_option("netconf-port", "int", default=830, help="NETCONF SSH listen port")
+        p.add_option("netconf-host-key", "str", default="", help="SSH host key file for NETCONF; ephemeral in-memory key if unset")
+        p.add_option("netconf-user", "str", default="admin", help="NETCONF SSH username (v1 static credential)")
+        p.add_option("netconf-password", "str", default="admin", help="NETCONF SSH password (v1 static credential)")
         p.add_bool("exit-on-done", "Exit after startup config has been applied")
 
         try:
             args = p.parse(argv)
             db_path = args.get_str("db")
-            return AppArgs(args.get_strlist("file"), db_path if db_path != "" else None, args.get_int("http-port"), args.get_bool("exit-on-done"))
+            host_key = args.get_str("netconf-host-key")
+            return AppArgs(args.get_strlist("file"), db_path if db_path != "" else None, args.get_int("http-port"), args.get_int("netconf-port"), host_key if host_key != "" else None, args.get_str("netconf-user"), args.get_str("netconf-password"), args.get_bool("exit-on-done"))
         except argparse.PrintUsage as exc:
             print(exc.error_message)
             exit(0)
@@ -124,8 +137,9 @@ actor StartupConfigApplier(config_files: list[str], exit_on_done: bool, top_sche
         after 0.5: _apply()
 
 
-actor StartupBootstrap(cfs: ttt.Layer, restore_from_db: bool, start_runtime: proc() -> None, exit: action(int) -> None, log_handler: logging.Handler):
+actor StartupBootstrap(cfs: ttt.Layer, restore_from_db: bool, netconf_host_key_path: ?str, rfcap: file.ReadFileCap, start_runtime: proc(?str) -> None, exit: action(int) -> None, log_handler: logging.Handler):
     var log = logging.Logger(log_handler)
+    var _netconf_host_key: ?str = None
 
     def _recompute_done(result):
         if isinstance(result, Exception):
@@ -133,11 +147,24 @@ actor StartupBootstrap(cfs: ttt.Layer, restore_from_db: bool, start_runtime: pro
             exit(1)
             return
         log.info("Restored TTT state reconciled")
-        start_runtime()
+        start_runtime(_netconf_host_key)
 
     def _run():
+        # The NETCONF SSH layer wants host-key material, not a path, so read the
+        # configured key file here (before launching the runtime) and forward it.
+        hkp = netconf_host_key_path
+        if hkp is not None:
+            try:
+                f = file.ReadFile(rfcap, hkp)
+                _netconf_host_key = (await async f.read()).decode()
+                f.close()
+            except Exception as e:
+                log.error("Error reading NETCONF host key", {"path": hkp, "error": e})
+                exit(1)
+                return
+
         if not restore_from_db:
-            start_runtime()
+            start_runtime(_netconf_host_key)
             return
 
         log.info("Loading persisted TTT state")

--- a/src/lib.act
+++ b/src/lib.act
@@ -8,10 +8,11 @@ import tmf.cfs
 import app as swapp
 import device as swdev
 import http_server as swhttp
+import netconf_server as swnetconf
 import test_rig as swts
 
 
-def main(sysspec: swapp.SysSpec, env: Env, http: bool=True):
+def main(sysspec: swapp.SysSpec, env: Env, http: bool=True, netconf: bool=True):
     """Start a production StratoWeave application.
 
     This entrypoint wires together the standard runtime components used by an
@@ -46,6 +47,10 @@ def main(sysspec: swapp.SysSpec, env: Env, http: bool=True):
     logh_http.set_handler(logh)
     logh_http.set_output_level(logging.DEBUG)
 
+    logh_netconf = logging.Handler("NETCONF")
+    logh_netconf.set_handler(logh)
+    logh_netconf.set_output_level(logging.DEBUG)
+
     logh_ttt = logging.Handler("TTT")
     logh_ttt.set_handler(logh)
     logh_ttt.set_output_level(logging.INFO)
@@ -67,16 +72,20 @@ def main(sysspec: swapp.SysSpec, env: Env, http: bool=True):
     cfs = sysspec.get_layers(dev_registry, logh_ttt, db)
     swapp.RfsReconf(dev_registry, cfs)
 
-    def start_runtime():
+    def start_runtime(netconf_host_key: ?str):
         if http:
             tcpl_cap = net.TCPListenCap(net.TCPCap(net.NetCap(env.cap)))
             enable_tmf = len(tmf.cfs.services_from_schema(top_schema)) > 0
             swhttp.HttpServer(tcpl_cap, top_schema=top_schema, cfs=cfs, dev_registry=dev_registry, schema_for_layer=sysspec.schema_for_layer, enable_tmf_api=enable_tmf, log_handler=logh_http, port=args.http_port)
 
+        if netconf:
+            nc_listen_cap = net.TCPListenCap(net.TCPCap(net.NetCap(env.cap)))
+            swnetconf.NetconfServer(nc_listen_cap, log_handler=logh_netconf, top_schema=top_schema, cfs=cfs, port=args.netconf_port, username=args.netconf_user, password=args.netconf_password, host_key=netconf_host_key)
+
         swapp.StartupConfigApplier(args.config_files, args.exit_on_done, top_schema, cfs, env.exit, rfcap, logh)
         log.info("StratoWeave running..")
 
-    swapp.StartupBootstrap(cfs, db is not None, start_runtime, env.exit, logh)
+    swapp.StartupBootstrap(cfs, db is not None, args.netconf_host_key_path if netconf else None, rfcap, start_runtime, env.exit, logh)
 
 def test_main(sysspec: swapp.SysSpec, log_handler: logging.Handler) -> swts.TestRig:
     """Create a `TestRig` for actor-based StratoWeave tests.

--- a/src/netconf_server.act
+++ b/src/netconf_server.act
@@ -1,0 +1,266 @@
+import logging
+import net
+import std.xml as xml
+
+import netconf
+import ssh.pipe as sshpipe
+
+import ttt as ttt
+import yang.gdata as ygdata
+import yang.schema as yschema
+import yang.xml as yxml
+
+
+# NETCONF base namespace, used on the <data> wrapper of get/get-config replies.
+NS_NC_1_0 = "urn:ietf:params:xml:ns:netconf:base:1.0"
+CAP_WRITABLE_RUNNING = "urn:ietf:params:netconf:capability:writable-running:1.0"
+
+
+def build_capabilities(schema: yschema.DRoot) -> list[str]:
+    """Build the NETCONF <hello> capability list for a top-level schema.
+
+    Advertises NETCONF base 1.0/1.1 and writable-running, plus one module
+    capability URI (namespace?module=NAME[&revision=REV]) per module in the
+    schema's metadata, so a client can discover every served namespace from the
+    hello exchange.
+    """
+    caps = [netconf.CAP_NC_1_0, netconf.CAP_NC_1_1, CAP_WRITABLE_RUNNING]
+    for ns in sorted(schema.module_metadata.keys()):
+        meta = schema.module_metadata[ns]
+        uri = "{ns}?module={meta.module}"
+        rev = meta.revision
+        if rev is not None:
+            uri = uri + "&revision={rev}"
+        caps.append(uri)
+    return caps
+
+
+actor StaticAuthChecker(expected_user: str, expected_password: str):
+    """An SSH authentication check for a single static username + password.
+
+    `check` has the asynchronous (continuation-passing) shape that
+    SshPipeListener expects: it inspects the offered credentials and calls
+    respond(True) to accept or respond(False) to reject. The async shape is the
+    point -- a real implementation can reach out to an authentication service
+    (RADIUS/LDAP/TACACS+) and call respond from that IO callback; this static
+    one answers immediately. Public-key attempts (password None) are rejected.
+    """
+    def check(user: str, password: ?str, pubkey: ?bytes, respond: action(bool) -> None):
+        respond(user == expected_user and password == expected_password)
+
+
+actor NetconfSession(pipe, log_handler: logging.Handler, top_schema: yschema.DRoot, cfs: ttt.Layer, capabilities: ?list[str]=None, on_close: ?action(NetconfSession) -> None=None):
+    """A single NETCONF session driving the configuration tree.
+
+    Wraps a netconf.Server bound to `pipe` (one transport channel) and handles
+    its RPCs against the `cfs` layer. v1 supports writable-running only:
+    get/get-config read the running datastore and edit-config applies straight
+    into it; everything else -- candidate's commit/discard-changes and
+    lock/unlock -- is rejected with operation-not-supported rather than faked.
+    Incoming <config> is parsed against `top_schema`, carrying per-node NETCONF
+    operation= semantics (merge/create/delete/remove/replace) into the edit.
+
+    `on_close`, if given, is called with this session when its transport drops,
+    so the owner can release its reference and let the session be reclaimed.
+    """
+    _log = logging.Logger(log_handler)
+
+    def _extract_filter(op: xml.Node) -> (?xml.Node, ?str):
+        for child in op.children:
+            if isinstance(child, xml.Node) and child.tag == "filter":
+                filter_type = None
+                for attr_name, attr_val in child.attributes:
+                    if attr_name == "type" or attr_name.split(":", -1)[-1] == "type":
+                        filter_type = attr_val
+                        break
+                if filter_type is None:
+                    filter_type = "subtree"
+                return (child, filter_type)
+        return (None, None)
+
+    def _extract_config(op: xml.Node) -> ?xml.Node:
+        for child in op.children:
+            if isinstance(child, xml.Node) and child.tag == "config":
+                return child
+        return None
+
+    def _expect_xml_node(n: ?xml.Node, ctx: str) -> xml.Node:
+        if n is not None:
+            return n
+        raise ValueError("expected xml.Node for: {ctx}")
+
+    def _datastore(op: xml.Node, wrapper_tag: str) -> ?str:
+        # The datastore named inside <target>/<source> (e.g. "running"), or None
+        # if the wrapper or its datastore element is absent. v1 only serves
+        # running, so callers require this to equal "running".
+        for child in op.children:
+            if isinstance(child, xml.Node) and child.tag == wrapper_tag:
+                for ds in child.children:
+                    if isinstance(ds, xml.Node):
+                        return ds.tag
+        return None
+
+    def _read(filter_node: ?xml.Node) -> list[xml.Node]:
+        filt: ?ygdata.FNode = None
+        if filter_node is not None:
+            filt = yxml.from_filter_xml(top_schema, filter_node)
+        data = cfs.newsession().get_data(filt)
+        if data is not None:
+            return data.to_xml(deterministic=True)
+        return []
+
+    def _parse_config(config_node: xml.Node) -> ygdata.Container:
+        # Wrap the <config> children in a <data> root and parse against the top
+        # schema. yxml.from_xml carries per-node NETCONF operation= attributes
+        # (merge/create/delete/remove/replace) into the gdata diff, which TTT's
+        # edit_config honors directly.
+        data_children: list[xml.Node] = []
+        for child in config_node.children:
+            if isinstance(child, xml.Node):
+                data_children.append(child)
+        wrapper = xml.Node("data", children=data_children)
+        return yxml.from_xml(top_schema, wrapper, loose=True)
+
+    def on_rpc(s: netconf.Server, message_id: str, op: xml.Node):
+        _log.debug("NETCONF rpc", {"message_id": message_id, "op": op.tag})
+
+        if op.tag == "get" or op.tag == "get-config":
+            if op.tag == "get-config" and _datastore(op, "source") != "running":
+                s.send_error(message_id, "operation-not-supported", "Only the running datastore is supported")
+                return
+            filter_node, filter_type = _extract_filter(op)
+            if filter_type is not None and filter_type != "subtree":
+                s.send_error(message_id, "operation-not-supported", "Unsupported filter type: {filter_type}")
+                return
+            data_children: list[xml.Node] = []
+            try:
+                data_children = _read(filter_node)
+            except Exception as e:
+                s.send_error(message_id, "invalid-value", "Failed to read datastore: {e}")
+                return
+            s.send_reply(message_id, [xml.Node("data", [(None, NS_NC_1_0)], children=data_children)])
+        elif op.tag == "edit-config":
+            if _datastore(op, "target") != "running":
+                s.send_error(message_id, "operation-not-supported", "Only the running datastore is writable")
+                return
+            config_node = _extract_config(op)
+            if config_node is None:
+                s.send_error(message_id, "missing-element", "Missing <config> in <edit-config>")
+                return
+            cfg = _expect_xml_node(config_node, "edit-config <config>")
+
+            def _on_done(result):
+                if isinstance(result, Exception):
+                    s.send_error(message_id, "operation-failed", "edit-config failed: {result}")
+                else:
+                    s.send_ok(message_id)
+            try:
+                # yxml.from_xml carries per-node NETCONF operation= attributes into
+                # the gdata diff; the `complete` callback fires <ok> only after the
+                # edit has been applied, persisted and committed through the TTT pipeline.
+                diff = _parse_config(cfg)
+                cfs.newsession().edit_config(diff, None, _on_done)
+            except Exception as e:
+                s.send_error(message_id, "invalid-value", "Failed to apply edit-config: {e}")
+                return
+        else:
+            # Everything beyond get/get-config/edit-config (close-session is
+            # handled inside netconf.Server). This includes candidate's commit/
+            # discard-changes and lock/unlock, which we deliberately do not fake:
+            # writable-running auto-commits every edit, and a no-op lock would
+            # hand out an exclusion guarantee we cannot keep.
+            s.send_error(message_id, "operation-not-supported", "Unsupported RPC operation: {op.tag}")
+
+    def _on_conn(s: netconf.Server, err: ?Exception):
+        # on_connect doubles as the disconnect signal: err is None on connect and
+        # non-None when the transport drops (channel close / EOF). On drop, tell
+        # the owner so it can release its reference and let us be reclaimed.
+        if err is not None:
+            cb = on_close
+            if cb is not None:
+                cb(self)
+
+    var server: netconf.Server = netconf.Server(pipe=pipe, on_connect=_on_conn, on_rpc=on_rpc, capabilities=capabilities, log_handler=log_handler)
+
+
+actor NetconfServer(
+    listen_cap: net.TCPListenCap,
+    log_handler: logging.Handler,
+    top_schema: yschema.DRoot,
+    cfs: ttt.Layer,
+    address: str = "::",
+    port: int = 830,
+    username: str = "admin",
+    password: str = "admin",
+    auth_check: ?action(str, ?str, ?bytes, action(bool) -> None) -> None = None,
+    host_key: ?str = None,
+    on_listen: ?action(?Exception) -> None = None,
+):
+    """Northbound NETCONF server over SSH.
+
+    Listens for SSH connections on `port` and serves the `netconf` subsystem;
+    each accepted channel becomes an independent NetconfSession sharing the `cfs`
+    configuration tree. `host_key` is the SSH host private key material (PEM /
+    OpenSSH text); when None the SSH library generates an ephemeral in-memory
+    host key per run. Reading a key from disk is the caller's job.
+
+    Authentication defaults to a static username/password check
+    (StaticAuthChecker). Pass `auth_check` to plug in any checker with the same
+    asynchronous shape -- e.g. one validating credentials against an external
+    service over the network before responding.
+    """
+    _log = logging.Logger(log_handler)
+    _capabilities = build_capabilities(top_schema)
+    _auth = auth_check if auth_check is not None else StaticAuthChecker(username, password).check
+    var _sessions: list[NetconfSession] = []
+    var listener: ?sshpipe.SshPipeListener = None
+
+    def _on_listen(l: sshpipe.SshPipeListener, err: ?Exception):
+        if err is not None:
+            # Non-fatal: a failed NETCONF bind must not take down the rest of the app.
+            _log.error("NETCONF SSH listen error", {"address": address, "port": port, "error": err})
+        else:
+            _log.info("NETCONF server listening", {"address": address, "port": port})
+        cb = on_listen
+        if cb is not None:
+            cb(err)
+
+    def _session_closed(s: NetconfSession):
+        # Drop the closed session so it (and its netconf.Server + pipe) can be
+        # reclaimed; without this _sessions would grow unbounded.
+        remaining: list[NetconfSession] = []
+        for x in _sessions:
+            if not (x is s):
+                remaining.append(x)
+        _sessions = remaining
+        _log.debug("NETCONF session closed", {"active_sessions": len(remaining)})
+
+    def _on_accept(l: sshpipe.SshPipeListener, p: sshpipe.SshListenPipe):
+        _log.info("NETCONF session accepted")
+        _sessions.append(NetconfSession(p, log_handler, top_schema, cfs, _capabilities, on_close=_session_closed))
+
+    listener = sshpipe.SshPipeListener(
+        listen_cap,
+        address=address,
+        port=port,
+        on_listen=_on_listen,
+        on_accept=_on_accept,
+        auth_check=_auth,
+        subsystem="netconf",
+        host_key=host_key,
+        log_handler=log_handler)
+
+    def bound_port() -> int:
+        l = listener
+        if l is not None:
+            return int(l.bound_port())
+        raise ValueError("NETCONF server is not listening")
+
+    def active_sessions() -> int:
+        return len(_sessions)
+
+    def close():
+        l = listener
+        if l is not None:
+            l.close()
+        listener = None

--- a/src/test_netconf_server.act
+++ b/src/test_netconf_server.act
@@ -1,0 +1,353 @@
+"""Integration tests for the northbound NETCONF server.
+
+Two angles, both against a real TTT layer:
+  - a netconf.Client drives a NetconfSession over an in-process pipe pair, which
+    exercises the RPC -> TTT logic (edit-config round trip, per-node
+    operation= semantics) without any transport; and
+  - a netconf.Client connects to a full NetconfServer over a real loopback SSH
+    transport, exercising listen/accept, password auth, the ephemeral host key,
+    and framing end to end.
+"""
+
+import logging
+import net
+import testing
+import std.xml as xml
+
+import netconf
+
+import ttt as ttt
+import yang
+import yang.gdata as gdata
+import yang.schema as yschema
+
+import netconf_server as swnetconf
+
+
+DEMO_NS = "urn:demo"
+DEMO_YANG = r"""module demo {
+  yang-version "1.1";
+  namespace "urn:demo";
+  prefix d;
+  container system {
+    leaf hostname { type string; }
+    leaf location { type string; }
+  }
+}"""
+
+
+def _q(n: str) -> gdata.Id:
+    return gdata.Id(DEMO_NS, n)
+
+
+def _demo_schema() -> yschema.DRoot:
+    return yang.compile([DEMO_YANG])
+
+
+def _demo_layer() -> ttt.Layer:
+    # Top container matches the schema's top-level `system` node; PassThrough
+    # retains whatever config is written so get-config can read it back.
+    return ttt.Layer("top", ttt.Container({
+        _q("system"): ttt.Transform(ttt.PassThrough),
+    }), None)
+
+
+def _leaf_text_from_reply(reply: ?xml.Node, leaf_name: str) -> ?str:
+    """Dig <rpc-reply><data><system><LEAF> out of a get-config reply."""
+    if reply is not None:
+        for data in reply.children:
+            if data.tag == "data":
+                for system in data.children:
+                    if system.tag == "system":
+                        for leaf in system.children:
+                            if leaf.tag == leaf_name:
+                                return leaf.text
+    return None
+
+
+actor _test_edit_config_roundtrip(t: testing.AsyncT):
+    """edit-config (merge) into running, then read it back via get-config."""
+    lh = logging.Handler("nctest")
+    schema = _demo_schema()
+    layer = _demo_layer()
+    caps = swnetconf.build_capabilities(schema)
+
+    pipes = netconf.actor_pipe_pair()
+    server = swnetconf.NetconfSession(pipes.server, lh, schema, layer, caps)
+
+    var done = False
+    def fail(e: Exception):
+        if not done:
+            done = True
+            t.failure(e)
+
+    def _on_get(c: netconf.Client, reply: ?xml.Node, err: ?netconf.NetconfError):
+        if err is not None:
+            fail(err)
+            return
+        hostname = _leaf_text_from_reply(reply, "hostname")
+        location = _leaf_text_from_reply(reply, "location")
+        if hostname != "r1":
+            fail(ValueError("expected hostname r1, got {hostname}"))
+            return
+        if location != "lab":
+            fail(ValueError("expected location lab, got {location}"))
+            return
+        if not done:
+            done = True
+            t.success()
+
+    def _on_edit(c: netconf.Client, err: ?netconf.NetconfError):
+        if err is not None:
+            fail(err)
+            return
+        c.get_config(_on_get, "running")
+
+    def _on_connect(c: netconf.Client, e: ?Exception):
+        if e is not None:
+            fail(ValueError("client connect failed: {e}"))
+            return
+        config = xml.decode('<system xmlns="urn:demo"><hostname>r1</hostname><location>lab</location></system>')
+        c.edit_config([config], _on_edit)
+
+    client = netconf.Client(None, "mock", 0, "admin", "admin", None, _on_connect, None, True, lh, pipe=pipes.client)
+
+    after 5.0: fail(ValueError("timed out waiting for NETCONF round trip"))
+
+
+actor _test_edit_config_delete(t: testing.AsyncT):
+    """A second edit-config with operation="delete" removes a leaf."""
+    lh = logging.Handler("nctest")
+    schema = _demo_schema()
+    layer = _demo_layer()
+    caps = swnetconf.build_capabilities(schema)
+
+    pipes = netconf.actor_pipe_pair()
+    server = swnetconf.NetconfSession(pipes.server, lh, schema, layer, caps)
+
+    var done = False
+    def fail(e: Exception):
+        if not done:
+            done = True
+            t.failure(e)
+
+    def _on_get_after_delete(c: netconf.Client, reply: ?xml.Node, err: ?netconf.NetconfError):
+        if err is not None:
+            fail(err)
+            return
+        # hostname deleted; location must remain.
+        if _leaf_text_from_reply(reply, "hostname") is not None:
+            fail(ValueError("expected hostname to be deleted"))
+            return
+        if _leaf_text_from_reply(reply, "location") != "lab":
+            fail(ValueError("expected location lab to survive delete"))
+            return
+        if not done:
+            done = True
+            t.success()
+
+    def _on_delete(c: netconf.Client, err: ?netconf.NetconfError):
+        if err is not None:
+            fail(err)
+            return
+        c.get_config(_on_get_after_delete, "running")
+
+    def _on_seed(c: netconf.Client, err: ?netconf.NetconfError):
+        if err is not None:
+            fail(err)
+            return
+        # Delete just the hostname leaf via nc:operation="delete". NB: the xmlns:nc
+        # declaration must sit on the element carrying the operation attribute --
+        # yang.xml._get_netconf_operation does not resolve prefixes declared on an
+        # ancestor (see its disabled _test_get_nc_op_pref_ancestor, "TODO: fix!").
+        del_xml = xml.decode('<system xmlns="urn:demo"><hostname xmlns:nc="urn:ietf:params:xml:ns:netconf:base:1.0" nc:operation="delete">r1</hostname></system>')
+        c.edit_config([del_xml], _on_delete)
+
+    def _on_connect(c: netconf.Client, e: ?Exception):
+        if e is not None:
+            fail(ValueError("client connect failed: {e}"))
+            return
+        seed = xml.decode('<system xmlns="urn:demo"><hostname>r1</hostname><location>lab</location></system>')
+        c.edit_config([seed], _on_seed)
+
+    client = netconf.Client(None, "mock", 0, "admin", "admin", None, _on_connect, None, True, lh, pipe=pipes.client)
+
+    after 5.0: fail(ValueError("timed out waiting for NETCONF delete round trip"))
+
+
+actor _test_edit_config_rejects_nonrunning_target(t: testing.AsyncT):
+    """edit-config to a datastore other than running is refused, not applied."""
+    lh = logging.Handler("nctest")
+    schema = _demo_schema()
+    layer = _demo_layer()
+    caps = swnetconf.build_capabilities(schema)
+
+    pipes = netconf.actor_pipe_pair()
+    server = swnetconf.NetconfSession(pipes.server, lh, schema, layer, caps)
+
+    var done = False
+    def fail(e: Exception):
+        if not done:
+            done = True
+            t.failure(e)
+
+    def _on_edit(c: netconf.Client, err: ?netconf.NetconfError):
+        # We asked to write the candidate datastore, which v1 does not serve, so
+        # the server must reject it rather than silently apply to running.
+        if err is not None:
+            if not done:
+                done = True
+                t.success()
+        else:
+            fail(ValueError("expected edit-config target=candidate to be rejected"))
+
+    def _on_connect(c: netconf.Client, e: ?Exception):
+        if e is not None:
+            fail(ValueError("client connect failed: {e}"))
+            return
+        config = xml.decode('<system xmlns="urn:demo"><hostname>nope</hostname></system>')
+        c.edit_config([config], _on_edit, datastore="candidate")
+
+    client = netconf.Client(None, "mock", 0, "admin", "admin", None, _on_connect, None, True, lh, pipe=pipes.client)
+
+    after 5.0: fail(ValueError("timed out waiting for edit-config rejection"))
+
+
+actor _test_ssh_edit_config_roundtrip(t: testing.EnvT):
+    """Full NetconfServer over a real loopback SSH transport.
+
+    Stands up a NetconfServer on an ephemeral port (default admin/admin auth,
+    ephemeral host key), connects a netconf.Client over SSH, and runs an
+    edit-config -> get-config round trip -- exercising listen/accept, auth and
+    framing, not just the RPC handler.
+    """
+    lh = t.log_handler
+    schema = _demo_schema()
+    layer = _demo_layer()
+    listen_cap = net.TCPListenCap(net.TCPCap(net.NetCap(t.env.cap)))
+    connect_cap = net.TCPConnectCap(net.TCPCap(net.NetCap(t.env.cap)))
+
+    var done = False
+    var server: ?swnetconf.NetconfServer = None
+
+    def _teardown():
+        s = server
+        if s is not None:
+            s.close()
+
+    def fail(e: Exception):
+        if not done:
+            done = True
+            _teardown()
+            t.failure(e)
+
+    def _on_get(c: netconf.Client, reply: ?xml.Node, err: ?netconf.NetconfError):
+        if err is not None:
+            fail(err)
+            return
+        if _leaf_text_from_reply(reply, "hostname") != "r1":
+            fail(ValueError("expected hostname r1 over SSH"))
+            return
+        if not done:
+            done = True
+            c.close(None)
+            _teardown()
+            t.success()
+
+    def _on_edit(c: netconf.Client, err: ?netconf.NetconfError):
+        if err is not None:
+            fail(err)
+            return
+        c.get_config(_on_get, "running")
+
+    def _on_connect(c: netconf.Client, e: ?Exception):
+        if e is not None:
+            fail(ValueError("SSH connect failed: {e}"))
+            return
+        config = xml.decode('<system xmlns="urn:demo"><hostname>r1</hostname></system>')
+        c.edit_config([config], _on_edit)
+
+    def _on_listen(err: ?Exception):
+        if err is not None:
+            fail(ValueError("NETCONF SSH listen failed: {err}"))
+            return
+        s = server
+        if s is not None:
+            port = await async s.bound_port()
+            netconf.Client(connect_cap, "127.0.0.1", port, "admin", "admin", None, _on_connect, None, True, lh)
+
+    server = swnetconf.NetconfServer(listen_cap, log_handler=lh, top_schema=schema, cfs=layer, address="127.0.0.1", port=0, on_listen=_on_listen)
+
+    after 15.0: fail(ValueError("timed out waiting for SSH NETCONF round trip"))
+
+
+actor _test_ssh_session_cleanup(t: testing.EnvT):
+    """NetconfServer reclaims a session when its SSH transport closes.
+
+    Connects over SSH (so active_sessions becomes 1), drops the client, then
+    waits for the server to prune the session back to 0 -- guarding against the
+    _sessions list growing without bound as clients come and go.
+    """
+    lh = t.log_handler
+    schema = _demo_schema()
+    layer = _demo_layer()
+    listen_cap = net.TCPListenCap(net.TCPCap(net.NetCap(t.env.cap)))
+    connect_cap = net.TCPConnectCap(net.TCPCap(net.NetCap(t.env.cap)))
+
+    var done = False
+    var server: ?swnetconf.NetconfServer = None
+    var attempts = 0
+
+    def _teardown():
+        s = server
+        if s is not None:
+            s.close()
+
+    def fail(e: Exception):
+        if not done:
+            done = True
+            _teardown()
+            t.failure(e)
+
+    def _await_cleanup():
+        attempts += 1
+        s = server
+        if s is not None:
+            n = await async s.active_sessions()
+            if n == 0:
+                if not done:
+                    done = True
+                    _teardown()
+                    t.success()
+                return
+            if attempts > 300:
+                fail(ValueError("session not reclaimed; active_sessions={n}"))
+                return
+            after 0.02: _await_cleanup()
+
+    def _on_connect(c: netconf.Client, e: ?Exception):
+        if e is not None:
+            fail(ValueError("SSH connect failed: {e}"))
+            return
+        s = server
+        if s is not None:
+            active = await async s.active_sessions()
+            if active < 1:
+                fail(ValueError("expected an active session after connect, got {active}"))
+                return
+        # Drop the transport; the server should reclaim the session.
+        c.close(None)
+        after 0.05: _await_cleanup()
+
+    def _on_listen(err: ?Exception):
+        if err is not None:
+            fail(ValueError("NETCONF SSH listen failed: {err}"))
+            return
+        s = server
+        if s is not None:
+            port = await async s.bound_port()
+            netconf.Client(connect_cap, "127.0.0.1", port, "admin", "admin", None, _on_connect, None, True, lh)
+
+    server = swnetconf.NetconfServer(listen_cap, log_handler=lh, top_schema=schema, cfs=layer, address="127.0.0.1", port=0, on_listen=_on_listen)
+
+    after 15.0: fail(ValueError("timed out waiting for session cleanup"))


### PR DESCRIPTION
StratoWeave has had a RESTCONF northbound for a while but no NETCONF equivalent. This adds one, supporting writable-running: an edit-config is applied straight into the top of the TTT tree so both protocols share a single configuration datastore and all the transform and linkage machinery below it.

The server speaks SSH, serving the netconf subsystem and giving each accepted channel its own session. RPCs map directly onto the TTT session API: get and get-config read get_data() and serialise the result, while edit-config parses its <config> into a gdata diff and applies it through edit_config(). The diff already carries the per-element NETCONF operation attribute (merge, create, delete, remove, replace), so those edit-config semantics come for free. The supported surface is deliberately small, get, get-config, edit-config and close-session, against the running datastore, and everything else is answered with operation-not-supported: candidate's commit and discard-changes (we do not advertise :candidate), lock and unlock (a no-op lock would promise an exclusion we cannot keep), and any target or source datastore other than running.

Authentication is a pluggable check, defaulting to a single static username and password but accepting any checker that can validate credentials against a remote service before answering. The SSH host key is supplied as key material read from a configured key file at startup, or generated ephemerally when none is given.