### PR TITLE
Remove the hardcoded preset capabilities

### DIFF
--- a/gen_adata/src/swyang.act
+++ b/gen_adata/src/swyang.act
@@ -163,12 +163,6 @@ rfs = r"""module stratoweave-rfs {
         type boolean;
         default "false";
       }
-      leaf-list preset {
-        type enumeration {
-          enum cisco-ios-xr;
-          enum juniper-junos;
-        }
-      }
       list module {
         key "name";
         leaf name {

--- a/minisys/src/mini/layers/y_1.act
+++ b/minisys/src/mini/layers/y_1.act
@@ -62,7 +62,6 @@ SRC_DNODE_CHILD_7: DLeaf = DLeaf(module='stratoweave-rfs', namespace='http://str
 
 SRC_DNODE_CHILD_8: DContainer = DContainer(module='stratoweave-rfs', namespace='http://stratoweave.org/yang/stratoweave-rfs', prefix='sw-rfs', name='mock', config=True, presence=False, children=[
     DLeaf(module='stratoweave-rfs', namespace='http://stratoweave.org/yang/stratoweave-rfs', prefix='sw-rfs', name='enabled', config=True, default='false', mandatory=False, type_=DTypeBoolean(name='boolean', description=None, reference=None, exts=[], builtin_type='boolean', default=None)),
-    DLeafList(module='stratoweave-rfs', namespace='http://stratoweave.org/yang/stratoweave-rfs', prefix='sw-rfs', name='preset', config=True, min_elements=0, ordered_by='system', type_=DTypeEnum(name='enumeration', description=None, reference=None, exts=[], builtin_type='enumeration', default=None, name_to_val={'cisco-ios-xr':0, 'juniper-junos':1})),
     DList(module='stratoweave-rfs', namespace='http://stratoweave.org/yang/stratoweave-rfs', prefix='sw-rfs', name='module', key=['name'], config=True, min_elements=0, ordered_by='system', children=[
         DLeaf(module='stratoweave-rfs', namespace='http://stratoweave.org/yang/stratoweave-rfs', prefix='sw-rfs', name='name', config=True, mandatory=False, type_=DTypeString(name='string', description=None, reference=None, exts=[], builtin_type='string', default=None, length=None, patterns=[])),
         DLeaf(module='stratoweave-rfs', namespace='http://stratoweave.org/yang/stratoweave-rfs', prefix='sw-rfs', name='namespace', config=True, mandatory=True, type_=DTypeString(name='string', description=None, reference=None, exts=[], builtin_type='string', default=None, length=None, patterns=[])),
@@ -404,12 +403,6 @@ SRC_YANG_2: str = r"""module stratoweave-rfs {
       leaf enabled {
         type boolean;
         default "false";
-      }
-      leaf-list preset {
-        type enumeration {
-          enum cisco-ios-xr;
-          enum juniper-junos;
-        }
       }
       list module {
         key "name";
@@ -1405,19 +1398,15 @@ extension stratoweave_rfs__device__mock__module(Indexed[str, stratoweave_rfs__de
 _breaker12: None = None
 class stratoweave_rfs__device__mock(yadata.MNode):
     enabled: bool
-    preset: list[str]
     module: stratoweave_rfs__device__mock__module
 
-    mut def __init__(self, enabled: ?bool=None, preset: ?list[str]=None, module: list[stratoweave_rfs__device__mock__module_entry]=[]) -> None:
+    mut def __init__(self, enabled: ?bool=None, module: list[stratoweave_rfs__device__mock__module_entry]=[]) -> None:
         self.enabled = enabled if enabled is not None else False
-        self.preset = preset if preset is not None else []
         self.module = stratoweave_rfs__device__mock__module(elements=module)
 
     pure def _get_attr(self, name: str) -> ?value:
         if name == 'sw-rfs:enabled':
             return self.enabled
-        if name == 'sw-rfs:preset':
-            return self.preset
         if name == 'sw-rfs:module':
             return iter(self.module)
 
@@ -1427,7 +1416,7 @@ class stratoweave_rfs__device__mock(yadata.MNode):
     @staticmethod
     mut def from_gdata(n: ?ygdata.Node) -> stratoweave_rfs__device__mock:
         if n is not None:
-            return stratoweave_rfs__device__mock(enabled=n.get_opt_bool(ygdata.Id(NS_stratoweave_rfs, 'enabled')), preset=n.get_opt_strs(ygdata.Id(NS_stratoweave_rfs, 'preset')), module=stratoweave_rfs__device__mock__module.from_gdata(n.get_opt_list(ygdata.Id(NS_stratoweave_rfs, 'module'))))
+            return stratoweave_rfs__device__mock(enabled=n.get_opt_bool(ygdata.Id(NS_stratoweave_rfs, 'enabled')), module=stratoweave_rfs__device__mock__module.from_gdata(n.get_opt_list(ygdata.Id(NS_stratoweave_rfs, 'module'))))
         return stratoweave_rfs__device__mock()
 
     mut def copy(self) -> stratoweave_rfs__device__mock:

--- a/minisys/src/mini/layers/y_1_loose.act
+++ b/minisys/src/mini/layers/y_1_loose.act
@@ -62,7 +62,6 @@ SRC_DNODE_CHILD_7: DLeaf = DLeaf(module='stratoweave-rfs', namespace='http://str
 
 SRC_DNODE_CHILD_8: DContainer = DContainer(module='stratoweave-rfs', namespace='http://stratoweave.org/yang/stratoweave-rfs', prefix='sw-rfs', name='mock', config=True, presence=False, children=[
     DLeaf(module='stratoweave-rfs', namespace='http://stratoweave.org/yang/stratoweave-rfs', prefix='sw-rfs', name='enabled', config=True, default='false', mandatory=False, type_=DTypeBoolean(name='boolean', description=None, reference=None, exts=[], builtin_type='boolean', default=None)),
-    DLeafList(module='stratoweave-rfs', namespace='http://stratoweave.org/yang/stratoweave-rfs', prefix='sw-rfs', name='preset', config=True, min_elements=0, ordered_by='system', type_=DTypeEnum(name='enumeration', description=None, reference=None, exts=[], builtin_type='enumeration', default=None, name_to_val={'cisco-ios-xr':0, 'juniper-junos':1})),
     DList(module='stratoweave-rfs', namespace='http://stratoweave.org/yang/stratoweave-rfs', prefix='sw-rfs', name='module', key=['name'], config=True, min_elements=0, ordered_by='system', children=[
         DLeaf(module='stratoweave-rfs', namespace='http://stratoweave.org/yang/stratoweave-rfs', prefix='sw-rfs', name='name', config=True, mandatory=False, type_=DTypeString(name='string', description=None, reference=None, exts=[], builtin_type='string', default=None, length=None, patterns=[])),
         DLeaf(module='stratoweave-rfs', namespace='http://stratoweave.org/yang/stratoweave-rfs', prefix='sw-rfs', name='namespace', config=True, mandatory=True, type_=DTypeString(name='string', description=None, reference=None, exts=[], builtin_type='string', default=None, length=None, patterns=[])),
@@ -404,12 +403,6 @@ SRC_YANG_2: str = r"""module stratoweave-rfs {
       leaf enabled {
         type boolean;
         default "false";
-      }
-      leaf-list preset {
-        type enumeration {
-          enum cisco-ios-xr;
-          enum juniper-junos;
-        }
       }
       list module {
         key "name";
@@ -1407,19 +1400,15 @@ extension stratoweave_rfs__device__mock__module(Indexed[str, stratoweave_rfs__de
 _breaker12: None = None
 class stratoweave_rfs__device__mock(yadata.MNode):
     enabled: ?bool
-    preset: list[str]
     module: stratoweave_rfs__device__mock__module
 
-    mut def __init__(self, enabled: ?bool, preset: ?list[str]=None, module: list[stratoweave_rfs__device__mock__module_entry]=[]) -> None:
+    mut def __init__(self, enabled: ?bool, module: list[stratoweave_rfs__device__mock__module_entry]=[]) -> None:
         self.enabled = enabled
-        self.preset = preset if preset is not None else []
         self.module = stratoweave_rfs__device__mock__module(elements=module)
 
     pure def _get_attr(self, name: str) -> ?value:
         if name == 'sw-rfs:enabled':
             return self.enabled
-        if name == 'sw-rfs:preset':
-            return self.preset
         if name == 'sw-rfs:module':
             return iter(self.module)
 
@@ -1429,7 +1418,7 @@ class stratoweave_rfs__device__mock(yadata.MNode):
     @staticmethod
     mut def from_gdata(n: ?ygdata.Node) -> stratoweave_rfs__device__mock:
         if n is not None:
-            return stratoweave_rfs__device__mock(enabled=n.get_opt_bool(ygdata.Id(NS_stratoweave_rfs, 'enabled')), preset=n.get_opt_strs(ygdata.Id(NS_stratoweave_rfs, 'preset')), module=stratoweave_rfs__device__mock__module.from_gdata(n.get_opt_list(ygdata.Id(NS_stratoweave_rfs, 'module'))))
+            return stratoweave_rfs__device__mock(enabled=n.get_opt_bool(ygdata.Id(NS_stratoweave_rfs, 'enabled')), module=stratoweave_rfs__device__mock__module.from_gdata(n.get_opt_list(ygdata.Id(NS_stratoweave_rfs, 'module'))))
         return stratoweave_rfs__device__mock()
 
     mut def copy(self) -> stratoweave_rfs__device__mock:

--- a/minisys/src/mini/layers/y_1_oper.act
+++ b/minisys/src/mini/layers/y_1_oper.act
@@ -63,7 +63,6 @@ SRC_DNODE_CHILD_7: DLeaf = DLeaf(module='stratoweave-rfs', namespace='http://str
 
 SRC_DNODE_CHILD_8: DContainer = DContainer(module='stratoweave-rfs', namespace='http://stratoweave.org/yang/stratoweave-rfs', prefix='sw-rfs', name='mock', config=True, presence=False, children=[
     DLeaf(module='stratoweave-rfs', namespace='http://stratoweave.org/yang/stratoweave-rfs', prefix='sw-rfs', name='enabled', config=True, default='false', mandatory=False, type_=DTypeBoolean(name='boolean', description=None, reference=None, exts=[], builtin_type='boolean', default=None)),
-    DLeafList(module='stratoweave-rfs', namespace='http://stratoweave.org/yang/stratoweave-rfs', prefix='sw-rfs', name='preset', config=True, min_elements=0, ordered_by='system', type_=DTypeEnum(name='enumeration', description=None, reference=None, exts=[], builtin_type='enumeration', default=None, name_to_val={'cisco-ios-xr':0, 'juniper-junos':1})),
     DList(module='stratoweave-rfs', namespace='http://stratoweave.org/yang/stratoweave-rfs', prefix='sw-rfs', name='module', key=['name'], config=True, min_elements=0, ordered_by='system', children=[
         DLeaf(module='stratoweave-rfs', namespace='http://stratoweave.org/yang/stratoweave-rfs', prefix='sw-rfs', name='name', config=True, mandatory=False, type_=DTypeString(name='string', description=None, reference=None, exts=[], builtin_type='string', default=None, length=None, patterns=[])),
         DLeaf(module='stratoweave-rfs', namespace='http://stratoweave.org/yang/stratoweave-rfs', prefix='sw-rfs', name='namespace', config=True, mandatory=True, type_=DTypeString(name='string', description=None, reference=None, exts=[], builtin_type='string', default=None, length=None, patterns=[])),
@@ -410,12 +409,6 @@ SRC_YANG_2: str = r"""module stratoweave-rfs {
       leaf enabled {
         type boolean;
         default "false";
-      }
-      leaf-list preset {
-        type enumeration {
-          enum cisco-ios-xr;
-          enum juniper-junos;
-        }
       }
       list module {
         key "name";
@@ -1413,19 +1406,15 @@ extension stratoweave_rfs__device__mock__module(Indexed[str, stratoweave_rfs__de
 _breaker12: None = None
 class stratoweave_rfs__device__mock(yadata.MNode):
     enabled: ?bool
-    preset: list[str]
     module: stratoweave_rfs__device__mock__module
 
-    mut def __init__(self, enabled: ?bool, preset: ?list[str]=None, module: list[stratoweave_rfs__device__mock__module_entry]=[]) -> None:
+    mut def __init__(self, enabled: ?bool, module: list[stratoweave_rfs__device__mock__module_entry]=[]) -> None:
         self.enabled = enabled
-        self.preset = preset if preset is not None else []
         self.module = stratoweave_rfs__device__mock__module(elements=module)
 
     pure def _get_attr(self, name: str) -> ?value:
         if name == 'sw-rfs:enabled':
             return self.enabled
-        if name == 'sw-rfs:preset':
-            return self.preset
         if name == 'sw-rfs:module':
             return iter(self.module)
 
@@ -1435,7 +1424,7 @@ class stratoweave_rfs__device__mock(yadata.MNode):
     @staticmethod
     mut def from_gdata(n: ?ygdata.Node) -> stratoweave_rfs__device__mock:
         if n is not None:
-            return stratoweave_rfs__device__mock(enabled=n.get_opt_bool(ygdata.Id(NS_stratoweave_rfs, 'enabled')), preset=n.get_opt_strs(ygdata.Id(NS_stratoweave_rfs, 'preset')), module=stratoweave_rfs__device__mock__module.from_gdata(n.get_opt_list(ygdata.Id(NS_stratoweave_rfs, 'module'))))
+            return stratoweave_rfs__device__mock(enabled=n.get_opt_bool(ygdata.Id(NS_stratoweave_rfs, 'enabled')), module=stratoweave_rfs__device__mock__module.from_gdata(n.get_opt_list(ygdata.Id(NS_stratoweave_rfs, 'module'))))
         return stratoweave_rfs__device__mock()
 
     mut def copy(self) -> stratoweave_rfs__device__mock:
@@ -2222,17 +2211,15 @@ class stratoweave_rfs__device__mock__module_subs(SubscriptionNode):
 _breaker37: None = None
 class stratoweave_rfs__device__mock_subs(SubscriptionNode):
     enabled: SubscriptionNode
-    preset: SubscriptionNode
     module: stratoweave_rfs__device__mock__module_subs
 
     pure def __init__(self, path: ?SubscriptionPath=None) -> None:
         SubscriptionNode.__init__(self, path)
         self.enabled = SubscriptionNode(SubscriptionPath(ygdata.Id(NS_stratoweave_rfs, 'enabled'), parent=path))
-        self.preset = SubscriptionNode(SubscriptionPath(ygdata.Id(NS_stratoweave_rfs, 'preset'), parent=path))
         self.module = stratoweave_rfs__device__mock__module_subs(SubscriptionPath(ygdata.Id(NS_stratoweave_rfs, 'module'), parent=path))
 
     pure def _direct_children(self) -> list[SubscriptionNode]:
-        direct: list[SubscriptionNode] = [self.enabled, self.preset, self.module]
+        direct: list[SubscriptionNode] = [self.enabled, self.module]
         return direct
 
 _breaker38: None = None

--- a/src/adapters/adapter.act
+++ b/src/adapters/adapter.act
@@ -153,26 +153,6 @@ def parse_cap(tcap: str) -> ModCap:
     return ModCap(name, namespace, revision, feature)
 
 
-def mock_preset_capabilities(presets: list[str]) -> list[str]:
-    caps: list[str] = []
-    if "cisco-ios-xr" in presets:
-        caps.extend([
-            "http://cisco.com/ns/yang/Cisco-IOS-XR-um-hostname-cfg?module=Cisco-IOS-XR-um-hostname-cfg&revision=2021-04-21",
-            "http://cisco.com/ns/yang/Cisco-IOS-XR-um-interface-cfg?module=Cisco-IOS-XR-um-interface-cfg&revision=2022-07-11",
-            "http://cisco.com/ns/yang/Cisco-IOS-XR-um-if-ipv4-cfg?module=Cisco-IOS-XR-um-if-ipv4-cfg&revision=2022-07-11",
-        ])
-    if "juniper-junos" in presets:
-        caps.extend([
-            "http://xml.juniper.net/netconf/junos/1.0",
-            "http://xml.juniper.net/dmi/system/1.0",
-        ])
-    if "ietf" in presets:
-        caps.extend([
-            "urn:ietf:params:xml:ns:yang:ietf-system?module=ietf-system&revision=2014-08-06",
-        ])
-    return caps
-
-
 class SharedSubscription(object):
     """Runtime state for one device subscription spec."""
     spec: ygdata.SubscriptionSpec
@@ -353,12 +333,6 @@ actor MockDriver(on_connect: action(dict[str, ModCap], ?u64) -> None, bundled_sc
         _log.debug("MockAdapter.set_dmc", {"new_dmc": new_dmc.to_gdata().to_yang_jsonstr()})
         _dmc = new_dmc
 
-        preset_caps = mock_preset_capabilities(new_dmc.mock.preset)
-        for cap in preset_caps:
-            m = parse_cap(cap)
-            modset[m.name] = m
-            _log.debug("Adding preset cap", {"cap": m.name})
-#
         if len(new_dmc.mock.module.elements) > 0:
             for mock_cap in new_dmc.mock.module.elements:
                 m = ModCap(mock_cap.name, mock_cap.namespace, mock_cap.revision, mock_cap.feature)

--- a/src/adapters/adapter.act
+++ b/src/adapters/adapter.act
@@ -6,6 +6,8 @@ import std.xml as xml
 import yang.adata as yadata
 import yang.gdata as ygdata
 
+from device_schema import DeviceSchema
+
 from device_meta_config import \
     stratoweave_rfs__device_entry as DeviceMetaConfig
 
@@ -274,7 +276,7 @@ class NoAdapter(DeviceAdapter):
 class MockAdapter(DeviceAdapter):
     """Mock device adapter
     """
-    def __init__(self, on_connect: action(dict[str, ModCap], ?u64) -> None, bundled_schema: object, log_handler, connect_cap: ?net.TCPConnectCap):
+    def __init__(self, on_connect: action(dict[str, ModCap], ?u64) -> None, bundled_schema: DeviceSchema, log_handler, connect_cap: ?net.TCPConnectCap):
         self._on_connect = on_connect
         self._bundled_schema = bundled_schema
         self._log_handler = log_handler
@@ -312,7 +314,7 @@ class MockAdapter(DeviceAdapter):
     def remove_subscriptions(self, owner_id: str):
         pass
 
-actor MockDriver(on_connect: action(dict[str, ModCap], ?u64) -> None, bundled_schema: object, log_handler: logging.Handler, connect_cap: ?net.TCPConnectCap):
+actor MockDriver(on_connect: action(dict[str, ModCap], ?u64) -> None, bundled_schema: DeviceSchema, log_handler: logging.Handler, connect_cap: ?net.TCPConnectCap):
     _log = logging.Logger(log_handler)
     _log.info("MockDriver starting up")
 
@@ -322,16 +324,22 @@ actor MockDriver(on_connect: action(dict[str, ModCap], ?u64) -> None, bundled_sc
     var conn_state: int = DISCONNECTED
     var running_conf: ?ygdata.Node = None
 
+    # The bundled schema is the device's baseline module inventory; advertise it
+    # so enabling mock connects without listing modules by hand. The mock/module
+    # extras (folded in per set_dmc) layer on top.
+    for ns, meta in bundled_schema.module_inventory().items():
+        modset[meta.module] = ModCap(meta.module, ns, meta.revision)
+
     def set_dmc(new_dmc):
         if dmc is not None and new_dmc is not None:
             old_dmcg = dmc.to_gdata()
             new_dmcg = new_dmc.to_gdata()
             if old_dmcg is not None and new_dmcg is not None:
-                if ygdata.diff(old_dmcg, new_dmcg) is not None:
+                if ygdata.diff(old_dmcg, new_dmcg) is None:
                     _log.debug("Device.set_dmc: ignoring new device meta-config identical to current device meta-config")
                     return
         _log.debug("MockAdapter.set_dmc", {"new_dmc": new_dmc.to_gdata().to_yang_jsonstr()})
-        _dmc = new_dmc
+        dmc = new_dmc
 
         if len(new_dmc.mock.module.elements) > 0:
             for mock_cap in new_dmc.mock.module.elements:

--- a/src/adapters/netconf.act
+++ b/src/adapters/netconf.act
@@ -19,7 +19,7 @@ from adapters.adapter import \
     DeviceAdapter, ModCap, DISCONNECTED, CONNECTING, CONNECTED, TRANSACTION, \
     NotConnectedError, BusyError, LockedError, TxidMismatchError, ConfigError, \
     SharedSubscription, SubscriptionOwner, parse_cap, \
-    mock_preset_capabilities, subscription_delay, merge_subscription_tree
+    subscription_delay, merge_subscription_tree
 
 def extract_txid(conf: ?xml.Node) -> ?str:
     """Attempt to extract a txid from configuration
@@ -68,9 +68,14 @@ def _mock_capabilities_from_dmc(new_dmc: DeviceMetaConfig) -> list[str]:
     caps: list[str] = [netconf.CAP_NC_1_0, netconf.CAP_NC_1_1,
         "urn:ietf:params:netconf:capability:writable-running:1.0",
         "urn:ietf:params:netconf:capability:candidate:1.0"]
-    # Presets are hardcoded vendor hello strings (a mix of true caps and module
-    # caps); they pass through untouched until presets are removed.
-    for cap in mock_preset_capabilities(new_dmc.mock.preset):
+    for mock_cap in new_dmc.mock.module.elements:
+        cap = mock_cap.namespace + "?module=" + mock_cap.name
+        rev = mock_cap.revision
+        if rev is not None:
+            cap = cap + "&revision=" + rev
+        features = mock_cap.feature
+        if len(features) > 0:
+            cap = cap + "&features=" + ",".join(features)
         caps.append(cap)
     return caps
 
@@ -564,7 +569,7 @@ actor NetconfDriver(dev: swdev.DeviceMgr, bundled_schema: swdev.DeviceSchema, in
         dmc = new_dmc
 
     def _connect(new_dmc):
-        use_mock_server = system_mock or new_dmc.mock.enabled or len(new_dmc.mock.preset) > 0 or len(new_dmc.mock.module.elements) > 0
+        use_mock_server = system_mock or new_dmc.mock.enabled or len(new_dmc.mock.module.elements) > 0
 
         username = new_dmc.credentials.username
         password = new_dmc.credentials.password

--- a/src/adapters/netconf.act
+++ b/src/adapters/netconf.act
@@ -4,7 +4,6 @@ import net
 import time
 import std.xml as xml
 
-import yang
 import yang.schema as yschema
 import yang.gdata as ygdata
 import yang.xml as yxml
@@ -13,6 +12,7 @@ import netconf
 import device as swdev
 import ietf_yang_library as yl
 import monitoring
+from device_schema import DeviceSchema
 from device_meta_config import \
     stratoweave_rfs__device_entry as DeviceMetaConfig
 from adapters.adapter import \
@@ -37,30 +37,6 @@ def extract_txid(conf: ?xml.Node) -> ?str:
 
 NS_YANG_LIBRARY = "urn:ietf:params:xml:ns:yang:ietf-yang-library"
 
-NETCONF_MOCK_IETF_SYSTEM_YANG = r"""module ietf-system {
-  yang-version "1.1";
-  namespace "urn:ietf:params:xml:ns:yang:ietf-system";
-  prefix sys;
-  container system-state {
-    config false;
-    container clock {
-      leaf current-datetime {
-        type string;
-      }
-      leaf boot-datetime {
-        type string;
-      }
-    }
-  }
-}"""
-
-
-def _netconf_mock_default_oper_schema() -> yschema.DRoot:
-    try:
-        return yang.compile([NETCONF_MOCK_IETF_SYSTEM_YANG])
-    except Exception:
-        return yschema.DRoot()
-
 
 def _mock_capabilities_from_dmc(new_dmc: DeviceMetaConfig) -> list[str]:
     """True protocol capabilities for the mock device hello exchange.
@@ -80,22 +56,25 @@ def _mock_capabilities_from_dmc(new_dmc: DeviceMetaConfig) -> list[str]:
     return caps
 
 
-actor NetconfMockServer(pipe, log_handler: logging.Handler, capabilities: list[str], config_schema: yschema.DRoot, operational_schema: yschema.DRoot):
+actor NetconfMockServer(pipe, log_handler: logging.Handler, capabilities: list[str], bundled_schema: DeviceSchema):
     # `capabilities` carries true NETCONF protocol capabilities only.
-    # `config_schema` and `operational_schema` are used both for parsing as well
-    # as module inventory. If ietf-yang-library is present, then the mock server
-    # adds it to the capabilities and populates the oper state. If not, then all
-    # modules are advertised as capabilities.
+    # The bundled_schema config and oper roots are used both for
+    # parsing and as the module inventory. If ietf-yang-library is present, then
+    # the mock server adds it to the capabilities and populates the oper state.
+    # If not, then all modules are advertised as capabilities.
     _log = logging.Logger(log_handler)
 
+    config_schema = bundled_schema.src_dnode
+    operational_schema = bundled_schema.oper_src_dnode
+
     # Schemas are mutable so tests can swap them on the fly via set_*_ds(...).
-    var conf_schema: yschema.DRoot = config_schema
-    var oper_schema: yschema.DRoot = operational_schema
+    var conf_schema = config_schema
+    var oper_schema = operational_schema
     # The mock starts with no operational data; tests that exercise <get>
     # side-load it via set_oper_ds(...). Fabricating ambient operational state
     # here would leak non-deterministically into transforms that read it.
-    var oper_ds: ygdata.Node = ygdata.Container({})
-    var conf_ds: ygdata.Node = ygdata.Container({})
+    var oper_ds = ygdata.Container({})
+    var conf_ds = ygdata.Container({})
     var rpc_log: list[(message_id: str, op: xml.Node)] = []
     NS_NC_1_0 = "urn:ietf:params:xml:ns:netconf:base:1.0"
 
@@ -327,7 +306,7 @@ actor NetconfMockServer(pipe, log_handler: logging.Handler, capabilities: list[s
             yl_view = _build_yl_view(conf_schema, oper_schema)
 
 
-actor NetconfDriver(dev: swdev.DeviceMgr, bundled_schema: swdev.DeviceSchema, init_dmc: DeviceMetaConfig, schema_registry: swdev.SchemaRegistry, log_handler: logging.Handler, connect_cap: ?net.TCPConnectCap):
+actor NetconfDriver(dev: swdev.DeviceMgr, bundled_schema: DeviceSchema, init_dmc: DeviceMetaConfig, schema_registry: swdev.SchemaRegistry, log_handler: logging.Handler, connect_cap: ?net.TCPConnectCap):
     """NETCONF device adapter
 
     It is possible to configure a device using different transaction commit
@@ -578,11 +557,10 @@ actor NetconfDriver(dev: swdev.DeviceMgr, bundled_schema: swdev.DeviceSchema, in
             state = CONNECTING
             pipes = netconf.actor_pipe_pair()
             # The mock owns its module-facing output: it derives its module
-            # inventory from these schemas and serves ietf-yang-library iff the
-            # inventory implements it.
-            oper_schema = bundled_schema.oper_src_dnode if len(bundled_schema.oper_src_dnode.children) > 0 else _netconf_mock_default_oper_schema()
+            # inventory from the bundled schema and serves ietf-yang-library iff
+            # the inventory implements it.
             caps = _mock_capabilities_from_dmc(new_dmc)
-            ms = NetconfMockServer(pipes.server, _con_log_handler, caps, bundled_schema.src_dnode, oper_schema)
+            ms = NetconfMockServer(pipes.server, _con_log_handler, caps, bundled_schema)
             mock_server = ms
             client = netconf.Client(connect_cap,
                                     "dummy-address",
@@ -1266,7 +1244,7 @@ class NetconfAdapter(DeviceAdapter):
     def supports_mocking(self) -> bool:
         return True
 
-    def __init__(self, dev: swdev.DeviceMgr, bundled_schema: swdev.DeviceSchema, init_dmc: DeviceMetaConfig, schema_registry: swdev.SchemaRegistry, log_handler, connect_cap: ?net.TCPConnectCap):
+    def __init__(self, dev: swdev.DeviceMgr, bundled_schema: DeviceSchema, init_dmc: DeviceMetaConfig, schema_registry: swdev.SchemaRegistry, log_handler, connect_cap: ?net.TCPConnectCap):
         self._dev = dev
         self._bundled_schema = bundled_schema
         self._schema_registry = schema_registry

--- a/src/device.act
+++ b/src/device.act
@@ -432,8 +432,6 @@ actor DeviceMgr(dev_types: dict[str, DeviceType]={}, connect_cap: ?net.TCPConnec
         def is_mock_device(new_dmc: DeviceMetaConfig) -> bool:
             if new_dmc.mock.enabled:
                 return True
-            if len(new_dmc.mock.preset) > 0:
-                return True
             if len(new_dmc.mock.module.elements) > 0:
                 return True
             return False

--- a/src/device.act
+++ b/src/device.act
@@ -16,26 +16,13 @@ from device_meta_config import \
     stratoweave_rfs__device_entry as DeviceMetaConfig, \
     stratoweave_rfs__device__credentials as Credentials
 
+from device_schema import DeviceSchema
+
 from adapters.adapter import \
     DeviceAdapter, NoAdapter, MockAdapter, MockRoot, \
     DeviceError, TransientError, PermanentError, NotConnectedError, \
     BusyError, LockedError, TxidMismatchError, ConfigError, ModCap, \
     hash_modset, modset_eq
-
-class DeviceSchema(object):
-    name: str
-
-    src_dnode: yschema.DRoot
-    oper_src_dnode: yschema.DRoot
-
-    def __init__(self, name, src_dnode, oper_src_dnode: ?yschema.DRoot=None):
-        self.name = name
-        self.src_dnode = src_dnode
-        self.oper_src_dnode = oper_src_dnode if oper_src_dnode is not None else src_dnode
-
-    @staticmethod
-    def mock():
-        return DeviceSchema("mock", yschema.DRoot())
 
 ## DeviceType represents a type of device, i.e. a specific platform or
 ## implementation of a device. It is used to define the schema and

--- a/src/device_meta_config.act
+++ b/src/device_meta_config.act
@@ -62,7 +62,6 @@ SRC_DNODE_CHILD_7: DLeaf = DLeaf(module='stratoweave-rfs', namespace='http://str
 
 SRC_DNODE_CHILD_8: DContainer = DContainer(module='stratoweave-rfs', namespace='http://stratoweave.org/yang/stratoweave-rfs', prefix='sw-rfs', name='mock', config=True, presence=False, children=[
     DLeaf(module='stratoweave-rfs', namespace='http://stratoweave.org/yang/stratoweave-rfs', prefix='sw-rfs', name='enabled', config=True, default='false', mandatory=False, type_=DTypeBoolean(name='boolean', description=None, reference=None, exts=[], builtin_type='boolean', default=None)),
-    DLeafList(module='stratoweave-rfs', namespace='http://stratoweave.org/yang/stratoweave-rfs', prefix='sw-rfs', name='preset', config=True, min_elements=0, ordered_by='system', type_=DTypeEnum(name='enumeration', description=None, reference=None, exts=[], builtin_type='enumeration', default=None, name_to_val={'cisco-ios-xr':0, 'juniper-junos':1})),
     DList(module='stratoweave-rfs', namespace='http://stratoweave.org/yang/stratoweave-rfs', prefix='sw-rfs', name='module', key=['name'], config=True, min_elements=0, ordered_by='system', children=[
         DLeaf(module='stratoweave-rfs', namespace='http://stratoweave.org/yang/stratoweave-rfs', prefix='sw-rfs', name='name', config=True, mandatory=False, type_=DTypeString(name='string', description=None, reference=None, exts=[], builtin_type='string', default=None, length=None, patterns=[])),
         DLeaf(module='stratoweave-rfs', namespace='http://stratoweave.org/yang/stratoweave-rfs', prefix='sw-rfs', name='namespace', config=True, mandatory=True, type_=DTypeString(name='string', description=None, reference=None, exts=[], builtin_type='string', default=None, length=None, patterns=[])),
@@ -194,12 +193,6 @@ SRC_YANG_0: str = r"""module stratoweave-rfs {
       leaf enabled {
         type boolean;
         default "false";
-      }
-      leaf-list preset {
-        type enumeration {
-          enum cisco-ios-xr;
-          enum juniper-junos;
-        }
       }
       list module {
         key "name";
@@ -1256,19 +1249,15 @@ extension stratoweave_rfs__device__mock__module(Indexed[str, stratoweave_rfs__de
 _breaker12: None = None
 class stratoweave_rfs__device__mock(yadata.MNode):
     enabled: bool
-    preset: list[str]
     module: stratoweave_rfs__device__mock__module
 
-    mut def __init__(self, enabled: ?bool=None, preset: ?list[str]=None, module: list[stratoweave_rfs__device__mock__module_entry]=[]) -> None:
+    mut def __init__(self, enabled: ?bool=None, module: list[stratoweave_rfs__device__mock__module_entry]=[]) -> None:
         self.enabled = enabled if enabled is not None else False
-        self.preset = preset if preset is not None else []
         self.module = stratoweave_rfs__device__mock__module(elements=module)
 
     pure def _get_attr(self, name: str) -> ?value:
         if name == 'sw-rfs:enabled':
             return self.enabled
-        if name == 'sw-rfs:preset':
-            return self.preset
         if name == 'sw-rfs:module':
             return iter(self.module)
 
@@ -1278,7 +1267,7 @@ class stratoweave_rfs__device__mock(yadata.MNode):
     @staticmethod
     mut def from_gdata(n: ?ygdata.Node) -> stratoweave_rfs__device__mock:
         if n is not None:
-            return stratoweave_rfs__device__mock(enabled=n.get_opt_bool(ygdata.Id(NS_stratoweave_rfs, 'enabled')), preset=n.get_opt_strs(ygdata.Id(NS_stratoweave_rfs, 'preset')), module=stratoweave_rfs__device__mock__module.from_gdata(n.get_opt_list(ygdata.Id(NS_stratoweave_rfs, 'module'))))
+            return stratoweave_rfs__device__mock(enabled=n.get_opt_bool(ygdata.Id(NS_stratoweave_rfs, 'enabled')), module=stratoweave_rfs__device__mock__module.from_gdata(n.get_opt_list(ygdata.Id(NS_stratoweave_rfs, 'module'))))
         return stratoweave_rfs__device__mock()
 
     mut def copy(self) -> stratoweave_rfs__device__mock:

--- a/src/device_schema.act
+++ b/src/device_schema.act
@@ -1,0 +1,25 @@
+import yang.schema as yschema
+
+
+class DeviceSchema(object):
+    name: str
+
+    src_dnode: yschema.DRoot
+    oper_src_dnode: yschema.DRoot
+
+    def __init__(self, name, src_dnode, oper_src_dnode: ?yschema.DRoot=None):
+        self.name = name
+        self.src_dnode = src_dnode
+        self.oper_src_dnode = oper_src_dnode if oper_src_dnode is not None else src_dnode
+
+    @staticmethod
+    def mock():
+        return DeviceSchema("mock", yschema.DRoot())
+
+    def module_inventory(self) -> dict[str, (module: str, revision: ?str)]:
+        merged = {}
+        for ns, meta in self.src_dnode.module_metadata.items():
+            merged[ns] = meta
+        for ns, meta in self.oper_src_dnode.module_metadata.items():
+            merged[ns] = meta
+        return merged

--- a/src/swyang.act
+++ b/src/swyang.act
@@ -163,12 +163,6 @@ rfs = r"""module stratoweave-rfs {
         type boolean;
         default "false";
       }
-      leaf-list preset {
-        type enumeration {
-          enum cisco-ios-xr;
-          enum juniper-junos;
-        }
-      }
       list module {
         key "name";
         leaf name {

--- a/src/test_device.act
+++ b/src/test_device.act
@@ -8,6 +8,7 @@ import yang.adata as yadata
 import yang.gdata as ygdata
 
 import device as swdev
+from device_schema import DeviceSchema
 import adapters.netconf as swna
 import device_meta_config as dmc
 import netconf
@@ -213,7 +214,7 @@ actor _test_netconf_double_commit(t: testing.EnvT):
         dev = swdev.DeviceMgr(dev_types, net.TCPConnectCap(net.TCPCap(net.NetCap(t.env.cap))), "test-device", t.log_handler, on_reconf, schema_registry)
 
         # Create a simple device schema
-        schema = swdev.DeviceSchema.mock()
+        schema = DeviceSchema.mock()
 
         # Create test DeviceMetaConfig
         test_dmc = create_test_dmc()
@@ -429,7 +430,7 @@ actor _test_netconf_adapter(t: testing.EnvT):
         dev = swdev.DeviceMgr(dev_types, net.TCPConnectCap(net.TCPCap(net.NetCap(t.env.cap))), "test-device", t.log_handler, on_reconf, schema_registry)
 
         # Create a simple device schema
-        schema = swdev.DeviceSchema.mock()
+        schema = DeviceSchema.mock()
 
         # Create test DeviceMetaConfig
         test_dmc = create_test_dmc()
@@ -564,7 +565,7 @@ actor _test_netconf_adapter_resync(t: testing.EnvT):
         dev = swdev.DeviceMgr(dev_types, net.TCPConnectCap(net.TCPCap(net.NetCap(t.env.cap))), "test-device", t.log_handler, on_reconf, schema_registry)
 
         # Create a simple device schema
-        schema = swdev.DeviceSchema.mock()
+        schema = DeviceSchema.mock()
 
         # Create test DeviceMetaConfig
         test_dmc = create_test_dmc()
@@ -601,7 +602,7 @@ actor _test_netconf_adapter_resync(t: testing.EnvT):
 #                              lambda name: log.info("Reconf callback", {"name": name}))
 #
 #    # Create a simple device schema
-#    schema = swdev.DeviceSchema(
+#    schema = DeviceSchema(
 #        "test",
 #        set(),
 #        swdev.MockRoot,
@@ -686,7 +687,7 @@ actor _test_netconf_adapter_resync(t: testing.EnvT):
 #    dev_mgr.on_connect = on_device_connect
 #
 #    # Create a simple device schema
-#    schema = swdev.DeviceSchema(
+#    schema = DeviceSchema(
 #        "test",
 #        set(),
 #        swdev.MockRoot,

--- a/src/test_device_crpd.act
+++ b/src/test_device_crpd.act
@@ -8,6 +8,7 @@ import yang.adata as yadata
 import yang.gdata as ygdata
 
 import device as swdev
+from device_schema import DeviceSchema
 import adapters.netconf as swna
 import device_meta_config as dmc
 import netconf
@@ -241,7 +242,7 @@ actor _test_txid(t: testing.EnvT):
         dev = swdev.DeviceMgr(dev_types, net.TCPConnectCap(net.TCPCap(net.NetCap(t.env.cap))), "test-device", t.log_handler, on_reconf, schema_registry)
 
         # Create a simple device schema
-        schema = swdev.DeviceSchema.mock()
+        schema = DeviceSchema.mock()
 
         # Create test DeviceMetaConfig
         test_dmc = create_test_dmc()

--- a/src/test_devicemgr_netconf.act
+++ b/src/test_devicemgr_netconf.act
@@ -21,6 +21,23 @@ from device_meta_config import \
 IETF_SYSTEM_NS = "urn:ietf:params:xml:ns:yang:ietf-system"
 IETF_SYSTEM_MODULE = "ietf-system"
 
+IETF_SYSTEM_YANG = r"""module ietf-system {
+  yang-version "1.1";
+  namespace "urn:ietf:params:xml:ns:yang:ietf-system";
+  prefix sys;
+  container system-state {
+    config false;
+    container clock {
+      leaf current-datetime {
+        type string;
+      }
+      leaf boot-datetime {
+        type string;
+      }
+    }
+  }
+}"""
+
 def _q(name: str) -> ygdata.Id:
     return ygdata.Id(IETF_SYSTEM_NS, name)
 
@@ -101,7 +118,7 @@ def make_netconf_mock_dmc(name: str) -> DeviceMetaConfig:
     )
 
 def new_netconf_mock_device_mgr(t: testing.EnvT, name: str, on_reconf: action(str) -> None, extra_models: list[str]=[]) -> swdev.DeviceMgr:
-    schema = yang.compile([swna.NETCONF_MOCK_IETF_SYSTEM_YANG] + extra_models)
+    schema = yang.compile([IETF_SYSTEM_YANG] + extra_models)
     dev_types = {
         "netconf": swdev.DeviceType(
             name="netconf",

--- a/src/test_ttt_callbacks.act
+++ b/src/test_ttt_callbacks.act
@@ -8,12 +8,16 @@ import device as swdev
 from device_meta_config import \
     stratoweave_rfs__device_entry as DeviceMetaConfig, \
     stratoweave_rfs__device__credentials as Credentials, \
-    stratoweave_rfs__device__mock as Mock
+    stratoweave_rfs__device__mock as Mock, \
+    stratoweave_rfs__device__mock__module_entry as MockModule
 
 TEST_NS = "urn:test"
 
 def q(n: str) -> gdata.Id:
     return gdata.Id(TEST_NS, n)
+
+def mock_with_module() -> Mock:
+    return Mock(module=[MockModule(name="mock-module", namespace="urn:mock", revision=None)])
 
 ########################
 
@@ -24,7 +28,7 @@ actor reconf(t: testing.AsyncT):
         #print("Reconfiguring", dev)
         t.success()
         
-    dmc = DeviceMetaConfig("k1", Credentials("admin", "admin"), mock=Mock(preset=["cisco-ios-xr"]))
+    dmc = DeviceMetaConfig("k1", Credentials("admin", "admin"), mock=mock_with_module())
     dev_registry.on_reconf(reconf_cb)
     dev_registry.get_or_create("k1").set_dmc(dmc)
 
@@ -62,7 +66,7 @@ actor reconf2(t: testing.AsyncT):
     sess = stack.newsession()
     
     def cont1(_r):
-        dmc = DeviceMetaConfig("k1", Credentials("admin", "admin"), mock=Mock(preset=["cisco-ios-xr"]))
+        dmc = DeviceMetaConfig("k1", Credentials("admin", "admin"), mock=mock_with_module())
         dev_registry.get_or_create("k1").set_dmc(dmc)
         dev_registry.get_or_create("k2").set_dmc(dmc)
     
@@ -120,8 +124,8 @@ actor complete(t: testing.AsyncT):
     dev_registry.on_reconf(reconf_cb)
     
     def cont1(_r):
-        dmc1 = DeviceMetaConfig("k1", Credentials("admin", "admin"), mock=Mock(preset=["cisco-ios-xr"]))
-        dmc2 = DeviceMetaConfig("k2", Credentials("admin", "admin"), mock=Mock(preset=["cisco-ios-xr"]))
+        dmc1 = DeviceMetaConfig("k1", Credentials("admin", "admin"), mock=mock_with_module())
+        dmc2 = DeviceMetaConfig("k2", Credentials("admin", "admin"), mock=mock_with_module())
         k1 = dev_registry.get_or_create("k1").set_dmc(dmc1)
         k2 = dev_registry.get_or_create("k2").set_dmc(dmc2)
     
@@ -173,7 +177,7 @@ actor rfs_transform_exception(t: testing.AsyncT):
 
     dev_registry.on_reconf(reconf_cb)
 
-    dmc = DeviceMetaConfig("k1", Credentials("admin", "admin"), mock=Mock(preset=["cisco-ios-xr"]))
+    dmc = DeviceMetaConfig("k1", Credentials("admin", "admin"), mock=mock_with_module())
     dev_registry.get_or_create("k1").set_dmc(dmc)
 
 


### PR DESCRIPTION
Mock devices advertise modules from their bundled schema or the
`device/mock/module` list. The `device/mock/preset` leaf-list and its
hardcoded vendor capability strings are no longer needed.