### PR TITLE
Add ncurl monitor built on the stratoweave DeviceAdapter

### DIFF
--- a/Build.act
+++ b/Build.act
@@ -16,10 +16,10 @@ dependencies = {
         url="https://github.com/stratoweave/acton-lmdb/archive/1c4eef48dd7e64c297ae2e3bb2822cefcbd2ac73.zip",
         hash="N-V-__8AANDaAABkwSAsE2p54o9HMzVSJHZaSq_MX1f7WNUQ"
     ),
-    "netconf": (
-        repo_url="https://github.com/stratoweave/netconf.git",
-        url="https://github.com/stratoweave/netconf/archive/66309f280aa8f791c0d0612b845370358424de67.zip",
-        hash="N-V-__8AAPi2AgC06C7FAoZ4ZPwlTG9zaVy_To7yEtVAM7Yz"
+    "pipe": (
+        repo_url="https://github.com/actonlang/pipe.git",
+        url="https://github.com/actonlang/pipe/archive/21a42ed57263c1d5c10ea733b03ae731b9efabd1.zip",
+        hash="N-V-__8AALYVAAAUvHQ_330h64Ozha0xuWXXabLGLRJgVxkm"
     ),
     "ssh": (
         repo_url="https://github.com/actonlang/acton-ssh",

--- a/src/ncurl.act
+++ b/src/ncurl.act
@@ -973,8 +973,9 @@ actor CmdMonitor(env, args, log_handler):
 
     Builds a stratoweave DeviceAdapter and declares a periodic subscription,
     relying on the adapter to realize that subscription in whatever way the
-    device supports. Each update is printed as it arrives, until --count
-    updates have been received (0 = run until interrupted).
+    device supports. By default the data is shown as a live tree that refreshes
+    in place as it changes; --format raw streams the raw XML instead. Runs until
+    --count updates have been received (0 = run until interrupted).
     """
 
     host = args.get_str("host")
@@ -983,6 +984,7 @@ actor CmdMonitor(env, args, log_handler):
     password = args.get_str("password")
     count = args.get_int("count")
     filter_subtree = args.get_str("filter-subtree")
+    format = args.get_str("format")
 
     owner_id = "ncurl-monitor"
     var dev: ?swdev.DeviceMgr = None
@@ -1023,7 +1025,13 @@ actor CmdMonitor(env, args, log_handler):
             return
         received += 1
         if n is not None:
-            print(n.to_xmlstr())
+            if format == "raw":
+                print(n.to_xmlstr())
+            else:
+                # Live tree: home + clear, then redraw in place like watch/top.
+                wrapper = xml.Node("data", children=n.to_xml())
+                header = "ncurl monitor — {host}:{port}  (updates={received})"
+                print("\x1b[H\x1b[J{header}\n\n{render_data_tree(wrapper, use_color=True)}")
         if count > 0 and received >= count:
             _finish(0)
 
@@ -1212,6 +1220,7 @@ actor main(env):
         p_monitor.add_option("period", "str", "?", "1.0", "Poll period in seconds")
         p_monitor.add_option("count", "int", "?", 0, "Stop after N updates (0 = run until interrupted)")
         p_monitor.add_option("filter-subtree", "str", "?", "", "XML subtree filter (limits what is monitored)")
+        p_monitor.add_option("format", "str", "?", "tree", "Output format: tree (live view) or raw (xml)")
 
         return p.parse(env.argv)
 

--- a/src/ncurl.act
+++ b/src/ncurl.act
@@ -1,0 +1,1098 @@
+#!/usr/bin/env acton
+"""ncurl - NETCONF URL tool
+
+A command-line tool for interacting with NETCONF devices, like curl but for
+NETCONF. Maybe one day we'll do RESTCONF and gNMI (the other YANG-based
+transports), and then we'll be network curl.
+"""
+
+import argparse
+import file
+import netconf.fixups as fixups
+import logging
+import netconf
+import net
+import time
+import std.xml as xml
+
+
+import yang
+import yang.data as ydata
+import yang.xml as yxml
+import ncurl.schema_filter as schema_filter
+
+
+def build_explicit_schemas_list(explicit_modules: list[str], format: str) -> list[(identifier: str, version: ?str, format: ?str)]:
+    """Build a list of schemas to download from explicit module specifications"""
+    schemas_to_download = []
+    for module in explicit_modules:
+        # Parse module specification (might include version as module@version)
+        if "@" in module:
+            module_parts = module.split("@", 1)
+            schemas_to_download.append((identifier=module_parts[0], version=module_parts[1], format=format))
+        else:
+            schemas_to_download.append((identifier=module, version=None, format=format))
+    return schemas_to_download
+
+
+def unwrap[T](a: ?T, msg: ?str=None) -> T:
+    if a is not None:
+        return a
+    errmsg = msg if msg is not None else "Expected non-None value"
+    raise ValueError(errmsg)
+
+
+def resolve_client_fixups(args, log_handler):
+    log = logging.Logger(log_handler)
+    no_fixups = args.get_bool("no-fixups")
+    if no_fixups:
+        log.info("NETCONF fixups: disabled (--no-fixups)")
+        return []
+    log.info("NETCONF fixups: enabled (default)")
+    return fixups.FIXUPS
+
+
+def _node_text(node) -> str:
+    if node.text is None:
+        return ""
+    text = str(node.text)
+    ws_stripped = text.replace(" ", "").replace("\t", "").replace("\n", "").replace("\r", "")
+    if ws_stripped == "":
+        return ""
+    return text.strip()
+
+
+def _color_value(value: str, use_color: bool) -> str:
+    if not use_color:
+        return value
+    return "\x1b[36m{value}\x1b[0m"
+
+
+def _inline_key(node) -> (str, str):
+    key_tags = ["name", "id", "index", "key"]
+    for key_tag in key_tags:
+        for child in node.children:
+            if child.tag == key_tag and len(child.children) == 0:
+                key_text = _node_text(child)
+                if key_text != "":
+                    return (key_tag, key_text)
+    return ("", "")
+
+
+def _is_hidden_key_child(child, key_tag: str, key_text: str) -> bool:
+    return key_tag != "" and child.tag == key_tag and len(child.children) == 0 and _node_text(child) == key_text
+
+
+def _tree_node_parts(node):
+    key_tag, key_text = _inline_key(node)
+    label = node.tag
+    if key_text != "":
+        label = "{label} {key_text}"
+    visible_children = [child for child in node.children if not _is_hidden_key_child(child, key_tag, key_text)]
+    return (label=label, text=_node_text(node), visible_children=visible_children)
+
+
+def _flatten_single_path(node, base_label: str) -> (label: str, value: ?str):
+    parts = _tree_node_parts(node)
+    label = "{base_label} {parts.label}"
+    if parts.text != "":
+        return (label=label, value=parts.text)
+    if len(parts.visible_children) == 1:
+        return _flatten_single_path(parts.visible_children[0], label)
+    return (label=label, value=None)
+
+
+def _collect_tree_rows(node, depth: int) -> list[(depth: int, label: str, value: ?str)]:
+    rows = []
+    parts = _tree_node_parts(node)
+    label = parts.label
+    node_text = parts.text
+    visible_children = parts.visible_children
+
+    # Recursively flatten single-child container chains into one row.
+    if node_text == "" and len(visible_children) == 1:
+        flattened = _flatten_single_path(visible_children[0], label)
+        if flattened.value is not None:
+            rows.append((depth=depth, label=flattened.label, value=flattened.value))
+            return rows
+
+    if len(visible_children) == 0:
+        leaf_value = node_text if node_text != "" else None
+        rows.append((depth=depth, label=label, value=leaf_value))
+        return rows
+
+    rows.append((depth=depth, label=label, value=None))
+    for child in visible_children:
+        rows.extend(_collect_tree_rows(child, depth + 1))
+    return rows
+
+
+def render_data_tree(data_node, use_color: bool=True) -> str:
+    rows = []
+    for child in data_node.children:
+        rows.extend(_collect_tree_rows(child, 0))
+
+    if len(rows) == 0:
+        text = _node_text(data_node)
+        data_value = text if text != "" else None
+        rows.append((depth=0, label="data", value=data_value))
+
+    rendered_rows = []
+    for row in rows:
+        rendered_rows.append((left="{'  ' * row.depth}{row.label}", value=row.value))
+
+    value_column = 20
+    for row in rendered_rows:
+        if row.value is not None and len(row.left) > value_column:
+            value_column = len(row.left)
+
+    lines = []
+    for row in rendered_rows:
+        left = row.left
+        if row.value is not None:
+            lines.append("{left.ljust(value_column)} : {_color_value(str(row.value), use_color)}")
+        else:
+            lines.append(left)
+    return "\n".join(lines)
+
+
+def extract_rpc_content(request_xml: str) -> xml.Node:
+    try:
+        root = xml.decode(request_xml)
+    except xml.XmlParseError as parse_error:
+        raise ValueError("Invalid RPC XML: {parse_error.error_message}")
+
+    if root.tag == "rpc":
+        if len(root.children) == 0:
+            raise ValueError("RPC request must contain an operation element")
+        if len(root.children) > 1:
+            raise ValueError("RPC request must contain exactly one operation element")
+        return root.children[0]
+
+    if root.tag == "rpc-reply":
+        raise ValueError("RPC request must not be an rpc-reply")
+    if root.tag == "hello":
+        raise ValueError("RPC request must not be a hello message")
+
+    return root
+
+
+actor CmdListSchemas(env, args, log_handler):
+    """List available schemas from a NETCONF server"""
+
+    host = args.get_str("host")
+    port = args.get_int("port")
+    username = args.get_str("username")
+    password = args.get_str("password")
+    skip_host_key_check = args.get_bool("insecure")
+    client_fixups = resolve_client_fixups(args, log_handler)
+
+    var schemas_found = []
+
+    def _on_connect(c: netconf.Client, e: ?Exception):
+        if e is not None:
+            print("Error: Failed to connect: {e}", err=True)
+            env.exit(1)
+        else:
+            c.list_schemas(_on_list_schemas)
+
+    def _on_list_schemas(c: netconf.Client, schemas: list[(identifier: ?str, namespace: ?str, version: ?str, format: ?str)], error: ?netconf.NetconfError):
+        for schema in schemas:
+            schemas_found.append(schema)
+
+        def _close_cb():
+            _display_schemas()
+
+        c.close(_close_cb)
+
+    def _display_schemas():
+        print("Available schemas:")
+        print("==================")
+        count = 0
+        for schema in schemas_found:
+            version_str = str(schema.version) if schema.version is not None else "N/A"
+            format_str = str(schema.format) if schema.format is not None else "N/A"
+            identifier_str = str(schema.identifier) if schema.identifier is not None else "N/A"
+            namespace_str = str(schema.namespace) if schema.namespace is not None else "N/A"
+            print("  {identifier_str:<40} {version_str:<15} {format_str:<5} {namespace_str}")
+            count += 1
+
+        print("\nTotal schemas: {count}")
+        env.exit(0)
+
+    c = netconf.Client(net.TCPConnectCap(net.TCPCap(net.NetCap(env.auth))),
+                      on_connect=_on_connect,
+                      on_notif=None,
+                      address=host,
+                      username=username,
+                      key=None,
+                      password=password,
+                      port=port,
+                      skip_host_key_check=skip_host_key_check,
+                      log_handler=log_handler,
+                      fixups=client_fixups)
+
+
+actor CmdHello(env, args, log_handler):
+    """Print NETCONF server capabilities from hello exchange"""
+
+    host = args.get_str("host")
+    port = args.get_int("port")
+    username = args.get_str("username")
+    password = args.get_str("password")
+    skip_host_key_check = args.get_bool("insecure")
+    client_fixups = resolve_client_fixups(args, log_handler)
+
+    def _on_connect(c: netconf.Client, e: ?Exception):
+        if e is not None:
+            print("Error: Failed to connect: {e}", err=True)
+            env.exit(1)
+        else:
+            capabilities = c.get_capabilities()
+            print("Server capabilities:")
+            print("====================")
+            print("\n".join(["  {c}" for c in capabilities]))
+
+            def _close_cb():
+                env.exit(0)
+
+            c.close(_close_cb)
+
+    netconf.Client(net.TCPConnectCap(net.TCPCap(net.NetCap(env.auth))),
+                   on_connect=_on_connect,
+                   on_notif=None,
+                   address=host,
+                   username=username,
+                   key=None,
+                   password=password,
+                   port=port,
+                   skip_host_key_check=skip_host_key_check,
+                   log_handler=log_handler,
+                   fixups=client_fixups)
+
+
+actor CmdGetData(env, args, log_handler, use_get_config: bool):
+    """Get data from a NETCONF server using get or get-config"""
+
+    host = args.get_str("host")
+    port = args.get_int("port")
+    username = args.get_str("username")
+    password = args.get_str("password")
+    skip_host_key_check = args.get_bool("insecure")
+    client_fixups = resolve_client_fixups(args, log_handler)
+    filter_subtree = args.get_str("filter-subtree")
+    filter_xpath = args.get_str("filter-xpath")
+    xpath_namespaces = args.get_strlist("xpath-namespaces")
+    output_file = args.get_str("output")
+    format = args.get_str("format")
+    module_sets = args.get_strlist("module-set")
+    explicit_modules = args.get_strlist("module")
+    request_label = "configuration" if use_get_config else "data"
+    save_label = "Configuration" if use_get_config else "Data"
+
+    var config_xml: ?xml.Node = None
+    var client: ?netconf.Client = None
+    var schemas: list[str] = []
+    var strict_quoting = True
+
+    def _on_connect(c: netconf.Client, e: ?Exception):
+        if e is not None:
+            print("Error: Failed to connect: {e}", err=True)
+            env.exit(1)
+
+        # Validate that module-set and module are mutually exclusive
+        if module_sets != [] and explicit_modules != []:
+            print("Error: Cannot specify both --module-set and --module options", err=True)
+            env.exit(1)
+
+        # Parse and validate module sets
+        if module_sets != []:
+            warnings = schema_filter.validate_module_sets(module_sets)
+            for warning in warnings:
+                print(warning, err=True)
+
+        # Build filter if provided
+        filter_node: ?xml.Node = None
+
+        if filter_subtree != "" and filter_xpath != "":
+            print("Error: Cannot specify both filter-subtree and filter-xpath", err=True)
+            env.exit(1)
+
+        if filter_subtree != "":
+            # Wrap subtree filter in <filter> element
+            try:
+                subtree_node = xml.decode(filter_subtree)
+                filter_node = xml.Node("filter", attributes=[("type", "subtree")], children=[subtree_node], text=None)
+            except xml.XmlParseError as parse_error:
+                print("Error: Invalid subtree filter XML: {parse_error.error_message}", err=True)
+                env.exit(1)
+        elif filter_xpath != "":
+            # Create XPath filter with proper namespace
+            filter_attrs = [("type", "xpath"), ("select", filter_xpath)]
+
+            # Add namespace declarations if provided
+            # Each namespace should be in format "prefix=uri"
+            nsdefs = []
+            for ns_decl in xpath_namespaces:
+                parts = ns_decl.split("=")
+                if len(parts) == 2:
+                    prefix = parts[0].strip()
+                    uri = parts[1].strip()
+                    nsdefs.append((prefix, uri))
+                else:
+                    print("Error: Invalid namespace format '{ns_decl}'. Use prefix=uri", err=True)
+                    env.exit(1)
+
+            filter_node = xml.Node("filter", nsdefs, attributes=filter_attrs)
+
+        if use_get_config:
+            source = args.get_str("source")
+            c.get_config(_on_get_data, source, filter_node)
+        else:
+            c.get(_on_get_data, filter_node)
+
+    def _on_get_data(c: netconf.Client, result: ?xml.Node, error: ?netconf.NetconfError):
+        # Check for errors
+        if error is not None:
+            print("Error getting {request_label}: {error.error_message}", err=True)
+            env.exit(1)
+
+        # Extract data element
+        if result is not None:
+            for child in result.children:
+                if child.tag == "data":
+                    config_xml = child
+                    break
+
+        if config_xml is None:
+            print("No data element in response", err=True)
+            env.exit(1)
+
+        # For raw-xml and tree, output directly from XML without schema download
+        if format == "raw-xml" or format == "tree":
+            if config_xml is not None:
+                if format == "tree":
+                    _output_data(render_data_tree(config_xml, use_color=output_file == ""))
+                    return
+                # Extract just the configuration data content
+                config = ""
+                if len(config_xml.children) > 0:
+                    # Encode children of data element
+                    for data_child in config_xml.children:
+                        config += data_child.encode()
+                elif config_xml.text is not None:
+                    # If data element has text content
+                    config = str(config_xml.text)
+                _output_data(config)
+        else:
+            # If format is not raw-xml/tree, fetch schemas
+            print("Fetching schemas for data conversion...")
+            # Check if explicit modules are provided
+            if len(explicit_modules) > 0:
+                schemas_to_download = build_explicit_schemas_list(explicit_modules, format)
+
+                print("Downloading {len(schemas_to_download)} specified schemas")
+                schema_getter = netconf.SchemaGetter(c)
+                sg = schema_getter
+                if sg is not None:
+                    sg.download(_on_schema_download, _on_schemas_complete, schemas_to_download)
+            else:
+                # List all schemas and filter based on module sets (or download all if no module sets)
+                c.list_schemas(_on_list_schemas)
+    def _on_list_schemas(c: netconf.Client, schemas: list[(identifier: str, namespace: str, version: str, format: str)], error: ?netconf.NetconfError):
+        if error is not None:
+            print("Error: Failed to list schemas: {error}", err=True)
+            env.exit(1)
+            return
+
+        schemas_to_download = []
+        for s in schemas:
+            # Skip non-YANG schemas
+            if s.format != "yang":
+                continue
+            # Skip known broken models
+            if s.identifier.startswith("junos-rpc"):
+                print("Skipping {s.identifier}: undefined grouping common-forwarding", err=True)
+                continue
+            elif s.identifier == "tailf-rollback" or s.identifier.startswith("cicso-xe-openconfig"):
+                print("Skipping {s.identifier}: Cisco IOS XE", err=True)
+                continue
+            if not schema_filter.should_include_module(s.identifier, module_sets):
+                continue
+            if s.identifier == "openconfig-isis-types" and s.version == "2017-01-13":
+                print("Skipping {s.identifier}: incorrect escape in double-quoted string", err=True)
+                strict_quoting = False
+            schemas_to_download.append((identifier=s.identifier, version=s.version, format=s.format))
+
+        if len(schemas_to_download) == 0:
+            print("No schemas available for download", err=True)
+            env.exit(1)
+            return
+
+        print("Found {len(schemas_to_download)} schemas to download")
+        sg = netconf.SchemaGetter(c)
+        sg.download(_on_schema_download, _on_schemas_complete, schemas_to_download)
+
+    def _on_schema_download(sg: netconf.SchemaGetter, current_index: int, total_schemas: int, schema: (identifier: str, version: ?str, format: ?str), schema_data: ?str, error: ?netconf.NetconfError):
+        """Collect downloaded schemas into the list"""
+        if error is not None:
+            print("Error downloading {schema.identifier}: {error}", err=True)
+        elif schema_data is not None:
+            schemas.append(schema_data)
+            print("Downloaded [{current_index}/{total_schemas}]: {schema.identifier}")
+        else:
+            print("Warning: no schema data received for {schema.identifier}", err=True)
+
+    def _on_schemas_complete(sg: netconf.SchemaGetter, error: ?netconf.NetconfError):
+        """Called when all schemas have been downloaded"""
+        if error is not None:
+            print("Error fetching schemas: {error.error_message}", err=True)
+            def _close_cb():
+                env.exit(1)
+            if client is not None:
+                client.close(_close_cb)
+            else:
+                env.exit(1)
+            return
+        def _close_cb():
+            env.exit(1)
+
+        print("Retrieved {len(schemas)} schemas")
+
+        t0 = time.Stopwatch()
+        fc = file.FileCap(env.cap)
+        root = yang.compile_with_cache(schemas, strict_quoting=strict_quoting, fc=fc)
+        print("Compiled schemas in {t0.elapsed().to_float()}s")
+        t0.reset()
+        c = config_xml
+        if c is not None:
+            gdata = yxml.from_xml(root, c, loose=True)
+            print("Parsed config to gdata in {t0.elapsed().to_float()}s")
+
+            if format == "json":
+                _output_data(gdata.to_yang_jsonstr())
+                return
+            elif format == "acton-gdata":
+                _output_data(gdata.prsrc())
+                return
+            elif format == "acton-adata":
+                _output_data(ydata.pradata(root, gdata, loose=True))
+                return
+            elif format == "xml":
+                _output_data(gdata.to_xmlstr())
+                return
+
+            print("Unknown output format")
+            if client is not None:
+                client.close(_close_cb)
+            else:
+                env.exit(1)
+        else:
+            print("No config")
+            if client is not None:
+                client.close(_close_cb)
+            else:
+                env.exit(1)
+
+    def _output_data(config):
+        """Output the configuration data"""
+        if output_file != "":
+            # Write to file
+            f = file.WriteFile(file.WriteFileCap(file.FileCap(env.auth)), output_file)
+            f.write(config.encode())
+            f.close()
+            print("{save_label} saved to: {output_file}")
+        else:
+            # Print to stdout
+            print(config)
+
+        def _close_cb():
+            env.exit(0)
+
+        if client is not None:
+            client.close(_close_cb)
+        else:
+            env.exit(0)
+
+    client = netconf.Client(net.TCPConnectCap(net.TCPCap(net.NetCap(env.auth))),
+                      on_connect=_on_connect,
+                      on_notif=None,
+                      address=host,
+                      username=username,
+                      key=None,
+                      password=password,
+                      port=port,
+                      skip_host_key_check=skip_host_key_check,
+                      log_handler=log_handler,
+                      fixups=client_fixups)
+
+
+actor CmdEditConfig(env, args, log_handler):
+    """Edit configuration on a NETCONF server"""
+
+    host = args.get_str("host")
+    port = args.get_int("port")
+    username = args.get_str("username")
+    password = args.get_str("password")
+    skip_host_key_check = args.get_bool("insecure")
+    target = args.get_str("target")
+    default_operation = args.get_str("default-operation")
+    config_source = args.get_str("config")
+    should_commit = args.get_bool("commit")
+    client_fixups = resolve_client_fixups(args, log_handler)
+
+    var config = ""
+    var client: ?netconf.Client = None
+    var stdin_buffer: list[str] = []
+    var empty_line_count = 0
+
+    def _on_connect(c: netconf.Client, e: ?Exception):
+        if e is not None:
+            print("Error: Failed to connect: {e}", err=True)
+            env.exit(1)
+
+        client = c
+        _do_edit_config()
+
+    def _on_stdin(input: str):
+        # Check for empty input (just newline) or special marker
+        # TODO: propagate EOF from Acton, handle it here ...
+        if input == "\n":
+            empty_line_count += 1
+            if empty_line_count >= 2:
+                # Two empty lines means end of input
+                config = "".join(stdin_buffer).strip()
+                _connect_and_edit()
+                return
+            stdin_buffer.append(input)
+        else:
+            empty_line_count = 0
+            stdin_buffer.append(input)
+
+    def _connect_and_edit():
+        netconf.Client(net.TCPConnectCap(net.TCPCap(net.NetCap(env.auth))),
+                          on_connect=_on_connect,
+                          on_notif=None,
+                          address=host,
+                          username=username,
+                          key=None,
+                          password=password,
+                          port=port,
+                          skip_host_key_check=skip_host_key_check,
+                          log_handler=log_handler,
+                          fixups=client_fixups)
+
+    def _do_edit_config():
+        if client is not None:
+            config_xml = xml.decode("<data>{config}</data>")
+            client.edit_config(config_xml.children, _on_edit_config, target, default_operation=default_operation if default_operation != "merge" else None)
+
+    def _on_edit_config(c: netconf.Client, error: ?netconf.NetconfError):
+        if error is not None:
+            print("Error editing config: {error.error_message}", err=True)
+            env.exit(1)
+        else:
+            print("Configuration successfully applied to {target} datastore")
+            if should_commit and target == "candidate":
+                c.commit(_on_commit)
+                return
+
+        def _close_cb():
+            env.exit(0 if error is None else 1)
+
+        c.close(_close_cb)
+
+    def _on_commit(c: netconf.Client, error: ?netconf.NetconfError):
+        if error is not None:
+            print("Error committing configuration: {error.error_message}", err=True)
+            env.exit(1)
+        else:
+            print("Configuration committed successfully")
+
+        def _close_cb():
+            env.exit(0 if error is None else 1)
+
+        c.close(_close_cb)
+
+    if config_source == "-":
+        print("Reading configuration from stdin (enter empty line or press Ctrl+D to finish)...", err=True)
+        env.stdin_install(on_stdin=_on_stdin)
+    else:
+        try:
+            f = file.ReadFile(file.ReadFileCap(file.FileCap(env.auth)), config_source)
+            config = f.read().decode()
+            f.close()
+            _connect_and_edit()
+        except Exception as ex:
+            print("Error reading file '{config_source}': {ex}", err=True)
+            env.exit(1)
+
+
+actor CmdRpc(env, args, log_handler):
+    """Send a raw RPC to a NETCONF server"""
+
+    host = args.get_str("host")
+    port = args.get_int("port")
+    username = args.get_str("username")
+    password = args.get_str("password")
+    skip_host_key_check = args.get_bool("insecure")
+    rpc_source = args.get_str("request")
+    output_file = args.get_str("output")
+    client_fixups = resolve_client_fixups(args, log_handler)
+
+    var request_xml = ""
+    var rpc_content: ?xml.Node = None
+    var client: ?netconf.Client = None
+    var stdin_buffer: list[str] = []
+    var empty_line_count = 0
+
+    def _parse_request() -> bool:
+        try:
+            rpc_content = extract_rpc_content(request_xml)
+            return True
+        except ValueError as ex:
+            print("Error parsing RPC request: {ex}", err=True)
+            env.exit(1)
+            return False
+
+    def _on_connect(c: netconf.Client, e: ?Exception):
+        if e is not None:
+            print("Error: Failed to connect: {e}", err=True)
+            env.exit(1)
+            return
+
+        client = c
+        if rpc_content is None:
+            print("Error: No RPC content to send", err=True)
+            env.exit(1)
+            return
+        c.rpc(unwrap(rpc_content, "Expected RPC content"), _on_rpc)
+
+    def _close_and_exit(exit_code: int):
+        def _close_cb():
+            env.exit(exit_code)
+
+        if client is not None:
+            client.close(_close_cb)
+        else:
+            env.exit(exit_code)
+
+    def _emit_reply(reply: str, exit_code: int, error: ?netconf.NetconfError=None):
+        if output_file != "":
+            f = file.WriteFile(file.WriteFileCap(file.FileCap(env.auth)), output_file)
+            f.write(reply.encode())
+            f.close()
+            print("RPC reply saved to: {output_file}")
+        else:
+            print(reply)
+
+        if error is not None:
+            print("RPC returned error: {error}", err=True)
+
+        _close_and_exit(exit_code)
+
+    def _on_rpc(c: netconf.Client, result: ?xml.Node, error: ?netconf.NetconfError):
+        if result is None:
+            if error is not None:
+                print("Error sending RPC: {error}", err=True)
+            else:
+                print("Error sending RPC: no rpc-reply received", err=True)
+            _close_and_exit(1)
+            return
+
+        _emit_reply(unwrap(result, "Expected rpc-reply").encode(), 1 if error is not None else 0, error)
+
+    def _connect_and_send():
+        netconf.Client(net.TCPConnectCap(net.TCPCap(net.NetCap(env.auth))),
+                       on_connect=_on_connect,
+                       on_notif=None,
+                       address=host,
+                       username=username,
+                       key=None,
+                       password=password,
+                       port=port,
+                       skip_host_key_check=skip_host_key_check,
+                       log_handler=log_handler,
+                       fixups=client_fixups)
+
+    def _on_stdin(input: str):
+        # Check for empty input (just newline) or special marker
+        # TODO: propagate EOF from Acton, handle it here ...
+        if input == "\n":
+            empty_line_count += 1
+            if empty_line_count >= 2:
+                request_xml = "".join(stdin_buffer).strip()
+                if _parse_request():
+                    _connect_and_send()
+                return
+            stdin_buffer.append(input)
+        else:
+            empty_line_count = 0
+            stdin_buffer.append(input)
+
+    if rpc_source == "-":
+        print("Reading RPC XML from stdin (enter empty line or press Ctrl+D to finish)...", err=True)
+        env.stdin_install(on_stdin=_on_stdin)
+    else:
+        try:
+            f = file.ReadFile(file.ReadFileCap(file.FileCap(env.auth)), rpc_source)
+            request_xml = f.read().decode()
+            f.close()
+            if _parse_request():
+                _connect_and_send()
+        except Exception as ex:
+            print("Error reading file '{rpc_source}': {ex}", err=True)
+            env.exit(1)
+
+
+actor CmdCommit(env, args, log_handler):
+    """Commit the candidate configuration to the running configuration"""
+
+    host = args.get_str("host")
+    port = args.get_int("port")
+    username = args.get_str("username")
+    password = args.get_str("password")
+    skip_host_key_check = args.get_bool("insecure")
+    client_fixups = resolve_client_fixups(args, log_handler)
+
+    def _on_connect(c: netconf.Client, e: ?Exception):
+        if e is not None:
+            print("Error: Failed to connect: {e}", err=True)
+            env.exit(1)
+        else:
+            c.commit(_on_commit)
+
+    def _on_commit(c: netconf.Client, error: ?netconf.NetconfError):
+        if error is not None:
+            print("Error committing configuration: {error.error_message}", err=True)
+            env.exit(1)
+        else:
+            print("Configuration committed successfully")
+
+        def _close_cb():
+            env.exit(0 if error is None else 1)
+
+        c.close(_close_cb)
+
+    netconf.Client(net.TCPConnectCap(net.TCPCap(net.NetCap(env.auth))),
+                      on_connect=_on_connect,
+                      on_notif=None,
+                      address=host,
+                      username=username,
+                      key=None,
+                      password=password,
+                      port=port,
+                      skip_host_key_check=skip_host_key_check,
+                      log_handler=log_handler,
+                      fixups=client_fixups)
+
+
+actor CmdDiscardChanges(env, args, log_handler):
+    """Discard changes in the candidate configuration"""
+
+    host = args.get_str("host")
+    port = args.get_int("port")
+    username = args.get_str("username")
+    password = args.get_str("password")
+    skip_host_key_check = args.get_bool("insecure")
+    client_fixups = resolve_client_fixups(args, log_handler)
+
+    def _on_connect(c: netconf.Client, e: ?Exception):
+        if e is not None:
+            print("Error: Failed to connect: {e}", err=True)
+            env.exit(1)
+        else:
+            c.discard_changes(_on_discard_changes)
+
+    def _on_discard_changes(c: netconf.Client, error: ?netconf.NetconfError):
+        if error is not None:
+            print("Error discarding changes: {error.error_message}", err=True)
+            env.exit(1)
+        else:
+            print("Candidate configuration changes discarded successfully")
+
+        def _close_cb():
+            env.exit(0 if error is None else 1)
+
+        c.close(_close_cb)
+
+    netconf.Client(net.TCPConnectCap(net.TCPCap(net.NetCap(env.auth))),
+                      on_connect=_on_connect,
+                      on_notif=None,
+                      address=host,
+                      username=username,
+                      key=None,
+                      password=password,
+                      port=port,
+                      skip_host_key_check=skip_host_key_check,
+                      log_handler=log_handler,
+                      fixups=client_fixups)
+
+
+actor CmdGetSchema(env, args, log_handler):
+    """Download schema(s) from a NETCONF server"""
+
+    host = args.get_str("host")
+    port = args.get_int("port")
+    username = args.get_str("username")
+    password = args.get_str("password")
+    skip_host_key_check = args.get_bool("insecure")
+    client_fixups = resolve_client_fixups(args, log_handler)
+    format = args.get_str("format")
+    output_dir = args.get_str("output-dir")
+    module_sets = args.get_strlist("module-set")
+    explicit_modules = args.get_strlist("module")
+
+    var client: ?netconf.Client = None
+
+    def _on_connect(c: netconf.Client, e: ?Exception):
+        if e is not None:
+            print("Error: Failed to connect: {e}", err=True)
+            env.exit(1)
+
+        # Validate that module-set and module are mutually exclusive
+        if module_sets != [] and explicit_modules != []:
+            print("Error: Cannot specify both --module-set and --module options", err=True)
+            env.exit(1)
+
+        # Parse and validate module sets
+        if module_sets != []:
+            warnings = schema_filter.validate_module_sets(module_sets)
+            for warning in warnings:
+                print(warning, err=True)
+
+        client = c  # Store client for later use
+
+        # Check if explicit modules are provided
+        if len(explicit_modules) > 0:
+            schemas_to_download = build_explicit_schemas_list(explicit_modules, format)
+
+            print("Downloading {len(schemas_to_download)} specified schemas")
+            schema_getter = netconf.SchemaGetter(c)
+            sg = schema_getter
+            if sg is not None:
+                sg.download(_on_schema_download, _on_schemas_complete, schemas_to_download)
+        else:
+            # List all schemas and filter based on module sets (or download all if no module sets)
+            c.list_schemas(_on_list_schemas)
+
+    def _on_list_schemas(c: netconf.Client, schemas: list[(identifier: str, namespace: str, version: str, format: str)], error: ?netconf.NetconfError):
+        if error is not None:
+            print("Error: Failed to list schemas: {error}", err=True)
+            env.exit(1)
+            return
+
+        # Convert to tuple argument for SchemaGetter.download (no namespace field)
+        schemas_to_download = [(identifier=s.identifier, version=s.version, format=s.format) for s in schemas]
+
+        if len(schemas_to_download) == 0:
+            print("No matching schemas found to download", err=True)
+            env.exit(1)
+            return
+
+        print("Found {len(schemas_to_download)} schemas to download")
+        sg = netconf.SchemaGetter(c)
+        sg.download(_on_schema_download, _on_schemas_complete, schemas_to_download)
+
+    def _on_schema_download(sg: netconf.SchemaGetter, current_index: int, total_schemas: int, schema: (identifier: str, version: ?str, format: ?str), schema_data: ?str, error: ?netconf.NetconfError):
+        """Handle each downloaded schema"""
+        print("Downloading [{current_index}/{total_schemas}]: {schema.identifier}")
+        if error is not None:
+            print("  {error}")
+        elif schema_data is not None:
+            # Build proper filename with identifier and version
+            filename = "{schema.identifier}"
+            if schema.version is not None and schema.version != "":
+                filename = "{schema.identifier}@{schema.version}"
+            if schema.format is not None and schema.format != "":
+                filename = "{filename}.{schema.format}"
+            else:
+                filename = "{filename}.yang"
+
+            if output_dir not in {"", "."}:
+                fs = file.FS(file.FileCap(env.auth))
+                try:
+                    await async fs.mkdir(output_dir)
+                except OSError as err:
+                    if "already exists" not in err.error_message:
+                        raise err
+                filepath = file.join_path([output_dir, filename])
+            else:
+                filepath = filename
+
+            # Write to file
+            f = file.WriteFile(file.WriteFileCap(file.FileCap(env.auth)), filepath)
+            f.write(schema_data.encode())
+            f.close()
+            print("  Saved to: {filepath}")
+        else:
+            print("  Warning: No data received for {schema.identifier}")
+
+    def _on_schemas_complete(sg: netconf.SchemaGetter, error: ?netconf.NetconfError):
+        """Called when all schemas have been downloaded"""
+        if error is not None:
+            print("\nError downloading schemas: {error.error_message}", err=True)
+            env.exit(1)
+            return
+
+        print("\nAll schemas downloaded successfully!")
+        _close_and_exit()
+
+    def _close_and_exit():
+        if client is not None:
+            def _close_cb():
+                env.exit(0)
+            client.close(_close_cb)
+        else:
+            env.exit(0)
+
+    # Connect and start the download process
+    client = netconf.Client(net.TCPConnectCap(net.TCPCap(net.NetCap(env.auth))),
+                  on_connect=_on_connect,
+                  on_notif=None,
+                  address=host,
+                  username=username,
+                  key=None,
+                  password=password,
+                  port=port,
+                  skip_host_key_check=skip_host_key_check,
+                  log_handler=log_handler,
+                  fixups=client_fixups)
+
+
+actor main(env):
+    logh = logging.Handler()
+
+    def cmd_list_schemas(args):
+        """Command handler for list-schemas"""
+        if args.get_bool("verbose"):
+            logh.set_output_level(logging.TRACE)
+            logh.add_sink(logging.ConsoleSink())
+        CmdListSchemas(env, args, logh)
+
+    def cmd_get(args):
+        """Command handler for get"""
+        if args.get_bool("verbose"):
+            logh.set_output_level(logging.TRACE)
+            logh.add_sink(logging.ConsoleSink())
+        CmdGetData(env, args, logh, False)
+
+    def cmd_get_config(args):
+        """Command handler for get-config"""
+        if args.get_bool("verbose"):
+            logh.set_output_level(logging.TRACE)
+            logh.add_sink(logging.ConsoleSink())
+        CmdGetData(env, args, logh, True)
+
+    def cmd_hello(args):
+        """Command handler for hello"""
+        if args.get_bool("verbose"):
+            logh.set_output_level(logging.TRACE)
+            logh.add_sink(logging.ConsoleSink())
+        CmdHello(env, args, logh)
+
+    def cmd_get_schema(args):
+        """Command handler for get-schema"""
+        if args.get_bool("verbose"):
+            logh.set_output_level(logging.TRACE)
+            logh.add_sink(logging.ConsoleSink())
+        CmdGetSchema(env, args, logh)
+
+    def cmd_edit_config(args):
+        """Command handler for edit-config"""
+        if args.get_bool("verbose"):
+            logh.set_output_level(logging.TRACE)
+            logh.add_sink(logging.ConsoleSink())
+        CmdEditConfig(env, args, logh)
+
+    def cmd_rpc(args):
+        """Command handler for rpc"""
+        if args.get_bool("verbose"):
+            logh.set_output_level(logging.TRACE)
+            logh.add_sink(logging.ConsoleSink())
+        CmdRpc(env, args, logh)
+
+    def cmd_commit(args):
+        """Command handler for commit"""
+        if args.get_bool("verbose"):
+            logh.set_output_level(logging.TRACE)
+            logh.add_sink(logging.ConsoleSink())
+        CmdCommit(env, args, logh)
+
+    def cmd_discard_changes(args):
+        """Command handler for discard-changes"""
+        if args.get_bool("verbose"):
+            logh.set_output_level(logging.TRACE)
+            logh.add_sink(logging.ConsoleSink())
+        CmdDiscardChanges(env, args, logh)
+
+    def _parse_args():
+        p = argparse.Parser()
+
+        # Global options
+        p.add_option("host", "str", "?", "localhost", "NETCONF server hostname")
+        p.add_option("port", "int", "?", 42830, "NETCONF server port")
+        p.add_option("username", "str", "?", "admin", "Username for authentication")
+        p.add_option("password", "str", "?", "admin", "Password for authentication")
+        p.add_bool("verbose", "Verbose logging from SSH / NETCONF client")
+        p.add_bool("insecure", "Disable SSH host key verification")
+        p.add_bool("no-fixups", "Disable NETCONF client fixups/workarounds")
+
+        # Commands
+        p_hello = p.add_cmd("hello", "Print server capabilities from hello exchange", cmd_hello)
+        p_list_schemas = p.add_cmd("list-schemas", "List available schemas", cmd_list_schemas)
+
+        p_get = p.add_cmd("get", "Get data from NETCONF server", cmd_get)
+        p_get.add_option("filter-subtree", "str", "?", "", "XML subtree filter")
+        p_get.add_option("filter-xpath", "str", "?", "", "XPath expression for filtering")
+        p_get.add_option("xpath-namespaces", "strlist", "*", [], "Namespace declarations for XPath filtering (format: prefix=uri)")
+        p_get.add_option("format", "str", "?", "raw-xml", "Output format (raw-xml, tree, xml, json, acton-gdata or acton-adata)")
+        p_get.add_option("output", "str", "?", "", "Output file (if not specified, prints to stdout)")
+        module_sets_help = "Module set(s) to include ({schema_filter.get_module_set_names()})"
+        p_get.add_option("module-set", "strlist", "+", [], module_sets_help)
+        p_get.add_option("module", "strlist", "+", [], "Module(s) to include")
+
+        p_get_config = p.add_cmd("get-config", "Get configuration from NETCONF server", cmd_get_config)
+        p_get_config.add_option("source", "str", "?", "running", "Configuration datastore (running, startup, candidate)")
+        p_get_config.add_option("filter-subtree", "str", "?", "", "XML subtree filter")
+        p_get_config.add_option("filter-xpath", "str", "?", "", "XPath expression for filtering")
+        p_get_config.add_option("xpath-namespaces", "strlist", "*", [], "Namespace declarations for XPath filtering (format: prefix=uri)")
+        p_get_config.add_option("format", "str", "?", "raw-xml", "Output format (raw-xml, tree, xml, json, acton-gdata or acton-adata)")
+        p_get_config.add_option("output", "str", "?", "", "Output file (if not specified, prints to stdout)")
+        module_sets_help = "Module set(s) to include ({schema_filter.get_module_set_names()})"
+        p_get_config.add_option("module-set", "strlist", "+", [], module_sets_help)
+        p_get_config.add_option("module", "strlist", "+", [], "Module(s) to include")
+
+        p_get_schema = p.add_cmd("get-schema", "Download schema(s) from NETCONF server", cmd_get_schema)
+        p_get_schema.add_option("format", "str", "?", "yang", "Schema format (yang or yin)")
+        p_get_schema.add_option("output-dir", "str", "?", "schemas", "Output directory for downloaded schemas")
+        module_sets_help = "Module set(s) to include ({schema_filter.get_module_set_names()})"
+        p_get_schema.add_option("module-set", "strlist", "+", [], module_sets_help)
+        p_get_schema.add_option("module", "strlist", "+", [], "Module(s) to include (optionally with version as module@version)")
+
+        p_edit_config = p.add_cmd("edit-config", "Edit configuration on NETCONF server", cmd_edit_config)
+        p_edit_config.add_option("target", "str", "?", "candidate", "Configuration datastore (running, startup, candidate)")
+        p_edit_config.add_option("default-operation", "str", "?", "merge", "Default operation (merge, replace, none)")
+        p_edit_config.add_bool("commit", "Commit changes (only applies when target is candidate)")
+        p_edit_config.add_arg("config", "Configuration XML, or - to read from stdin", False)
+
+        p_rpc = p.add_cmd("rpc", "Send raw RPC XML to NETCONF server", cmd_rpc)
+        p_rpc.add_option("output", "str", "?", "", "Output file (if not specified, prints to stdout)")
+        p_rpc.add_arg("request", "RPC XML file path, or - to read from stdin", False)
+
+        p_commit = p.add_cmd("commit", "Commit candidate configuration to running", cmd_commit)
+
+        p_discard = p.add_cmd("discard-changes", "Discard changes in candidate configuration", cmd_discard_changes)
+
+        return p.parse(env.argv)
+
+    try:
+        args = _parse_args()
+        cmd = args.cmd
+        if cmd is not None:
+            cmd(args)
+        else:
+            env.exit(0)
+    except argparse.ArgumentError as exc:
+        print(str(exc), err=True)
+        env.exit(1)

--- a/src/ncurl.act
+++ b/src/ncurl.act
@@ -18,8 +18,16 @@ import std.xml as xml
 
 import yang
 import yang.data as ydata
+import yang.gdata as ygdata
+import yang.schema as yschema
 import yang.xml as yxml
+import device as swdev
+import adapters.netconf as swna
 import ncurl.schema_filter as schema_filter
+
+from device_meta_config import \
+    stratoweave_rfs__device_entry as DeviceMetaConfig, \
+    stratoweave_rfs__device__credentials as Credentials
 
 
 def build_explicit_schemas_list(explicit_modules: list[str], format: str) -> list[(identifier: str, version: ?str, format: ?str)]:
@@ -960,6 +968,115 @@ actor CmdGetSchema(env, args, log_handler):
                   fixups=client_fixups)
 
 
+actor CmdMonitor(env, args, log_handler):
+    """Monitor operational data from a NETCONF device.
+
+    Builds a stratoweave DeviceAdapter and declares a periodic subscription,
+    relying on the adapter to realize that subscription in whatever way the
+    device supports. Each update is printed as it arrives, until --count
+    updates have been received (0 = run until interrupted).
+    """
+
+    host = args.get_str("host")
+    port = args.get_int("port")
+    username = args.get_str("username")
+    password = args.get_str("password")
+    count = args.get_int("count")
+    filter_subtree = args.get_str("filter-subtree")
+
+    owner_id = "ncurl-monitor"
+    var dev: ?swdev.DeviceMgr = None
+    var received = 0
+    var subscribed = False
+    var done = False
+
+    pstr = args.get_str("period")
+    var period: ?float = None
+    try:
+        period = float(pstr)
+    except ValueError:
+        period = None
+
+    # Parse the optional subtree filter XML up front (syntax only). It is turned
+    # into a typed filter once the device's schema is known (in _on_connect),
+    # since that conversion needs the schema.
+    var filter_node: ?xml.Node = None
+    var filter_error: ?str = None
+    if filter_subtree != "":
+        try:
+            filter_node = xml.Node("filter", attributes=[("type", "subtree")], children=[xml.decode(filter_subtree)])
+        except xml.XmlParseError as e:
+            filter_error = e.error_message
+
+    def _finish(code: int):
+        if not done:
+            done = True
+            d = dev
+            if d is not None:
+                d.remove_subscriptions(owner_id)
+            env.exit(code)
+
+    def _on_update(n: ?ygdata.Node, err: ?Exception):
+        if err is not None:
+            print("Error: subscription update failed: {err}", err=True)
+            _finish(1)
+            return
+        received += 1
+        if n is not None:
+            print(n.to_xmlstr())
+        if count > 0 and received >= count:
+            _finish(0)
+
+    def _on_connect(name: str):
+        # on_reconf can fire more than once; only subscribe the first time.
+        if subscribed:
+            return
+        d = dev
+        p = period
+        if d is not None and p is not None:
+            filt: ?ygdata.FNode = None
+            fnode = filter_node
+            if fnode is not None:
+                schema = d.get_fetched_schema()
+                if schema is not None:
+                    try:
+                        filt = yxml.from_filter_xml(schema, fnode)
+                    except Exception as e:
+                        print("Error: --filter-subtree did not match the device schema: {e}", err=True)
+                        _finish(1)
+                        return
+                else:
+                    print("Error: device schema not available for --filter-subtree", err=True)
+                    _finish(1)
+                    return
+            subscribed = True
+            d.declare_subscriptions(owner_id, _on_update, {ygdata.SubscriptionSpec(filt, period=p)})
+
+    if period is None:
+        print("Error: --period must be a number of seconds, got '{pstr}'", err=True)
+        env.exit(1)
+    elif filter_error is not None:
+        print("Error: invalid --filter-subtree XML: {filter_error}", err=True)
+        env.exit(1)
+    else:
+        # Build a stratoweave DeviceAdapter pointed at the target device and
+        # start connecting. An empty bundled schema + runtime_schema_fetch lets
+        # it work against arbitrary devices: the schema is fetched from the
+        # device at connect. Connection is asynchronous; _on_connect fires once
+        # the device is ready.
+        cap = net.TCPConnectCap(net.TCPCap(net.NetCap(env.auth)))
+        schema_registry = swdev.SchemaRegistry()
+        dev_types = {
+            "netconf": swdev.DeviceType(name="netconf", adapter_type=swna.NetconfAdapter, src_dnode=yschema.DRoot())
+        }
+        dmc = DeviceMetaConfig(name="ncurl-target", credentials=Credentials(username, password), type="netconf")
+        dmc.address.create("primary", host, u64(port))
+        dmc.feature_flags.runtime_schema_fetch = True
+        device = swdev.DeviceMgr(dev_types, cap, "ncurl-target", log_handler, _on_connect, schema_registry)
+        device.set_dmc(dmc)
+        dev = device
+
+
 actor main(env):
     logh = logging.Handler()
 
@@ -1026,6 +1143,13 @@ actor main(env):
             logh.add_sink(logging.ConsoleSink())
         CmdDiscardChanges(env, args, logh)
 
+    def cmd_monitor(args):
+        """Command handler for monitor"""
+        if args.get_bool("verbose"):
+            logh.set_output_level(logging.TRACE)
+            logh.add_sink(logging.ConsoleSink())
+        CmdMonitor(env, args, logh)
+
     def _parse_args():
         p = argparse.Parser()
 
@@ -1083,6 +1207,11 @@ actor main(env):
         p_commit = p.add_cmd("commit", "Commit candidate configuration to running", cmd_commit)
 
         p_discard = p.add_cmd("discard-changes", "Discard changes in candidate configuration", cmd_discard_changes)
+
+        p_monitor = p.add_cmd("monitor", "Monitor operational data from a NETCONF device", cmd_monitor)
+        p_monitor.add_option("period", "str", "?", "1.0", "Poll period in seconds")
+        p_monitor.add_option("count", "int", "?", 0, "Stop after N updates (0 = run until interrupted)")
+        p_monitor.add_option("filter-subtree", "str", "?", "", "XML subtree filter (limits what is monitored)")
 
         return p.parse(env.argv)
 

--- a/src/ncurl/schema_filter.act
+++ b/src/ncurl/schema_filter.act
@@ -1,0 +1,153 @@
+"""Schema filtering support for YANG module sets
+
+This module provides pattern-based filtering for YANG schemas, allowing
+users to select specific sets of modules (classic, unified-model, openconfig, etc.)
+to avoid conflicts and reduce compilation overhead.
+"""
+
+import re
+
+class ModuleSet:
+    """Represents a set of YANG modules defined by include/exclude patterns"""
+
+    name: str
+    description: str
+    include_patterns: list[str]
+    exclude_patterns: list[str]
+
+    def __init__(self, name: str, description: str, include_patterns: list[str]=[], exclude_patterns: list[str]=[]):
+        self.name = name
+        self.description = description
+        self.include_patterns = include_patterns
+        self.exclude_patterns = exclude_patterns
+
+    def matches(self, module_name: str) -> bool:
+        """Check if a module name matches this module set's patterns"""
+        # First check if it matches any include pattern
+        if len(self.include_patterns) == 0:
+            matched = True
+        else:
+            matched = False
+            for pattern in self.include_patterns:
+                if re.match(pattern, module_name) is not None:
+                    matched = True
+                    break
+
+        if not matched:
+            return False
+
+        # Then check it doesn't match any exclude pattern
+        for pattern in self.exclude_patterns:
+            if re.match(pattern, module_name) is not None:
+                return False
+
+        return True
+
+
+# Define standard module sets
+CISCO_XR_CLASSIC = ModuleSet(
+    "cisco-xr-classic",
+    "Cisco IOS XR Classic configuration models",
+    include_patterns=["^Cisco-IOS-XR-", "^tailf-", "^cisco-semver", "^ietf-inet-types", "^ietf-syslog-types", "^ietf-yang-types", "^iana-tls-cipher-suite"],
+    exclude_patterns=["^Cisco-IOS-XR-um-", "^Cisco-IOS-XR-openconfig"]
+)
+
+CISCO_XR_UNIFIED_MODEL = ModuleSet(
+    "cisco-xr-unified-model",
+    "Cisco IOS XR Unified Model with base types",
+    include_patterns=["^Cisco-IOS-XR-um-", "^Cisco-IOS-XR-types", "^Cisco-IOS-XR-.*-datatypes", "^ietf-inet-types", "^ietf-yang-types", "^iana-tls-cipher-suite-algs", "^tailf-", "^cisco-semver"]
+)
+
+CISCO_XE_NATIVE = ModuleSet(
+    "cisco-xe-native",
+    """Cisco IOS XE "native" configuration model with dependencies""",
+    include_patterns=["^Cisco-IOS-XE-", "^cisco-semver", "^ietf-inet-types", "^ietf-yang-types"]
+)
+
+OPENCONFIG = ModuleSet(
+    "openconfig",
+    "OpenConfig standard models",
+    include_patterns=["^openconfig-"]
+)
+
+IETF = ModuleSet(
+    "ietf",
+    "IETF standard models",
+    include_patterns=["^ietf-", "^iana-"]
+)
+
+ALL_MODULES = ModuleSet(
+    "all",
+    "All available models"
+)
+
+# Registry of all available module sets
+MODULE_SETS = {
+    "cisco-xr-classic": CISCO_XR_CLASSIC,
+    "cisco-xr-unified-model": CISCO_XR_UNIFIED_MODEL,
+    "cisco-xe-native": CISCO_XE_NATIVE,
+    "openconfig": OPENCONFIG,
+    "ietf": IETF,
+    "all": ALL_MODULES
+}
+
+
+def should_include_module(module_name: str, module_set_names: list[str]) -> bool:
+    """Check if a module should be included based on selected module sets"""
+    # If no sets specified, include everything
+    if len(module_set_names) == 0:
+        return True
+
+    # Check if module matches any of the selected sets
+    for set_name in module_set_names:
+        module_set = MODULE_SETS.get(set_name)
+        if module_set is not None and module_set.matches(module_name):
+            return True
+
+    return False
+
+
+def filter_schemas(
+    schemas: list[(identifier: str, namespace: ?str, version: ?str, format: str)],
+    module_set_names: list[str]
+) -> list[(identifier: str, namespace: ?str, version: ?str, format: str)]:
+    """Filter a list of schemas based on selected module sets"""
+    if len(module_set_names) == 0:
+        return schemas
+
+    filtered = []
+    for schema in schemas:
+        if should_include_module(schema.identifier, module_set_names):
+            filtered.append(schema)
+
+    return filtered
+
+
+def validate_module_sets(set_names: list[str]) -> list[str]:
+    """Validate module set names and check for known incompatibilities"""
+    warnings = []
+
+    # Check all set names are valid
+    for name in set_names:
+        if name not in MODULE_SETS:
+            warnings.append("Unknown module set: {name}")
+
+    # Check for known incompatibilities
+    if "cisco-xr-classic" in set_names and "cisco-xr-unified-model" in set_names:
+        warnings.append("Warning: Cisco XR Classic and Cisco XR Unified Model may have conflicting definitions")
+
+    if "cisco-xr-classic" in set_names and "openconfig" in set_names:
+        warnings.append("Warning: Cisco XR Classic and OpenConfig may have overlapping namespaces for common features")
+
+    if "cisco-xr-unified-model" in set_names and "openconfig" in set_names:
+        warnings.append("Warning: Cisco XR Unified Model and OpenConfig may have overlapping namespaces")
+
+    return warnings
+
+
+def get_module_set_names() -> str:
+    """Get a comma-separated string of available module set names for help text"""
+    names = []
+    for key in MODULE_SETS:
+        names.append(key)
+    return ", ".join(sorted(names))

--- a/src/netconf.act
+++ b/src/netconf.act
@@ -1,0 +1,2068 @@
+# Copyright (C) Deutsche Telekom AG
+#
+# Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+#
+# 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+#
+# 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
+#
+# 3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+"""NETCONF client
+"""
+
+import logging
+import net
+import random
+import testing
+import std.xml as xml
+from pipe import Pipe, actor_pipe_pair as _actor_pipe_pair
+
+from netconf.buffer import Buffer, IncompleteReadError
+from netconf.fixups import FIXUPS
+from netconf.fixups.base import Fixup
+import ssh.pipe as sshpipe
+from netconf.transport import TcpListenPipe, TcpPipe, TcpPipeListener
+
+SEPARATOR_FRAMING: int = 0
+CHUNKED_FRAMING: int = 1
+
+CHUNK_SIZE_MAX: int = 4294967295
+
+LEGACY_SEPARATOR: bytes = "]]>]]>".encode()
+
+CHUNK_TAG_PREFIX: bytes = "\n#".encode()
+CHUNK_TAG_END_OF_MSG: bytes = "#".encode()
+CHUNK_TAG_POSTFIX: bytes = "\n".encode()
+
+CAP_NC_1_0 = "urn:ietf:params:netconf:base:1.0"
+CAP_NC_1_1 = "urn:ietf:params:netconf:base:1.1"
+
+NS_NC_1_0 = "urn:ietf:params:xml:ns:netconf:base:1.0"
+NS_YANG_ACTION = "urn:ietf:params:xml:ns:yang:1"
+
+def actor_pipe_pair() -> (client: Pipe, server: Pipe):
+    return _actor_pipe_pair()
+
+# TODO: I think this should be in __builtin__
+class UnreachableError(Exception):
+    pass
+
+# TODO: move these to __builtin__
+class ConnectionError(OSError):
+    pass
+
+class BrokenPipeError(ConnectionError):
+    pass
+
+class ConnectionAbortedError(ConnectionError):
+    pass
+
+class ConnectionRefusedError(ConnectionError):
+    pass
+
+class ConnectionResetError(ConnectionError):
+    pass
+
+def unwrap[T](a: ?T, msg: ?str=None) -> T:
+    if a is not None:
+        return a
+    errmsg = msg if msg is not None else "Expected non-None value"
+    raise ValueError(errmsg)
+
+
+class NetconfError(Exception):
+    def __init__(self, error_message: ?str, rpc_error: ?list[RpcError]):
+        self.error_message = error_message if error_message is not None else ""
+        self.rpc_error = rpc_error
+
+    def __str__(self):
+        return "{self._name()}: {self.error_message.strip()}"
+
+    def __repr__(self):
+        return "{self._name()}({repr(self.error_message)}, {repr(self.rpc_error)})"
+
+
+class RpcError(object):
+    # RFC 6241 rpc-error fields
+    error_type: str         # transport/rpc/protocol/application
+    error_tag: str          # in-use/invalid-value/too-big/etc.
+    error_severity: str     # error/warning
+    error_app_tag: ?str     # optional application-specific tag
+    error_path: ?str        # optional XPath/element path
+    error_message: ?str     # optional human-readable message
+    error_info: ?dict[str, str]  # optional additional error information
+    xml: xml.Node          # raw <rpc-error> XML, including any vendor extension elements
+
+    def __init__(self, xml_node: xml.Node):
+        # Initialize all attributes before any references to self escape
+        self.xml = xml_node
+        self.error_type = ""  # Will be set from XML, required field
+        self.error_tag = ""   # Will be set from XML, required field
+        self.error_severity = ""  # Will be set from XML, required field
+        self.error_app_tag = None
+        self.error_path = None
+        self.error_message = None
+        self.error_info = None
+
+        # Parse the XML into well-known attributes
+        for child in xml_node.children:
+            if child.tag == "error-type":
+                self.error_type = unwrap(child.text, "rpc-error missing expected error-type")
+            elif child.tag == "error-tag":
+                self.error_tag = unwrap(child.text, "rpc-error missing expected error-tag")
+            elif child.tag == "error-severity":
+                self.error_severity = unwrap(child.text, "rpc-error missing expected error-severity")
+            elif child.tag == "error-app-tag":
+                self.error_app_tag = child.text
+            elif child.tag == "error-path":
+                self.error_path = child.text
+            elif child.tag == "error-message":
+                self.error_message = child.text
+            elif child.tag == "error-info":
+                # Parse error-info elements into a dictionary
+                info = {}
+                for info_child in child.children:
+                    info_child_text = info_child.text
+                    if info_child_text is not None:
+                        info[info_child.tag] = info_child_text
+                if len(info) > 0:
+                    self.error_info = info
+
+    def __repr__(self):
+        args = "error_type={repr(self.error_type)}"
+        args += ", error_tag={repr(self.error_tag)}"
+        args += ", error_severity={repr(self.error_severity)}"
+        if self.error_app_tag is not None:
+            args += ", error_app_tag={repr(self.error_app_tag)}"
+        if self.error_path is not None:
+            args += ", error_path={repr(self.error_path)}"
+        if self.error_message is not None:
+            args += ", error_message={repr(self.error_message)}"
+        if self.error_info is not None:
+            args += ", error_info={repr(self.error_info)}"
+
+        return "netconf.RpcError({args})"
+
+
+STATE_NONE          = 0
+STATE_CONNECTING    = 1
+STATE_CONNECTED     = 2
+STATE_DISCONNECTING = 3
+
+state_name = {
+    STATE_NONE:          "none",
+    STATE_CONNECTING:    "connecting",
+    STATE_CONNECTED:     "connected",
+    STATE_DISCONNECTING: "disconnecting"
+}
+
+
+actor Client(
+        connect_cap: ?net.TCPConnectCap,
+        address: str,
+        port: int,
+        username: str,
+        password: ?str,
+        key: ?str,
+        on_connect: action(Client, ?Exception) -> None,
+        on_notif: ?action(Client, xml.Node) -> None,
+        skip_host_key_check: bool=False,
+        log_handler: ?logging.Handler,
+        pipe: ?Pipe=None,
+        fixups: ?list[proc() -> Fixup]=FIXUPS):
+
+    _log = logging.Logger(log_handler)
+    _log.info("Connecting to " + address + ":" + str(port) + " as " + username)
+
+    var framing = SEPARATOR_FRAMING
+    var recv_buf = Buffer()
+    var chunk_buf = Buffer()
+
+    var session_id: ?str = None
+    var capabilities: list[str] = []
+
+    # Tracks explicit namespace prefix used in NETCONF messages. To maximize
+    # compatibility, we track and mirror the same namespace prefix declaration
+    # pattern used by the server. The default is to not use any prefix and set
+    # the xmlns default namespace on the root element. If we a prefix used in a
+    # server response, we switch over to use an explicit prefix on all elements,
+    # including attributes.
+    #
+    # The NETCONF RFC 6241 allows for any valid XML encoding to be used, but
+    # real world experience has shown that some implementations are sensitive.
+    # By dynamically aligning on what we detect the remote end is doing, we
+    # maximize our chances of interoperability.
+    #
+    # For examples JUNOS with rfc-compliant mode [1] enabled will NOT include
+    # the message-id in rpc-reply if the message-id attribute in the rpc is sent
+    # without an explicit namespace prefix.
+    #
+    # We always use the "urn:ietf:params:xml:ns:netconf:base:1.0" namespace when
+    # creating xml.Node for tags. The nsdefs tuple (nc_prefix, NS_NC_1_1)
+    # renders to either the default or explicit namespace declaration depending
+    # nc_prefix.
+    #
+    # [1]: (https://www.juniper.net/documentation/us/en/software/junos/netconf/topics/concept/netconf-session-rfc-compliant.html)
+    var nc_prefix: ?str = None
+
+    var message_id = 1
+    var rpc_cbs: list[(id: str, cb: action(Client, ?xml.Node, ?NetconfError) -> None)] = []
+
+    var p: ?Pipe = pipe
+    var state = STATE_NONE
+    var active_fixups: list[Fixup] = []
+
+    def _prune_inactive_fixups():
+        active: list[Fixup] = []
+        for fx in active_fixups:
+            if fx.active:
+                active.append(fx)
+            else:
+                _log.info("NETCONF fixup deactivated", {"fixup": fx.name, "reason": fx.deactivate_reason})
+        active_fixups = active
+
+    def _activate_fixups():
+        active_fixups.clear()
+        if fixups is None:
+            _log.debug("NETCONF fixups disabled")
+            return
+        configured_fixups = unwrap(fixups, "Expected fixup list")
+
+        for mk in configured_fixups:
+            try:
+                fx = mk()
+                activated = fx.activate(capabilities)
+                if activated and fx.active:
+                    active_fixups.append(fx)
+                    _log.info("NETCONF fixup activated", {"fixup": fx.name})
+                else:
+                    reason = fx.deactivate_reason
+                    if reason is None:
+                        if not activated:
+                            reason = "capability mismatch"
+                        else:
+                            reason = "inactive after activation"
+                    _log.info("NETCONF fixup not activated", {"fixup": fx.name, "reason": reason})
+            except Exception as exc:
+                _log.error("NETCONF fixup activation failed", {"exception": exc})
+        _prune_inactive_fixups()
+
+    def _apply_request_fixups(op: xml.Node) -> xml.Node:
+        out = op
+        for fx in active_fixups:
+            try:
+                out = fx.on_request(out)
+            except Exception as exc:
+                _log.error("NETCONF request fixup failed", {"fixup": fx.name, "exception": exc})
+        _prune_inactive_fixups()
+        return out
+
+    def _apply_response_fixups(rpc_reply: xml.Node) -> xml.Node:
+        out = rpc_reply
+        # Run response hooks in reverse order (stack-like unwind)
+        for fx in reversed(active_fixups):
+            try:
+                out = fx.on_response(out)
+            except Exception as exc:
+                _log.error("NETCONF response fixup failed", {"fixup": fx.name, "exception": exc})
+        _prune_inactive_fixups()
+        return out
+
+    def _parse_rpc_errors(rpc_reply: xml.Node) -> ?NetconfError:
+        """Parse <rpc-error> elements from an rpc-reply and return NetconfError if found"""
+        errors = []
+        for child in rpc_reply.children:
+            if child.tag == "rpc-error":
+                errors.append(RpcError(child))
+
+        if len(errors) == 0:
+            return None
+        else:
+            # Construct error message summary
+            messages = []
+            for err in errors:
+                error_message = err.error_message
+                if error_message is not None:
+                    messages.append(error_message)
+            error_message = "; ".join(messages) if len(messages) > 0 else None
+            return NetconfError(error_message, errors)
+
+    def get_capabilities() -> list[str]:
+        return capabilities
+
+    # TODO: Close protocol
+    def close(cb: ?action() -> None) -> None:
+        for rpc_cb in rpc_cbs:
+            rpc_cb.cb(self, None, None)
+        rpc_cbs.clear()
+
+        if p is not None:
+            p.close(cb)
+        else:
+            if cb is not None:
+                cb()
+
+    # TODO: Restart protocol
+    def restart() -> None:
+        _log.info("Restarting")
+        for rpc_cb in rpc_cbs:
+            rpc_cb.cb(self, None, None)
+
+        framing = SEPARATOR_FRAMING
+        recv_buf = Buffer()
+        chunk_buf = Buffer()
+
+        session_id = None
+        capabilities = []
+
+        message_id = 1
+        rpc_cbs.clear()
+
+        state = STATE_NONE
+        active_fixups.clear()
+
+        if p is not None:
+            p.restart()
+        else:
+            _log.warning("Cannot restart, transport pipe is not running")
+
+    def _send_message(data: Buffer) -> None:
+        if p is not None:
+            if framing == SEPARATOR_FRAMING:
+                data.write_bytes(LEGACY_SEPARATOR)
+                _msg = data.read_all_bytes()
+                _log.trace("Sending message", {"msg": _msg})
+                p.write(_msg)
+            elif framing == CHUNKED_FRAMING:
+                while True:
+                    chunk_size = CHUNK_SIZE_MAX if data.unread_bytes > CHUNK_SIZE_MAX else data.unread_bytes
+                    if chunk_size <= 0:
+                        p.write("\n##\n".encode())
+                        break
+
+                    _chunk = data.read_bytes(chunk_size)
+                    _log.trace("Sending chunk", {"chunk_size": chunk_size, "chunk": _chunk})
+                    p.write(("\n#" + str(chunk_size) + "\n").encode())
+                    p.write(_chunk)
+        else:
+            on_connect(self, BrokenPipeError("Cannot send message, transport pipe is not running"))
+
+    def rpc(content: xml.Node, callback: action(Client, ?xml.Node, ?NetconfError) -> None) -> None:
+        message_id_text = str(message_id)
+        message_id += 1
+        fixed_content = _apply_request_fixups(content)
+
+        # If using an explicit namespace prefix, prepend it to the attribute name.
+        # The namespace (prefix or not) is defined in the tag.
+        if nc_prefix is not None:
+            rpc_attrs = [(nc_prefix + ":message-id", message_id_text)]
+        else:
+            rpc_attrs = [("message-id", message_id_text)]
+
+        root = xml.Node("rpc", [(nc_prefix, NS_NC_1_0)], nc_prefix, rpc_attrs, [fixed_content])
+
+        buf: Buffer = Buffer()
+        buf.write_str(xml.encode(root))
+
+        rpc_cbs.append((id=message_id_text, cb=callback))
+        _log.debug("Sending RPC", {"message-id": message_id_text, "content": content})
+        _send_message(buf)
+
+    def get(cb: action(Client, ?xml.Node, ?NetconfError) -> None, filter: ?xml.Node=None) -> None:
+        _log.info("NETCONF get")
+        nc_nsdefs = [(None, NS_NC_1_0)]
+        children = []
+        if filter is not None:
+            children.append(filter)
+        rpc(xml.Node("get", nc_nsdefs, children=children), cb)
+
+    def get_config(cb: action(Client, ?xml.Node, ?NetconfError) -> None, datastore: str="running", filter: ?xml.Node=None) -> None:
+        _log.info("NETCONF get-config")
+        nc_nsdefs = [(nc_prefix, NS_NC_1_0)]
+        children = [
+            xml.Node("source", [], nc_prefix, children=[
+                xml.Node(datastore, [], nc_prefix)
+            ])
+        ]
+        if filter is not None:
+            children.append(filter)
+        rpc(xml.Node("get-config", nc_nsdefs, nc_prefix, children=children), cb)
+
+    def edit_config(config: list[xml.Node], cb: action(Client, ?NetconfError) -> None, datastore: str="running", default_operation: ?str=None) -> None:
+        _log.info("NETCONF edit-config", {"datastore": datastore, "default-operation": default_operation})
+        nc_nsdefs = [(nc_prefix, NS_NC_1_0)]
+        edit_config_children = [
+            xml.Node("target", [], nc_prefix, children=[
+                xml.Node(datastore, [], nc_prefix)
+            ])
+        ]
+        if default_operation is not None:
+            if default_operation not in {"merge", "replace", "none"}:
+                raise ValueError("Invalid default-operation: {default_operation}")
+            edit_config_children.append(xml.Node("default-operation", text=default_operation))
+        # Define "xc" namespace prefix for NETCONF operation attributes.
+        # Cisco IOS XRd requires namespace declaration on an ancestor node,
+        # not just where operation attributes are used.
+        edit_config_children.append(xml.Node("config", [("xc", "urn:ietf:params:xml:ns:netconf:base:1.0")], nc_prefix, children=config))
+        rpc(xml.Node("edit-config", nc_nsdefs, nc_prefix, children=edit_config_children), lambda c, _, err: cb(c, err))
+
+    def commit(cb: action(Client, ?NetconfError) -> None) -> None:
+        _log.info("NETCONF commit", {})
+        nc_nsdefs = [(nc_prefix, NS_NC_1_0)]
+        rpc(xml.Node("commit", nc_nsdefs, nc_prefix), lambda c, _, err: cb(c, err))
+
+    def discard_changes(cb: action(Client, ?NetconfError) -> None) -> None:
+        _log.info("NETCONF discard-changes", {})
+        nc_nsdefs = [(nc_prefix, NS_NC_1_0)]
+        rpc(xml.Node("discard-changes", nc_nsdefs, nc_prefix), lambda c, _, err: cb(c, err))
+
+    def lock(cb: action(Client, ?NetconfError) -> None, datastore: str) -> None:
+        _log.info("NETCONF lock", {"datastore": datastore})
+        nc_nsdefs = [(nc_prefix, NS_NC_1_0)]
+        rpc(xml.Node("lock", nc_nsdefs, nc_prefix, children=[
+            xml.Node("target", [], nc_prefix, children=[
+                xml.Node(datastore, [], nc_prefix)
+            ])
+        ]), lambda c, _, err: cb(c, err))
+
+    def unlock(cb: action(Client, ?NetconfError) -> None, datastore: str) -> None:
+        _log.info("NETCONF unlock", {"datastore": datastore})
+        nc_nsdefs = [(nc_prefix, NS_NC_1_0)]
+        rpc(xml.Node("unlock", nc_nsdefs, nc_prefix, children=[
+            xml.Node("target", [], nc_prefix, children=[
+                xml.Node(datastore, [], nc_prefix)
+            ])
+        ]), lambda c, _, err: cb(c, err))
+
+    def get_schema(cb: action(Client, ?xml.Node, ?NetconfError) -> None, identifier: str, version: ?str=None, format: str="yang") -> None:
+        _log.info("NETCONF get-schema", {"identifier": identifier, "version": version, "format": format})
+        # get-schema is part of ietf-netconf-monitoring, not base NETCONF
+        nc_nsdefs = [(None, "urn:ietf:params:xml:ns:yang:ietf-netconf-monitoring")]
+        children = [xml.Node("identifier", text=identifier)]
+        if version is not None:
+            children.append(xml.Node("version", text=version))
+        children.append(xml.Node("format", text=format))
+        rpc(xml.Node("get-schema", nc_nsdefs, children=children), cb)
+
+    def list_schemas(cb: action(Client, list[(identifier: str, namespace: str, version: str, format: str)], ?NetconfError) -> None) -> None:
+        """List available schemas and return parsed list of (identifier, namespace, version, format) tuples
+
+        Uses ietf-yang-library (RFC 8525) if available, which returns modules used by
+        the running datastore. Falls back to ietf-netconf-monitoring (RFC 6022) which
+        returns all schemas available on the device.
+        """
+        _log.info("NETCONF list-schemas")
+
+        def parse_response_yang_library(c: Client, result: ?xml.Node, error: ?NetconfError):
+            """Parse response from ietf-yang-library query"""
+            if error is not None:
+                _log.error("ietf-yang-library query failed", {"error": error})
+                cb(c, [], error)
+                return
+
+            schemas = []
+            if result is not None and result.tag == "rpc-reply":
+                for child in result.children:
+                    if child.tag == "data":
+                        schemas = parse_yang_library_data(child)
+                        _log.debug("Found schemas in yang-library", {"count": len(schemas)})
+
+            cb(c, schemas, None)
+
+        def parse_yang_library_data(data_node: xml.Node) -> list[(identifier: str, namespace: str, version: str, format: str)]:
+            """Parse module data from ietf-yang-library response
+
+            1. Find the running datastore's schema
+            2. Get the module-sets referenced by that schema
+            3. Collect modules from those module-sets
+            """
+            schemas = []
+            running_schema_name = None
+            target_module_sets: list[str] = []
+
+            # TODO: parse this with schema-driven parser and convert to adata?!
+            for yang_library in data_node.children:
+                if yang_library.tag == "yang-library":
+                    # First: Find the schema used by the running datastore
+                    for child in yang_library.children:
+                        if child.tag == "datastore":
+                            datastore_name = None
+                            schema_name = None
+                            for ds_child in child.children:
+                                if ds_child.tag == "name":
+                                    datastore_name = ds_child.text
+                                elif ds_child.tag == "schema":
+                                    schema_name = ds_child.text
+                            # Look for the running datastore
+                            if datastore_name in ["ietf-datastores:running", "running", "ds:running"] and schema_name is not None:
+                                running_schema_name = schema_name
+                                break
+
+                    # Second: Find which module-sets are used by the running schema
+                    if running_schema_name is not None:
+                        for child in yang_library.children:
+                            if child.tag == "schema":
+                                schema_name = None
+                                for schema_child in child.children:
+                                    if schema_child.tag == "name":
+                                        schema_name = schema_child.text
+                                    elif schema_child.tag == "module-set" and schema_name == running_schema_name:
+                                        ms_text = schema_child.text
+                                        if ms_text is not None:
+                                            target_module_sets.append(ms_text)
+
+                    # Third: Collect modules from the target module-sets
+                    for child in yang_library.children:
+                        if child.tag == "module-set":
+                            module_set_name: ?str = None
+                            # First find the module-set name
+                            for ms_child in child.children:
+                                if ms_child.tag == "name":
+                                    module_set_name = ms_child.text
+                                    break
+
+                            # Then collect modules if this module-set is in our target list
+                            if module_set_name is not None and module_set_name in target_module_sets:
+                                for ms_child in child.children:
+                                    if ms_child.tag == "module" or ms_child.tag == "import-only-module":
+                                        name = None
+                                        namespace = None
+                                        revision = None
+                                        submodules: list[(name: str, revision: str)] = []
+                                        for attr in ms_child.children:
+                                            attr_text = attr.text
+                                            if attr.tag == "name" and attr_text is not None:
+                                                name = attr_text
+                                            elif attr.tag == "namespace" and attr_text is not None:
+                                                namespace = attr_text
+                                            elif attr.tag == "revision" and attr_text is not None:
+                                                revision = attr_text
+                                            elif attr.tag == "submodule":
+                                                # Parse submodule information
+                                                submod_name = None
+                                                submod_revision = None
+                                                for submod_attr in attr.children:
+                                                    submod_text = submod_attr.text
+                                                    if submod_attr.tag == "name" and submod_text is not None:
+                                                        submod_name = submod_text
+                                                    elif submod_attr.tag == "revision" and submod_text is not None:
+                                                        submod_revision = submod_text
+                                                if submod_name is not None:
+                                                    submod_version = submod_revision if submod_revision is not None else ""
+                                                    submodules.append((name=submod_name, revision=submod_version))
+
+                                        # Add the main module
+                                        if name is not None and namespace is not None:
+                                            version = revision if revision is not None else ""
+                                            schemas.append((identifier=name, namespace=namespace, version=version, format="yang"))
+
+                                            # Add all submodules (they inherit namespace from parent module)
+                                            for submod in submodules:
+                                                schemas.append((identifier=submod.name, namespace=namespace, version=submod.revision, format="yang"))
+
+            return schemas
+
+        def parse_response_netconf_monitoring(c: Client, result: ?xml.Node, error: ?NetconfError):
+            """Parse response from ietf-netconf-monitoring query"""
+            if error is not None:
+                _log.error("ietf-netconf-monitoring query failed", {"error": error})
+                cb(c, [], error)
+                return
+
+            schemas = []
+            if result is not None and result.tag == "rpc-reply":
+                for child in result.children:
+                    if child.tag == "data":
+                        schemas = parse_netconf_monitoring_data(child)
+                        _log.debug("Found schemas in netconf-monitoring", {"count": len(schemas)})
+
+            cb(c, schemas, None)
+
+        def parse_netconf_monitoring_data(data_node: xml.Node) -> list[(identifier: str, namespace: str, version: str, format: str)]:
+            """Parse schema data from ietf-netconf-monitoring response"""
+            schemas = []
+            for netconf_state in data_node.children:
+                if netconf_state.tag == "netconf-state":
+                    for schemas_node in netconf_state.children:
+                        if schemas_node.tag == "schemas":
+                            for schema in schemas_node.children:
+                                if schema.tag == "schema":
+                                    identifier = None
+                                    namespace = None
+                                    version = None
+                                    format = None
+                                    for attr in schema.children:
+                                        attr_text = attr.text
+                                        if attr.tag == "identifier" and attr_text is not None:
+                                            identifier = attr_text
+                                        elif attr.tag == "namespace" and attr_text is not None:
+                                            namespace = attr_text
+                                        elif attr.tag == "version" and attr_text is not None:
+                                            version = attr_text
+                                        elif attr.tag == "format" and attr_text is not None:
+                                            format = attr_text
+                                    if identifier is not None and namespace is not None and version is not None and format is not None:
+                                        schemas.append((identifier=identifier, namespace=namespace, version=version, format=format))
+            return schemas
+
+        # Check what capabilities the server supports
+        supports_yang_library = False
+        supports_netconf_monitoring = False
+
+        for cap in capabilities:
+            if "urn:ietf:params:netconf:capability:yang-library" in cap:
+                supports_yang_library = True
+            if "urn:ietf:params:xml:ns:yang:ietf-netconf-monitoring" in cap:
+                supports_netconf_monitoring = True
+
+        # Use yang-library if available (preferred), otherwise netconf-monitoring
+        if supports_yang_library:
+            _log.debug("Using ietf-yang-library for schema discovery")
+            # Get the complete yang-library data including:
+            # - datastore definitions (to know which module-sets each datastore uses)
+            # - module-sets (containing modules and import-only-modules)
+            filter_node = xml.Node("filter", None, None, [("type", "subtree")], [
+                xml.Node("yang-library",
+                    [(None, "urn:ietf:params:xml:ns:yang:ietf-yang-library")],
+                    children=[
+                        xml.Node("datastore"),
+                        xml.Node("schema"),
+                        xml.Node("module-set")
+                    ]
+                )
+            ], None, None)
+            get(parse_response_yang_library, filter_node)
+        elif supports_netconf_monitoring:
+            _log.debug("Using ietf-netconf-monitoring for schema discovery")
+            filter_node = xml.Node("filter", None, None, [("type", "subtree")], [
+                xml.Node("netconf-state",
+                    [(None, "urn:ietf:params:xml:ns:yang:ietf-netconf-monitoring")],
+                    children=[xml.Node("schemas")]
+                )
+            ], None, None)
+            get(parse_response_netconf_monitoring, filter_node)
+        else:
+            # No schema discovery methods advertised
+            cb(self, [], NetconfError("No schema discovery method advertised (neither ietf-yang-library nor ietf-netconf-monitoring)"))
+
+    def rpc_action(content: xml.Node, callback: action(Client, ?xml.Node, ?NetconfError) -> None) -> None:
+        action_node = xml.Node("action", [(None, NS_YANG_ACTION)], None, [], [content], None, None)
+        rpc(action_node, callback)
+
+    def _send_hello() -> None:
+        hello = """<?xml version="1.0" encoding="UTF-8"?>
+        <hello xmlns="urn:ietf:params:xml:ns:netconf:base:1.0">
+            <capabilities>
+                <capability>urn:ietf:params:netconf:base:1.0</capability>
+                <capability>urn:ietf:params:netconf:base:1.1</capability>
+            </capabilities>
+        </hello>"""
+        buf: Buffer = Buffer()
+        buf.write_str(hello)
+        _send_message(buf)
+
+    def handle_msg(msg: str) -> None:
+        if len(msg) == 0:
+            _log.debug("Ignoring empty message")
+            return
+        _log.trace("MSG:", {"msg": msg})
+        try:
+            root = xml.decode(msg)
+
+            # Detect/update namespace prefix mode from server messages
+            root_prefix = root.prefix
+            if root_prefix is not None and root_prefix != nc_prefix:
+                if nc_prefix is None:
+                    _log.info("Server switched to explict namespace prefix mode", {"prefix": root_prefix})
+                else:
+                    _log.info("Explicit namespace prefix changed", {"previous": nc_prefix, "new": root_prefix})
+                nc_prefix = root_prefix
+            elif root_prefix is None and nc_prefix is not None:
+                _log.info("Server switched to implicit namespace mode")
+                nc_prefix = None
+
+            if root.tag == "notification": # TODO: check namespace as well?
+                _on_msg_notification(root)
+            elif root.tag == "rpc-reply": # TODO: check namespace as well?
+                _on_msg_rpc_reply(root)
+            elif root.tag == "hello": # TODO: check namespace as well?
+                _on_msg_hello(root)
+            else:
+                _log.warning("Unhandled message type:", {"root.tag": root.tag})
+        except Exception as exc:
+            _log.error("Failed to parse XML", {"msg": msg, "exc": exc})
+            # TODO: I think we need to disconnect and start over, no?
+
+    def _on_msg_hello(root: xml.Node) -> None:
+        for n in root.children:
+            if n.tag == "capabilities": # TODO: check namespace as well?
+                capabilities.clear()
+                for cap in n.children:
+                    if cap.tag == "capability": # TODO: check namespace as well?
+                        cap_body = cap.text # cap_body = cap.text.strip()
+                        _on_capability(cap)
+                    else:
+                        pass # TODO: Warn?
+            elif n.tag == "session-id": # TODO: check namespace as well?
+                session_id = n.text
+        _activate_fixups()
+        state = "CONNECTED"
+        on_connect(self, None)
+
+    def _on_capability(cap: xml.Node) -> None:
+        cap_text = cap.text # cap_text = cap.text.strip()
+        if cap_text is not None:
+            capabilities.append(cap_text)
+            if cap_text == CAP_NC_1_1:
+                _log.debug("NETCONF 1.1 supported, switching to chunked framing")
+                framing = CHUNKED_FRAMING
+
+    def _on_msg_rpc_reply(root: xml.Node) -> None:
+        msg_id: ?str = None
+        for attr_name, attr_val in root.attributes:
+            # Handle both "message-id" and "nc:message-id" attributes
+            if attr_name == "message-id" or attr_name == "nc:message-id":
+                msg_id = attr_val
+                break
+            # Also handle other potential namespace prefixes
+            elif attr_name.split(":", -1)[-1] == "message-id":
+                msg_id = attr_val
+                break
+
+        fixed_root = _apply_response_fixups(root)
+
+        if len(rpc_cbs) > 0:
+            cb = rpc_cbs.pop(0)
+            if msg_id is None:
+                _log.warning("Received invalid rpc-reply, missing message-id", {"msg": fixed_root.encode()})
+            elif msg_id is not None and msg_id != cb.id:
+                _log.warning("Received rpc-reply with unexpected message-id", {"msg-id": msg_id, "cb.id": cb.id})
+
+            if len(fixed_root.children) == 0:
+                cb.cb(self, fixed_root, NetconfError("Empty <rpc-reply>"))
+            elif len(fixed_root.children) == 1 and fixed_root.children[0].tag == "ok":
+                # TODO: Should also verify namespace is NS_NC_1_0
+                cb.cb(self, fixed_root, None)
+            else:
+                # Parse for errors
+                error = _parse_rpc_errors(fixed_root)
+
+                if error is not None:
+                    # Error response
+                    cb.cb(self, fixed_root, error)
+                else:
+                    # Normal data response - pass the whole root
+                    cb.cb(self, fixed_root, None)
+        else:
+            _log.error("No more RPC callbacks", {"msg-id": msg_id})
+
+
+
+    def _on_msg_notification(root: xml.Node) -> None:
+        _on_notif = on_notif
+        if _on_notif is not None:
+            _on_notif(self, root)
+
+    def _on_legacy_msg_data() -> bool:
+        i = recv_buf.find_bytes(LEGACY_SEPARATOR)
+        if isinstance(i, int):
+            _msg_data = recv_buf.read_bytes(i)
+            if isinstance(_msg_data, bytes):
+                recv_buf.skip_bytes(len(LEGACY_SEPARATOR))
+                recv_buf.consume()
+                handle_msg(_msg_data.decode())
+                return True
+        recv_buf.rewind()
+        return False
+
+    def _on_chunked_msg_data() -> bool:
+        m = recv_buf.match_bytes(CHUNK_TAG_PREFIX)
+        if isinstance(m, IncompleteReadError):
+            recv_buf.rewind()
+            return False
+        elif isinstance(m, bool):
+            if not m:
+                on_connect(self, NetconfError("Invalid chunk framing data"))
+                return False
+            _len_text_len = recv_buf.find_bytes(CHUNK_TAG_POSTFIX)
+            if isinstance(_len_text_len, IncompleteReadError):
+                recv_buf.rewind()
+                return False
+            elif isinstance(_len_text_len, int):
+                _len_text = recv_buf.read_bytes(_len_text_len)
+
+                _skip = recv_buf.skip_bytes(len(CHUNK_TAG_POSTFIX))
+                if isinstance(_skip, IncompleteReadError):
+                    recv_buf.rewind()
+                    return False
+                elif isinstance(_skip, bool) and _skip:
+                    if isinstance(_len_text, bytes):
+                        if _len_text == CHUNK_TAG_END_OF_MSG:
+                            _msg_data = chunk_buf.read_all_bytes()
+                            chunk_buf.consume()
+                            handle_msg(_msg_data.decode())
+                            return True
+                        else:
+                            try:
+                                l = int(_len_text.decode())
+                                chunk = recv_buf.read_bytes(l)
+                                chunk_buf.write_bytes(chunk)
+                                recv_buf.consume()
+                                return True
+                            except IncompleteReadError:
+                                recv_buf.rewind()
+                                return False
+        # TODO: FIXME: match_bytes should always return bytes or raise exception
+        raise UnreachableError("Unexpected state in _on_chunked_msg_data")
+
+    def _on_receive(data: bytes):
+        #_log.trace("DATA:", {"data": data})
+        recv_buf.write_bytes(data)
+        try_read: bool = True
+        # while recv_buf.has_unread_bytes() and try_read: # actonc: Name try_read is not in scope
+        while recv_buf.has_unread_bytes():
+            if not try_read:
+                break
+            if framing == SEPARATOR_FRAMING:
+                try_read = _on_legacy_msg_data()
+            elif framing == CHUNKED_FRAMING:
+                try_read = _on_chunked_msg_data()
+            else:
+                try_read = False
+                on_connect(self, NetconfError("Unknown framing type: {framing}"))
+
+    def _on_pipe_event(err: ?Exception, data: ?bytes):
+        if data is not None:
+            _on_receive(data)
+            return
+        _on_connect(err)
+
+    def _on_connect(err: ?Exception):
+        if err is not None:
+            _log.error("Failed to connect", {"err": err})
+            on_connect(self, err)
+        else:
+            _log.info("Connected", {"address": address, "port": port, "username": username})
+            state = STATE_CONNECTED
+            _send_hello()
+
+    def _connect():
+        if p is None:
+            if connect_cap is not None:
+                sp = sshpipe.SshPipe(
+                    connect_cap,
+                    address=address,
+                    port=port,
+                    username=username,
+                    password=password,
+                    private_key_file=key,
+                    subsystem="netconf",
+                    host_key_check=sshpipe.HOST_KEY_CHECK_NONE if skip_host_key_check else sshpipe.HOST_KEY_CHECK_ACCEPT_NEW,
+                    log_handler=log_handler)
+                sp.read_cb(_on_pipe_event)
+                p = sp
+            else:
+                on_connect(self, ValueError("a TCP connect capability is required to establish an SSH connection"))
+        else:
+            if p is not None:
+                p.read_cb(_on_pipe_event)
+
+    _connect()
+
+
+actor Server(
+        pipe: Pipe,
+        on_connect: ?action(Server, ?Exception) -> None=None,
+        on_rpc: action(Server, str, xml.Node) -> None,
+        capabilities: ?list[str]=None,
+        log_handler: ?logging.Handler=None):
+
+    _log = logging.Logger(log_handler)
+
+    var framing = SEPARATOR_FRAMING
+    var recv_buf = Buffer()
+    var chunk_buf = Buffer()
+    var server_capabilities = capabilities if capabilities is not None else [CAP_NC_1_0, CAP_NC_1_1]
+
+    def close(cb: ?action() -> None):
+        pipe.close(cb)
+
+    def restart():
+        framing = SEPARATOR_FRAMING
+        recv_buf = Buffer()
+        chunk_buf = Buffer()
+        pipe.restart()
+
+    def _send_message(data: Buffer):
+        if framing == SEPARATOR_FRAMING:
+            data.write_bytes(LEGACY_SEPARATOR)
+            pipe.write(data.read_all_bytes())
+        elif framing == CHUNKED_FRAMING:
+            while True:
+                chunk_size = CHUNK_SIZE_MAX if data.unread_bytes > CHUNK_SIZE_MAX else data.unread_bytes
+                if chunk_size <= 0:
+                    pipe.write("\n##\n".encode())
+                    break
+
+                chunk = data.read_bytes(chunk_size)
+                pipe.write(("\n#" + str(chunk_size) + "\n").encode())
+                pipe.write(chunk)
+
+    def _send_node(node: xml.Node):
+        buf = Buffer()
+        buf.write_str(xml.encode(node))
+        _send_message(buf)
+
+    def _send_hello():
+        caps = []
+        for cap in server_capabilities:
+            caps.append(xml.Node("capability", text=cap))
+
+        hello = xml.Node("hello", [(None, NS_NC_1_0)], children=[
+            xml.Node("capabilities", children=caps)
+        ])
+        _send_node(hello)
+
+    def _send_rpc_reply(message_id: str, children: list[xml.Node]):
+        rpc_reply = xml.Node("rpc-reply", [(None, NS_NC_1_0)], None, [("message-id", message_id)], children)
+        _send_node(rpc_reply)
+
+    def send_reply(message_id: str, children: list[xml.Node]):
+        _send_rpc_reply(message_id, children)
+
+    def send_notification(notification: xml.Node):
+        _send_node(notification)
+
+    def _send_ok(message_id: str):
+        _send_rpc_reply(message_id, [xml.Node("ok")])
+
+    def send_ok(message_id: str):
+        _send_ok(message_id)
+
+    def _send_error(message_id: str, error_tag: str, error_message: str, error_type: str="application"):
+        rpc_error = xml.Node("rpc-error", children=[
+            xml.Node("error-type", text=error_type),
+            xml.Node("error-tag", text=error_tag),
+            xml.Node("error-severity", text="error"),
+            xml.Node("error-message", text=error_message)
+        ])
+        _send_rpc_reply(message_id, [rpc_error])
+
+    def send_error(message_id: str, error_tag: str, error_message: str, error_type: str="application"):
+        _send_error(message_id, error_tag, error_message, error_type)
+
+    def _read_message_id(root: xml.Node, default_id: str) -> str:
+        message_id = default_id
+        for attr_name, attr_val in root.attributes:
+            if attr_name == "message-id" or attr_name.split(":", -1)[-1] == "message-id":
+                message_id = attr_val
+                break
+        return message_id
+
+    def _on_msg_hello(root: xml.Node):
+        client_supports_1_1 = False
+        for n in root.children:
+            if n.tag == "capabilities":
+                for cap in n.children:
+                    if cap.tag == "capability":
+                        cap_text = cap.text
+                        if cap_text is not None and cap_text == CAP_NC_1_1:
+                            client_supports_1_1 = True
+        if client_supports_1_1 and CAP_NC_1_1 in server_capabilities:
+            framing = CHUNKED_FRAMING
+
+    def _dispatch_rpc(message_id: str, op: xml.Node):
+        if op.tag == "close-session":
+            _send_ok(message_id)
+            return
+
+        on_rpc(self, message_id, op)
+
+    def _on_msg_rpc(root: xml.Node):
+        message_id = _read_message_id(root, "0")
+        if len(root.children) == 0:
+            _send_error(message_id, "missing-element", "RPC request has no operation")
+            return
+        _dispatch_rpc(message_id, root.children[0])
+
+    def _handle_msg(msg: str):
+        if msg == "":
+            return
+
+        try:
+            root = xml.decode(msg)
+            if root.tag == "hello":
+                _on_msg_hello(root)
+            elif root.tag == "rpc":
+                _on_msg_rpc(root)
+            else:
+                _log.warning("Unhandled NETCONF message", {"tag": root.tag})
+        except Exception as e:
+            _log.error("Failed to decode NETCONF message", {"exception": e, "msg": msg})
+
+    def _on_legacy_msg_data() -> bool:
+        i = recv_buf.find_bytes(LEGACY_SEPARATOR)
+        if isinstance(i, int):
+            msg_data = recv_buf.read_bytes(i)
+            if isinstance(msg_data, bytes):
+                recv_buf.skip_bytes(len(LEGACY_SEPARATOR))
+                recv_buf.consume()
+                _handle_msg(msg_data.decode())
+                return True
+        recv_buf.rewind()
+        return False
+
+    def _on_chunked_msg_data() -> bool:
+        m = recv_buf.match_bytes(CHUNK_TAG_PREFIX)
+        if isinstance(m, IncompleteReadError):
+            recv_buf.rewind()
+            return False
+        elif isinstance(m, bool):
+            if not m:
+                _log.error("Invalid NETCONF chunk framing")
+                return False
+
+            len_text_len = recv_buf.find_bytes(CHUNK_TAG_POSTFIX)
+            if isinstance(len_text_len, IncompleteReadError):
+                recv_buf.rewind()
+                return False
+            elif isinstance(len_text_len, int):
+                len_text = recv_buf.read_bytes(len_text_len)
+
+                skip_ok = recv_buf.skip_bytes(len(CHUNK_TAG_POSTFIX))
+                if isinstance(skip_ok, IncompleteReadError):
+                    recv_buf.rewind()
+                    return False
+                elif isinstance(skip_ok, bool) and skip_ok:
+                    if isinstance(len_text, bytes):
+                        if len_text == CHUNK_TAG_END_OF_MSG:
+                            msg_data = chunk_buf.read_all_bytes()
+                            chunk_buf.consume()
+                            _handle_msg(msg_data.decode())
+                            return True
+
+                        try:
+                            l = int(len_text.decode())
+                            chunk = recv_buf.read_bytes(l)
+                            chunk_buf.write_bytes(chunk)
+                            recv_buf.consume()
+                            return True
+                        except IncompleteReadError:
+                            recv_buf.rewind()
+                            return False
+        raise UnreachableError("Unexpected state in _on_chunked_msg_data")
+
+    def _on_receive(data: bytes):
+        recv_buf.write_bytes(data)
+        try_read: bool = True
+        while recv_buf.has_unread_bytes():
+            if not try_read:
+                break
+            if framing == SEPARATOR_FRAMING:
+                try_read = _on_legacy_msg_data()
+            elif framing == CHUNKED_FRAMING:
+                try_read = _on_chunked_msg_data()
+            else:
+                try_read = False
+                _log.error("Unknown framing type", {"framing": framing})
+
+    def _on_pipe_event(err: ?Exception, data: ?bytes):
+        if data is not None:
+            _on_receive(data)
+            return
+
+        if err is None:
+            framing = SEPARATOR_FRAMING
+            recv_buf = Buffer()
+            chunk_buf = Buffer()
+            _send_hello()
+            _on_connect = on_connect
+            if _on_connect is not None:
+                _on_connect(self, None)
+        else:
+            _log.error("Transport pipe connection error", {"error": err})
+            _on_connect = on_connect
+            if _on_connect is not None:
+                _on_connect(self, err)
+
+    pipe.read_cb(_on_pipe_event)
+
+
+class NsMaps(object):
+    def __init__(self, namespaces: list[(?str, str)], parent: ?NsMaps):
+        self.nsmap = {_prefix if _prefix is not None else "": _ns for _prefix, _ns in namespaces}
+        self.parent = parent
+
+    def lookup(self, prefix: ?str) -> ?str:
+        _inst = self
+        while True:
+            ns: ?str = self.nsmap.get(prefix if prefix is not None else "")
+            if ns is not None:
+                return ns
+            _parent = _inst.parent
+            if _parent is not None:
+                _inst = _parent
+            else:
+                return None
+
+
+actor SchemaGetter(client):
+    """Helper actor for downloading schemas from NETCONF server."""
+
+    def download(on_get_schema: action(SchemaGetter, int, int, (identifier: str, version: ?str, format: ?str), ?str, ?NetconfError) -> None, on_done: action(SchemaGetter, ?NetconfError) -> None, schemas: list[(identifier: str, version: ?str, format: ?str)]):
+        """Download schemas from a NETCONF server.
+
+        Download a list of schemas from NETCONF server with <get-schema>.
+        Users should prepare the schema list themselves, typically by calling
+        list_schemas() first and applying any necessary filtering.
+
+        Args:
+            on_get_schema: Callback invoked for each schema download. Parameters:
+                - current_index (int): index of current schema being downloaded
+                - total_count (int): Total number of schemas to download
+                - schema_id: (identifier, ?version, ?format)
+                - schema_data (?str): Schema content if successful, None on error
+                - error (?NetconfError): None if successful, error details if failed
+            on_done: Callback invoked when all downloads complete. Parameter:
+                - error (?NetconfError): None if successful, error details if failed
+            schemas: List of schemas to download, each as named tuple (identifier, ?version, ?format)
+            TODO: ideally this would be a set of tuples, once named tuples are *Hashable*
+        """
+        def _download_next_schema(current_download_index):
+            """Download the next schema in the queue"""
+            if current_download_index >= len(schemas):
+                # All schemas downloaded successfully
+                on_done(self)
+                return
+            schema = schemas[current_download_index]
+
+            # Use "yang" as default format if not specified
+            format_str = schema.format if schema.format is not None else "yang"
+            client.get_schema(
+                lambda c, r, e: _on_get_schema(current_download_index, c, r, e),
+                schema.identifier, schema.version, format_str
+            )
+
+        def _on_get_schema(current_download_index, c: Client, result: ?xml.Node, error: ?NetconfError):
+            """Handle individual schema response"""
+            schema = schemas[current_download_index]
+            if error is not None:
+                on_get_schema(self, current_download_index+1, len(schemas), schema, None, error)
+            else:
+                # Extract schema data
+                schema_data = None
+                if result is not None:
+                    for child in result.children:
+                        if child.tag == "data":
+                            schema_data = child.text
+                            break
+
+                # Call the callback with current progress and schema data
+                if schema_data is not None and schema_data.strip() != "":
+                    on_get_schema(self, current_download_index+1, len(schemas), schema, schema_data)
+                else:
+                    on_get_schema(self, current_download_index+1, len(schemas), schema, None, NetconfError("Missing schema data"))
+
+            # Move to next schema
+            _download_next_schema(current_download_index + 1)
+
+        _download_next_schema(0)
+
+
+################################################################################
+## Tests                                                                      ##
+################################################################################
+#
+# These test cases can be run with `acton test` but they require a running SSH
+# server, for example `docker run -td -P ghcr.io/notconf/notconf` - grab the
+# port and update test_port below, i.e.:
+# - docker run -td --name notconf -P ghcr.io/notconf/notconf
+# - docker inspect notconf | jq -r '.[0].NetworkSettings.Ports["830/tcp"][0].HostPort'
+# - update test_port below with the port from the above command
+# - acton test
+
+test_port = 42830
+test_address = "localhost"
+test_username = "admin"
+test_password = "admin"
+
+
+actor _test_client_server_actor_pipe_get(t: testing.EnvT):
+    """Test in-process Client <-> Server over ActorPipe with a static <get> reply."""
+    log = logging.Logger(t.log_handler)
+    pipes = actor_pipe_pair()
+
+    def _on_server_rpc(s: Server,
+                       message_id: str,
+                       op: xml.Node):
+        if op.tag != "get":
+            s.send_error(message_id, "operation-not-supported", "Unsupported RPC operation: {op.tag}")
+            return
+
+        s.send_reply(message_id, [xml.Node("data", [(None, NS_NC_1_0)], children=[
+            xml.Node("system", [(None, "urn:example:system")], children=[
+                xml.Node("hostname", text="actor-pipe-demo")
+            ])
+        ])])
+
+    def _on_connect(c: Client, e: ?Exception):
+        if e is not None:
+            t.failure(ValueError("Failed to connect to in-process NETCONF server: {e}"))
+        else:
+            c.get(_on_get)
+
+    def _on_get(c: Client, result: ?xml.Node, error: ?NetconfError):
+        if error is not None:
+            t.failure(error)
+            return
+        if result is None:
+            t.failure(ValueError("Missing rpc-reply"))
+            return
+
+        hostname = None
+        if result is not None:
+            for rpc_child in result.children:
+                if rpc_child.tag == "data":
+                    for data_child in rpc_child.children:
+                        if data_child.tag == "system":
+                            for system_child in data_child.children:
+                                if system_child.tag == "hostname":
+                                    hostname = system_child.text
+
+        if hostname == "actor-pipe-demo":
+            log.info("In-process NETCONF <get> completed")
+            c.close(None)
+            t.success()
+        else:
+            t.failure(ValueError("Unexpected hostname in reply: {hostname}"))
+
+    server = Server(pipe=pipes.server, on_rpc=_on_server_rpc, log_handler=t.log_handler)
+    client = Client(None,
+                    address="actor-pipe",
+                    username="actor-pipe",
+                    key=None,
+                    password=None,
+                    port=0,
+                    on_connect=_on_connect,
+                    on_notif=None,
+                    log_handler=t.log_handler,
+                    pipe=pipes.client)
+
+
+actor _test_client_server_tcp_get(t: testing.EnvT):
+    """Test loopback TCP Client <-> Server over TcpPipe with a static <get> reply."""
+    log = logging.Logger(t.log_handler)
+    var port = random.randint(20000, 29999)
+    var listen_attempts = 0
+    var done = False
+    var servers: list[Server] = []
+    var listener: ?TcpPipeListener = None
+    var client: ?Client = None
+    connect_cap = net.TCPConnectCap(net.TCPCap(net.NetCap(t.env.auth)))
+    listen_cap = net.TCPListenCap(net.TCPCap(net.NetCap(t.env.auth)))
+
+    def _fail_once(err: Exception):
+        if done:
+            return
+        done = True
+        t.failure(err)
+
+    def _success_once():
+        if done:
+            return
+        done = True
+        t.success()
+
+    def _on_server_rpc(s: Server, message_id: str, op: xml.Node):
+        if op.tag != "get":
+            s.send_error(message_id, "operation-not-supported", "Unsupported RPC operation: {op.tag}")
+            return
+
+        s.send_reply(message_id, [xml.Node("data", [(None, NS_NC_1_0)], children=[
+            xml.Node("system", [(None, "urn:example:system")], children=[
+                xml.Node("hostname", text="tcp-pipe-demo")
+            ])
+        ])])
+
+    def _on_accept(l: TcpPipeListener, p: TcpListenPipe):
+        servers.append(Server(pipe=p, on_rpc=_on_server_rpc, log_handler=t.log_handler))
+
+    def _on_listen(l: TcpPipeListener, err: ?Exception):
+        if err is not None:
+            # net.TCPListener cannot report an ephemerally-bound port, so we
+            # pick random ones; on a (rare) collision just retry with a new one.
+            if listen_attempts < 5:
+                listen_attempts += 1
+                port = random.randint(20000, 29999)
+                listener = TcpPipeListener(listen_cap, "127.0.0.1", port, _on_listen, _on_accept)
+            else:
+                _fail_once(ValueError("Failed to start TCP listener on 127.0.0.1:{port}: {err}"))
+            return
+
+        log.info("TCP listener ready", {"port": port})
+        client_pipe = TcpPipe(connect_cap=connect_cap, address="127.0.0.1", port=port)
+        client = Client(None,
+                        address="127.0.0.1",
+                        username="tcp-pipe",
+                        key=None,
+                        password=None,
+                        port=port,
+                        on_connect=_on_connect,
+                        on_notif=None,
+                        log_handler=t.log_handler,
+                        pipe=client_pipe)
+
+    def _on_connect(c: Client, e: ?Exception):
+        if e is not None:
+            _fail_once(ValueError("Failed to connect to loopback NETCONF server: {e}"))
+        else:
+            c.get(_on_get)
+
+    def _on_get(c: Client, result: ?xml.Node, error: ?NetconfError):
+        if error is not None:
+            _fail_once(error)
+            return
+        if result is None:
+            _fail_once(ValueError("Missing rpc-reply"))
+            return
+
+        hostname = None
+        if result is not None:
+            for rpc_child in result.children:
+                if rpc_child.tag == "data":
+                    for data_child in rpc_child.children:
+                        if data_child.tag == "system":
+                            for system_child in data_child.children:
+                                if system_child.tag == "hostname":
+                                    hostname = system_child.text
+
+        if hostname == "tcp-pipe-demo":
+            log.info("Loopback TCP NETCONF <get> completed")
+            c.close(None)
+            _success_once()
+        else:
+            _fail_once(ValueError("Unexpected hostname in reply: {hostname}"))
+
+    def _on_timeout():
+        _fail_once(ValueError("Timed out waiting for loopback TCP NETCONF <get>"))
+
+    after 2.0: _on_timeout()
+    listener = TcpPipeListener(listen_cap, "127.0.0.1", port, _on_listen, _on_accept)
+
+
+_ssh_test_username = "netconf"
+_ssh_test_password = "sekret"
+
+actor _SshTestServer(t: testing.EnvT,
+                     on_rpc: action(Server, str, xml.Node) -> None,
+                     on_port: action(int) -> None,
+                     on_error: action(str) -> None,
+                     capabilities: ?list[str]=None):
+    """A minimal NETCONF server over SSH: SshPipeListener feeding netconf.Server.
+
+    Serves the "netconf" subsystem with password authentication; every accepted
+    SSH channel becomes an independent NETCONF session driven by on_rpc.
+    """
+    var listener: ?sshpipe.SshPipeListener = None
+    var sessions: list[Server] = []
+
+    def _on_listen(l: sshpipe.SshPipeListener, err: ?Exception):
+        if err is not None:
+            on_error("SSH listen error: {err}")
+            return
+        port = l.bound_port()
+        on_port(int(port))
+
+    def _on_accept(l: sshpipe.SshPipeListener, p: sshpipe.SshListenPipe):
+        sessions.append(Server(pipe=p, on_rpc=on_rpc, capabilities=capabilities,
+                               log_handler=t.log_handler))
+
+    def close():
+        l = listener
+        if l is not None:
+            l.close()
+
+    def _auth(user: str, password: ?str, pubkey: ?bytes, respond: action(bool) -> None):
+        respond(user == _ssh_test_username and password == _ssh_test_password)
+
+    listener = sshpipe.SshPipeListener(
+        net.TCPListenCap(net.TCPCap(net.NetCap(t.env.cap))),
+        address="127.0.0.1",
+        port=0,
+        on_listen=_on_listen,
+        on_accept=_on_accept,
+        auth_check=_auth,
+        subsystem="netconf",
+        log_handler=t.log_handler)
+
+
+actor _test_client_server_ssh_get(t: testing.EnvT):
+    """Loopback NETCONF Client <-> Server over a real SSH transport (chunked framing)."""
+    log = logging.Logger(t.log_handler)
+    var done = False
+    var srv: ?_SshTestServer = None
+    var client: ?Client = None
+
+    def _fail_once(e: Exception):
+        if done:
+            return
+        done = True
+        _teardown()
+        t.failure(e)
+
+    def _success_once():
+        if done:
+            return
+        done = True
+        _teardown()
+        t.success()
+
+    def _teardown():
+        s = srv
+        if s is not None:
+            s.close()
+
+    def _on_server_rpc(s: Server, message_id: str, op: xml.Node):
+        if op.tag != "get":
+            s.send_error(message_id, "operation-not-supported", "Unsupported RPC operation: {op.tag}")
+            return
+        s.send_reply(message_id, [xml.Node("data", [(None, NS_NC_1_0)], children=[
+            xml.Node("system", [(None, "urn:example:system")], children=[
+                xml.Node("hostname", text="ssh-loopback-demo")
+            ])
+        ])])
+
+    def _on_get(c: Client, result: ?xml.Node, error: ?NetconfError):
+        if error is not None:
+            _fail_once(error)
+            return
+        hostname = None
+        if result is not None:
+            for rpc_child in result.children:
+                if rpc_child.tag == "data":
+                    for data_child in rpc_child.children:
+                        if data_child.tag == "system":
+                            for system_child in data_child.children:
+                                if system_child.tag == "hostname":
+                                    hostname = system_child.text
+        if hostname == "ssh-loopback-demo":
+            log.info("Loopback SSH NETCONF <get> completed")
+            c.close(None)
+            _success_once()
+        else:
+            _fail_once(ValueError("Unexpected hostname in reply: {hostname}"))
+
+    def _on_connect(c: Client, e: ?Exception):
+        if e is not None:
+            _fail_once(ValueError("Failed to connect over SSH: {e}"))
+        else:
+            c.get(_on_get)
+
+    def _on_port(port: int):
+        client = Client(net.TCPConnectCap(net.TCPCap(net.NetCap(t.env.cap))),
+                        address="127.0.0.1",
+                        port=port,
+                        username=_ssh_test_username,
+                        password=_ssh_test_password,
+                        key=None,
+                        on_connect=_on_connect,
+                        on_notif=None,
+                        skip_host_key_check=True,
+                        log_handler=t.log_handler)
+
+    def _on_error(msg: str):
+        _fail_once(ValueError(msg))
+
+    def _on_timeout():
+        _fail_once(ValueError("Timed out waiting for loopback SSH NETCONF <get>"))
+
+    srv = _SshTestServer(t, _on_server_rpc, _on_port, _on_error)
+    after 10.0: _on_timeout()
+
+
+actor _test_client_server_ssh_legacy_framing(t: testing.EnvT):
+    """SSH loopback against a 1.0-only server: legacy ]]>]]> framing end-to-end."""
+    log = logging.Logger(t.log_handler)
+    var done = False
+    var srv: ?_SshTestServer = None
+    var client: ?Client = None
+
+    def _fail_once(e: Exception):
+        if done:
+            return
+        done = True
+        _teardown()
+        t.failure(e)
+
+    def _success_once():
+        if done:
+            return
+        done = True
+        _teardown()
+        t.success()
+
+    def _teardown():
+        s = srv
+        if s is not None:
+            s.close()
+
+    def _on_server_rpc(s: Server, message_id: str, op: xml.Node):
+        s.send_reply(message_id, [xml.Node("data", [(None, NS_NC_1_0)], children=[
+            xml.Node("system", [(None, "urn:example:system")], children=[
+                xml.Node("hostname", text="ssh-legacy-demo")
+            ])
+        ])])
+
+    def _on_get(c: Client, result: ?xml.Node, error: ?NetconfError):
+        if error is not None:
+            _fail_once(error)
+            return
+        # A 1.0-only server exchange only completes if both sides stayed on
+        # legacy separator framing; chunked frames would never parse.
+        log.info("Loopback SSH NETCONF <get> with legacy framing completed")
+        c.close(None)
+        _success_once()
+
+    def _on_connect(c: Client, e: ?Exception):
+        if e is not None:
+            _fail_once(ValueError("Failed to connect over SSH: {e}"))
+        else:
+            c.get(_on_get)
+
+    def _on_port(port: int):
+        client = Client(net.TCPConnectCap(net.TCPCap(net.NetCap(t.env.cap))),
+                        address="127.0.0.1",
+                        port=port,
+                        username=_ssh_test_username,
+                        password=_ssh_test_password,
+                        key=None,
+                        on_connect=_on_connect,
+                        on_notif=None,
+                        skip_host_key_check=True,
+                        log_handler=t.log_handler)
+
+    def _on_error(msg: str):
+        _fail_once(ValueError(msg))
+
+    def _on_timeout():
+        _fail_once(ValueError("Timed out waiting for legacy framing SSH NETCONF <get>"))
+
+    srv = _SshTestServer(t, _on_server_rpc, _on_port, _on_error, capabilities=[CAP_NC_1_0])
+    after 10.0: _on_timeout()
+
+
+actor _test_client_server_ssh_auth_reject(t: testing.EnvT):
+    """Wrong SSH password: connect fails, on_connect carries the error."""
+    var done = False
+    var srv: ?_SshTestServer = None
+    var client: ?Client = None
+
+    def _on_server_rpc(s: Server, message_id: str, op: xml.Node):
+        pass
+
+    def _on_connect(c: Client, e: ?Exception):
+        if done:
+            return
+        done = True
+        s = srv
+        if s is not None:
+            s.close()
+        if e is not None:
+            t.success()
+        else:
+            t.failure(ValueError("Connect succeeded with wrong password"))
+
+    def _on_port(port: int):
+        client = Client(net.TCPConnectCap(net.TCPCap(net.NetCap(t.env.cap))),
+                        address="127.0.0.1",
+                        port=port,
+                        username=_ssh_test_username,
+                        password="wrong-password",
+                        key=None,
+                        on_connect=_on_connect,
+                        on_notif=None,
+                        skip_host_key_check=True,
+                        log_handler=t.log_handler)
+
+    def _on_error(msg: str):
+        if not done:
+            done = True
+            t.failure(ValueError(msg))
+
+    def _on_timeout():
+        if not done:
+            done = True
+            s = srv
+            if s is not None:
+                s.close()
+            t.failure(ValueError("Timed out waiting for SSH auth reject"))
+
+    srv = _SshTestServer(t, _on_server_rpc, _on_port, _on_error)
+    after 10.0: _on_timeout()
+
+
+actor _test_client_server_ssh_large_reply(t: testing.EnvT):
+    """A reply spanning many SSH channel reads survives reassembly intact."""
+    log = logging.Logger(t.log_handler)
+    var done = False
+    var srv: ?_SshTestServer = None
+    var client: ?Client = None
+    N_ENTRIES = 2000
+
+    def _fail_once(e: Exception):
+        if done:
+            return
+        done = True
+        _teardown()
+        t.failure(e)
+
+    def _success_once():
+        if done:
+            return
+        done = True
+        _teardown()
+        t.success()
+
+    def _teardown():
+        s = srv
+        if s is not None:
+            s.close()
+
+    def _on_server_rpc(s: Server, message_id: str, op: xml.Node):
+        entries = []
+        for i in range(N_ENTRIES):
+            entries.append(xml.Node("entry", children=[
+                xml.Node("index", text=str(i)),
+                xml.Node("value", text="payload-{i}-abcdefghijklmnopqrstuvwxyz")
+            ]))
+        s.send_reply(message_id, [xml.Node("data", [(None, NS_NC_1_0)], children=entries)])
+
+    def _on_get(c: Client, result: ?xml.Node, error: ?NetconfError):
+        if error is not None:
+            _fail_once(error)
+            return
+        count = 0
+        last_ok = False
+        if result is not None:
+            for rpc_child in result.children:
+                if rpc_child.tag == "data":
+                    for entry in rpc_child.children:
+                        if entry.tag == "entry":
+                            count += 1
+                            for f in entry.children:
+                                if f.tag == "index" and f.text == str(N_ENTRIES - 1):
+                                    last_ok = True
+        if count == N_ENTRIES and last_ok:
+            log.info("Large SSH NETCONF reply reassembled", {"entries": count})
+            c.close(None)
+            _success_once()
+        else:
+            _fail_once(ValueError("Large reply corrupted: {count} entries, last_ok={last_ok}"))
+
+    def _on_connect(c: Client, e: ?Exception):
+        if e is not None:
+            _fail_once(ValueError("Failed to connect over SSH: {e}"))
+        else:
+            c.get(_on_get)
+
+    def _on_port(port: int):
+        client = Client(net.TCPConnectCap(net.TCPCap(net.NetCap(t.env.cap))),
+                        address="127.0.0.1",
+                        port=port,
+                        username=_ssh_test_username,
+                        password=_ssh_test_password,
+                        key=None,
+                        on_connect=_on_connect,
+                        on_notif=None,
+                        skip_host_key_check=True,
+                        log_handler=t.log_handler)
+
+    def _on_error(msg: str):
+        _fail_once(ValueError(msg))
+
+    def _on_timeout():
+        _fail_once(ValueError("Timed out waiting for large SSH NETCONF reply"))
+
+    srv = _SshTestServer(t, _on_server_rpc, _on_port, _on_error)
+    after 15.0: _on_timeout()
+
+
+actor _test_netconf(t: testing.EnvT):
+    """Test SSH client towards a NETCONF server, like notconf
+    """
+    t.require("notconf-server")
+    log = logging.Logger(t.log_handler)
+
+    def _on_connect(c: Client, e: ?Exception):
+        if e is not None:
+            log.error("Failed to connect", {"error": e})
+            t.failure(ValueError("Failed to connect to NETCONF server: {e}"))
+        else:
+            log.info("Connected to NETCONF server")
+            for cap in c.get_capabilities():
+                if cap.startswith("urn:ietf:params:netconf:base:1"):
+                    log.info("Got NETCONF {cap} capability, looks reasonable, hello success")
+                    c.get_config(_on_get_config)
+
+    def _on_get_config(c: Client, result: ?xml.Node, error: ?NetconfError):
+        if error is not None:
+            log.error("<get-config> failed", {"error": error})
+            t.failure(ValueError("get-config failed with error"))
+        else:
+            log.info("<get-config> success")
+            t.success()
+
+    c = Client(net.TCPConnectCap(net.TCPCap(net.NetCap(t.env.cap))),
+                on_connect=_on_connect,
+                address=test_address,
+                username=test_username,
+                key=None,
+                password=test_password,
+                port=test_port,
+                on_notif=None,
+                skip_host_key_check=True,
+                log_handler=t.log_handler)
+
+
+actor _test_get_schema(t: testing.EnvT):
+    """Test SSH client get-schema operation towards a NETCONF server
+    """
+    t.require("notconf-server")
+    log = logging.Logger(t.log_handler)
+
+    def _on_connect(c: Client, e: ?Exception):
+        if e is not None:
+            log.error("Failed to connect", {"error": e})
+            t.failure(ValueError("Failed to connect to NETCONF server: {e}"))
+        else:
+            log.info("Connected to NETCONF server")
+            for cap in c.get_capabilities():
+                if cap.startswith("urn:ietf:params:netconf:base:1"):
+                    log.info("Got NETCONF {cap} capability, looks reasonable, hello success")
+                    c.get_schema(_on_get_schema, "ietf-netconf")
+
+    def _on_get_schema(c: Client, result: ?xml.Node, error: ?NetconfError):
+        if error is not None:
+            log.error("<get-schema> failed", {"error": error})
+            t.failure(ValueError("get-schema failed with error"))
+        elif result is not None:
+            log.info("<get-schema> received response", {"result": result.encode()})
+            t.success(result.encode())
+        else:
+            log.error("<get-schema> received null response")
+            t.failure(ValueError("get-schema returned null"))
+
+    c = Client(net.TCPConnectCap(net.TCPCap(net.NetCap(t.env.cap))),
+                on_connect=_on_connect,
+                on_notif=None,
+                address=test_address,
+                username=test_username,
+                key=None,
+                password=test_password,
+                port=test_port,
+                skip_host_key_check=True,
+                log_handler=t.log_handler)
+
+
+actor _test_list_schemas(t: testing.EnvT):
+    """Test listing available schemas from a NETCONF server
+    """
+    t.require("notconf-server")
+    log = logging.Logger(t.log_handler)
+
+    def _on_connect(c: Client, e: ?Exception):
+        if e is not None:
+            log.error("Failed to connect", {"error": e})
+            t.failure(ValueError("Failed to connect to NETCONF server: {e}"))
+        else:
+            log.info("Connected to NETCONF server")
+            c.list_schemas(_on_list_schemas)
+
+    def _on_list_schemas(c: Client, schemas: list[(identifier: str, namespace: str, version: str, format: str)], error: ?NetconfError):
+        if error is not None:
+            log.error("<list-schemas> failed", {"error": error})
+            t.failure(error)
+        else:
+            log.info("Received schemas list", {"count": len(schemas)})
+            for schema in schemas:
+                log.info("Schema found", {"identifier": schema.identifier, "namespace": schema.namespace, "version": schema.version, "format": schema.format})
+            if len(schemas) > 0:
+                t.success("\n".join([s.__repr__() for s in schemas]))
+            else:
+                log.warning("No schemas found")
+                t.failure(Exception("No schemas found"))
+
+    c = Client(net.TCPConnectCap(net.TCPCap(net.NetCap(t.env.cap))),
+                on_connect=_on_connect,
+                on_notif=None,
+                address=test_address,
+                username=test_username,
+                key=None,
+                password=test_password,
+                port=test_port,
+                skip_host_key_check=True,
+                log_handler=t.log_handler)
+
+
+actor _test_schema_getter(t: testing.EnvT):
+    """Test listing available schemas from a NETCONF server
+    """
+    t.require("notconf-server")
+    log = logging.Logger(t.log_handler)
+    expected = 0
+    var count = 0
+
+    def _on_connect(c: Client, e: ?Exception):
+        if e is not None:
+            log.error("Failed to connect", {"error": e})
+            t.failure(ValueError("Failed to connect to NETCONF server: {e}"))
+        else:
+            log.info("Connected to NETCONF server")
+            # First list all available schemas
+            c.list_schemas(_on_list_schemas)
+
+    def _on_list_schemas(c: Client, schemas: list[(identifier: str, namespace: str, version: str, format: str)], error: ?NetconfError):
+        if error is not None:
+            log.error("Failed to list schemas", {"error": error})
+            t.failure(error)
+            return
+
+        # TODO: would it be possible to pass the schemas list directly to
+        # SchemaGetter.download(..., schemas: list[(identifier: str, version: ?str, format: ?str)])
+        # Note how that named tuple has a subset of our arguments, some are even optional ...
+        schemas_to_download = [(identifier=s.identifier, version=s.version, format=s.format) for s in schemas]
+
+        log.info("Starting download of schemas", {"count": len(schemas_to_download)})
+        sg = SchemaGetter(c)
+        sg.download(_on_schema_download, _on_download_complete, schemas_to_download)
+
+    def _on_schema_download(sg: SchemaGetter, index: int, total: int, schema_id: (identifier: str, version: ?str, format: ?str), schema_data, error):
+        expected = total
+        log.debug("Download {index}/{total} {schema_id.identifier}")
+        if error is not None:
+            t.failure(Exception("{schema_id.identifier}: {error}"))
+        elif schema_data is None:
+            t.failure(Exception("{schema_id.identifier}: empty"))
+        else:
+            count += 1
+
+    def _on_download_complete(sg: SchemaGetter, error):
+        if count != expected:
+            t.failure(ValueError("Incorrect count: {count} != {expected}"))
+        elif error is not None:
+            t.failure(error)
+        else:
+            t.success()
+
+    c = Client(net.TCPConnectCap(net.TCPCap(net.NetCap(t.env.cap))),
+                on_connect=_on_connect,
+                on_notif=None,
+                address=test_address,
+                username=test_username,
+                key=None,
+                password=test_password,
+                port=test_port,
+                skip_host_key_check=True,
+                log_handler=t.log_handler)
+
+
+actor _test_lock_unlock(t: testing.EnvT):
+    """Test lock and unlock operations on a datastore
+    """
+    t.require("notconf-server")
+    log = logging.Logger(t.log_handler)
+
+    def _on_connect(c: Client, e: ?Exception):
+        if e is not None:
+            log.error("Failed to connect", {"error": e})
+            t.failure(ValueError("Failed to connect to NETCONF server: {e}"))
+        else:
+            log.info("Connected to NETCONF server")
+            c.lock(_on_lock, "candidate")
+
+    def _on_lock(c: Client, error: ?NetconfError):
+        if error is not None:
+            log.error("Lock operation failed", {"error": error})
+            t.failure(ValueError("Lock operation failed with error"))
+        else:
+            log.info("Lock operation successful")
+            # Now unlock the datastore
+            c.unlock(_on_unlock, "candidate")
+
+    def _on_unlock(c: Client, error: ?NetconfError):
+        if error is not None:
+            log.error("Unlock operation failed", {"error": error})
+            t.failure(ValueError("Unlock operation failed with error"))
+        else:
+            log.info("Unlock operation successful")
+            log.info("Lock and unlock test completed successfully")
+            t.success()
+
+    c = Client(net.TCPConnectCap(net.TCPCap(net.NetCap(t.env.cap))),
+                on_connect=_on_connect,
+                on_notif=None,
+                address=test_address,
+                username=test_username,
+                key=None,
+                password=test_password,
+                port=test_port,
+                skip_host_key_check=True,
+                log_handler=t.log_handler)
+
+
+actor _test_get_config_with_filter(t: testing.EnvT):
+    """Test get-config operation with a subtree filter
+    """
+    t.require("notconf-server")
+    log = logging.Logger(t.log_handler)
+
+    def _on_connect(c: Client, e: ?Exception):
+        if e is not None:
+            log.error("Failed to connect", {"error": e})
+            t.failure(ValueError("Failed to connect to NETCONF server: {e}"))
+        else:
+            log.info("Connected to NETCONF server")
+            # Create a subtree filter to get only specific configuration
+            # Example: filter for interfaces configuration
+            filter_node = xml.Node("filter", None, None, [("type", "subtree")], [
+                xml.Node("interfaces",
+                    [(None, "urn:ietf:params:xml:ns:yang:ietf-interfaces")],
+                    children=[
+                        xml.Node("interface", children=[
+                            xml.Node("name", text="eth0")
+                        ])
+                    ]
+                )
+            ])
+            c.get_config(_on_get_config_filtered, "running", filter_node)
+
+    def _on_get_config_filtered(c: Client, result: ?xml.Node, error: ?NetconfError):
+        if error is not None:
+            log.error("<get-config> with filter failed", {"error": error})
+            t.failure(ValueError("get-config with filter failed with error"))
+        elif result is not None:
+            log.info("<get-config> with filter received response")
+            # Check if we got an rpc-reply
+            if result.tag == "rpc-reply":
+                # For successful get-config, there should be a single <data> element
+                if len(result.children) > 0 and result.children[0].tag == "data":
+                    log.info("Filtered config data received successfully")
+                    t.success()
+                else:
+                    log.warning("No data element in response, but this might be normal if no matching config exists")
+                    t.success()  # Still success as empty result is valid for filter
+            else:
+                log.error("Unexpected response type", {"tag": result.tag})
+                t.failure(ValueError("Unexpected response type: {result.tag}"))
+        else:
+            log.error("<get-config> with filter received null response")
+            t.failure(ValueError("get-config with filter returned null"))
+
+    c = Client(net.TCPConnectCap(net.TCPCap(net.NetCap(t.env.cap))),
+                on_connect=_on_connect,
+                on_notif=None,
+                address=test_address,
+                username=test_username,
+                key=None,
+                password=test_password,
+                port=test_port,
+                skip_host_key_check=True,
+                log_handler=t.log_handler)
+
+
+actor _test_get_config_with_xpath_filter(t: testing.EnvT):
+    """Test get-config operation with an XPath filter
+    """
+    t.require("notconf-server")
+    log = logging.Logger(t.log_handler)
+
+    def _on_connect(c: Client, e: ?Exception):
+        if e is not None:
+            log.error("Failed to connect", {"error": e})
+            t.failure(ValueError("Failed to connect to NETCONF server: {e}"))
+        else:
+            log.info("Connected to NETCONF server")
+            # Create an XPath filter to select specific configuration elements
+            # Example: select all interface names
+            filter_node = xml.Node("filter", None, None,
+                [("type", "xpath"),
+                 ("select", "/interfaces/interface/name")],
+                []
+            )
+            c.get_config(_on_get_config_xpath_filtered, "running", filter_node)
+
+    def _on_get_config_xpath_filtered(c: Client, result: ?xml.Node, error: ?NetconfError):
+        if error is not None:
+            # XPath might not be supported, which is ok
+            log.info("Server returned error (XPath might not be supported)", {"error": error})
+            t.success()  # Still consider it success if XPath is not supported
+        elif result is not None:
+            log.info("<get-config> with XPath filter received response")
+            # Check if we got an rpc-reply
+            if result.tag == "rpc-reply":
+                # For successful get-config, there should be a single <data> element
+                if len(result.children) > 0 and result.children[0].tag == "data":
+                    log.info("XPath filtered config data received successfully")
+                    t.success()
+                else:
+                    log.warning("No data element in response")
+                    t.success()  # Still success as empty result is valid
+            else:
+                log.error("Unexpected response type", {"tag": result.tag})
+                t.failure(ValueError("Unexpected response type: {result.tag}"))
+        else:
+            log.error("<get-config> with XPath filter received null response")
+            t.failure(ValueError("get-config with XPath filter returned null"))
+
+    c = Client(net.TCPConnectCap(net.TCPCap(net.NetCap(t.env.cap))),
+                on_connect=_on_connect,
+                on_notif=None,
+                address=test_address,
+                username=test_username,
+                key=None,
+                password=test_password,
+                port=test_port,
+                skip_host_key_check=True,
+                log_handler=t.log_handler)
+
+
+actor _test_rpc_error_repr(t: testing.EnvT):
+    """Test that NetconfError repr() works correctly with RPC errors
+
+    This test intentionally triggers an RPC error by trying to lock a
+    non-existent datastore, then verifies the repr() output.
+    """
+    t.require("notconf-server")
+    log = logging.Logger(t.log_handler)
+
+    def _on_connect(c: Client, e: ?Exception):
+        if e is not None:
+            log.error("Failed to connect", {"error": e})
+            t.failure(ValueError("Failed to connect to NETCONF server: {e}"))
+        else:
+            log.info("Connected to NETCONF server")
+            # Try to lock a non-existent datastore to trigger an error
+            c.lock(_on_lock_error, "non-existent-datastore")
+
+    def _on_lock_error(c: Client, error: ?NetconfError):
+        if error is not None:
+            log.info("Got expected error from invalid lock operation", {"error": error})
+            t.success(repr(error))
+        else:
+            # We expected an error, but didn't get one
+            log.error("Expected an error from invalid lock operation, but got success")
+            t.failure(ValueError("Lock on non-existent datastore should have failed"))
+
+    c = Client(net.TCPConnectCap(net.TCPCap(net.NetCap(t.env.cap))),
+                on_connect=_on_connect,
+                on_notif=None,
+                address=test_address,
+                username=test_username,
+                key=None,
+                password=test_password,
+                port=test_port,
+                skip_host_key_check=True,
+                log_handler=t.log_handler)

--- a/src/netconf/buffer.act
+++ b/src/netconf/buffer.act
@@ -1,0 +1,428 @@
+import testing
+
+
+class IncompleteReadError(Exception):
+    def __init__(self):
+        self.error_message = "Not enough data to read from buffer"
+        self.msg = "Not enough data to read from buffer"
+
+class Buffer(object):
+    parts: list[bytes]
+    i: int
+    j: int
+    total_bytes: int
+    unread_bytes: int
+    _cached_pattern: ?bytes
+    _cached_search_i: int
+    _cached_search_j: int
+    _cached_search_index: int
+
+    def __init__(self):
+        self.parts = []
+        self.i = 0
+        self.j = 0
+        self.total_bytes = 0
+        self.unread_bytes = 0
+        self._cached_pattern = None
+        self._cached_search_i = 0
+        self._cached_search_j = 0
+        self._cached_search_index = 0
+
+    def write_bytes(self, data: bytes):
+        l = len(data)
+        self.parts.append(data)
+        self.total_bytes += l
+        self.unread_bytes += l
+
+    def write_str(self, data: str):
+        self.write_bytes(data.encode())
+
+    def consume(self):
+        #print("CONSUME!", self.i, self.j)
+        if self.i > 0:
+            # TODO: use a queue rather then list, i.e. parts: queue[bytes] to avoid copying/moving all elements in list
+            self.parts = self.parts[self.i:]
+            self.i = 0
+        if self.j > 0:
+            if len(self.parts) > 0:
+                #self.parts[0] = self.parts[0][self.j:]
+                parts: list[bytes] = self.parts # Workaround type-checker bug?
+                parts[0] = parts[0][self.j:]
+            self.j = 0
+        self.total_bytes = self.unread_bytes
+        # Invalidate cache after consume
+        self._cached_pattern = None
+        #print("CONSUMED!", self.parts)
+
+    def rewind(self):
+        #print("REWIND!")
+        self.i = 0
+        self.j = 0
+        self.unread_bytes = self.total_bytes
+        # Invalidate cache after rewind
+        self._cached_pattern = None
+
+    def read_bytes_count(self) -> int:
+        return self.total_bytes - self.unread_bytes
+
+    def has_unread_bytes(self) -> bool:
+        return self.unread_bytes > 0
+
+    def assert_unread_bytes(self, count: int) -> value: # (bool | IncompleteReadError)
+        # if self.unread_bytes < count:
+        #     raise IncompleteReadError()
+        if self.unread_bytes < count:
+            return IncompleteReadError()
+        else:
+            return True
+
+    def read_bytes(self, count: int) -> bytes: # (bytes | IncompleteReadError)
+        #print("READ", count)
+        #print("READ0!", self.i, self.j)
+        if count > self.unread_bytes:
+            raise IncompleteReadError()
+        remaining = count
+        acc = []
+        parts: list[bytes] = self.parts # Workaround type-checker bug?
+        while remaining > 0:
+            #part = self.parts[self.i]
+            part = parts[self.i]
+            next_j = self.j + remaining
+            chunk = part[self.j:next_j]
+            chunk_len = len(chunk)
+            remaining -= chunk_len
+            if next_j >= len(part):
+                self.i += 1
+                next_j = 0
+            self.j = next_j
+            acc.append(chunk)
+        self.unread_bytes -= count
+        #print("READ1!", self.i, self.j)
+        # Invalidate cache after read since buffer position has changed
+        self._cached_pattern = None
+        return bytes([]).join(acc)
+
+    def read_all_bytes(self) -> bytes:
+        b = self.read_bytes(self.unread_bytes)
+        if isinstance(b, bytes):
+            return b
+        else:
+            return bytes([])
+
+    def skip_bytes(self, count: int) -> value: # (bool | IncompleteReadError):
+        #print("SKIP", count)
+        #print("SKIP0!", self.i, self.j)
+        if count > self.unread_bytes:
+            return IncompleteReadError()
+        remaining = count
+        parts: list[bytes] = self.parts # Workaround type-checker bug?
+        while remaining > 0:
+            #part = self.parts[self.i]
+            part = parts[self.i]
+            part_len = len(part)
+            part_remain = part_len - self.j
+            if remaining < part_remain:
+                self.j += remaining
+                break
+            remaining -= part_remain
+            self.i += 1
+            self.j = 0
+        self.unread_bytes -= count
+        #print("SKIP0!", self.i, self.j)
+        # Invalidate cache after skip since buffer position has changed
+        self._cached_pattern = None
+        return True
+
+    def find_bytes(self, pattern: bytes) -> value: # (index: int | err: IncompleteReadError)
+        pattern_len = len(pattern)
+        if pattern_len == 0:
+            return 0
+        elif pattern_len > self.unread_bytes:
+            return IncompleteReadError()
+
+        # Check if we have any parts to search
+        if len(self.parts) == 0:
+            return IncompleteReadError()
+
+        if self._cached_pattern == pattern:
+            index = self._cached_search_index
+            _i = self._cached_search_i
+            _j = self._cached_search_j
+        else:
+            index = 0   # tracks absolute position in buffer
+            _i = self.i # current part (index of self.parts)
+            _j = self.j # current position in current part
+            self._cached_pattern = pattern
+
+        while index <= self.unread_bytes - pattern_len:
+            pos = self.parts[_i].find(chr(pattern[0]).encode(), _j)
+
+            if pos >= 0:
+                # Found first byte, update index to this position
+                index += pos - _j
+
+                # Scan the rest of the pattern byte-by-byte because the pattern
+                # may be split across parts
+                scan_i = _i
+                scan_j = pos + 1
+                for pattern_index in range(1, pattern_len):
+                    if scan_j >= len(self.parts[scan_i]):
+                        # Advance to next part
+                        scan_j = 0
+                        scan_i += 1
+                        if scan_i >= len(self.parts):
+                            # Exhausted all parts
+                            break
+                    if self.parts[scan_i][scan_j] != pattern[pattern_index]:
+                        break
+                    scan_j += 1
+                else:
+                    return index
+
+                # No match, advance position by 1 and continue
+                _j = pos + 1
+                index += 1
+            else:
+                # First byte not found in rest of this part
+                index += len(self.parts[_i]) - _j
+                _i += 1
+                _j = 0
+                if _i >= len(self.parts):
+                    # Exhausted all parts
+                    break
+
+        # Cache current position for next search
+        self._cached_search_i = _i
+        self._cached_search_j = _j
+        self._cached_search_index = index
+
+        return IncompleteReadError()
+
+    def match_bytes(self, pattern: bytes) -> value: # (is_match: bool | err: IncompleteReadError)
+        b = self.read_bytes(len(pattern))
+        if isinstance(b, bytes):
+            return b == pattern
+        else:
+            return b
+
+def _test_buffer_find_bytes_start():
+    """Test finding 'hello' at beginning of buffer"""
+    buf = Buffer()
+    buf.write_str("hello world, this is bob")
+    result = buf.find_bytes("hello".encode())
+    testing.assertTrue(isinstance(result, int), "Should return int for found pattern")
+    if isinstance(result, int):
+        testing.assertEqual(result, 0, "Should find 'hello' at position 0")
+
+
+def _test_buffer_find_bytes_mid():
+    """Test finding 'world' in middle of buffer"""
+    buf = Buffer()
+    buf.write_str("hello world, this is bob")
+    result = buf.find_bytes("world".encode())
+    testing.assertTrue(isinstance(result, int), "Should return int for found pattern")
+    if isinstance(result, int):
+        testing.assertEqual(result, 6, "Should find 'world' at position 6")
+
+
+def _test_buffer_find_bytes_end():
+    """Test finding 'world' in middle of buffer"""
+    buf = Buffer()
+    buf.write_str("hello world, this is bob")
+    result = buf.find_bytes("bob".encode())
+    testing.assertTrue(isinstance(result, int), "Should return int for found pattern")
+    if isinstance(result, int):
+        testing.assertEqual(result, 21, "Should find 'bob' at position 21")
+
+
+def _test_buffer_find_bytes_one():
+    """Test finding space character in buffer"""
+    buf = Buffer()
+    buf.write_str("hello world")
+    result = buf.find_bytes(" ".encode())
+    testing.assertTrue(isinstance(result, int), "Should return int for found pattern")
+    if isinstance(result, int):
+        testing.assertEqual(result, 5, "Should find space at position 5")
+
+
+def _test_buffer_find_bytes_not_found():
+    """Test pattern not found returns IncompleteReadError"""
+    buf = Buffer()
+    buf.write_str("hello world")
+    result = buf.find_bytes("xyz".encode())
+    testing.assertTrue(isinstance(result, IncompleteReadError), "Should return IncompleteReadError for non-existent pattern")
+
+
+# Test overlapping patterns
+
+def _test_buffer_find_bytes_separator_single_bracket():
+    """Test finding NETCONF separator preceded by single ]"""
+    buf = Buffer()
+    separator = "]]>]]>".encode()
+    buf.write_str("]]]>]]>")
+    result = buf.find_bytes(separator)
+    testing.assertTrue(isinstance(result, int), "Should return int for found pattern")
+    if isinstance(result, int):
+        testing.assertEqual(result, 1, "Should find separator at position 1 after single ]")
+
+
+def _test_buffer_find_bytes_separator_double_bracket():
+    """Test finding NETCONF separator preceded by double ]]"""
+    buf = Buffer()
+    separator = "]]>]]>".encode()
+    buf.write_str("]]]]>]]>")
+    result = buf.find_bytes(separator)
+    testing.assertTrue(isinstance(result, int), "Should return int for found pattern")
+    if isinstance(result, int):
+        testing.assertEqual(result, 2, "Should find separator at position 2 after double ]]")
+
+
+def _test_buffer_find_bytes_separator_mixed_prefix():
+    """Test finding NETCONF separator preceded by ]>]"""
+    buf = Buffer()
+    separator = "]]>]]>".encode()
+    buf.write_str("]>]]]>]]>")
+    result = buf.find_bytes(separator)
+    testing.assertTrue(isinstance(result, int), "Should return int for found pattern")
+    if isinstance(result, int):
+        testing.assertEqual(result, 3, "Should find separator at position 3 after ]>]")
+
+
+def _test_buffer_find_bytes_split_across_two_parts():
+    """Test finding pattern split across two buffer parts"""
+    buf = Buffer()
+    separator = "]]>]]>".encode()
+    buf.write_str("data]]")
+    buf.write_str(">]]>more")
+    result = buf.find_bytes(separator)
+    testing.assertTrue(isinstance(result, int), "Should return int for found pattern")
+    if isinstance(result, int):
+        testing.assertEqual(result, 4, "Should find separator split across parts")
+
+
+def _test_buffer_find_bytes_split_with_overlap():
+    """Test finding pattern with overlapping character before split"""
+    buf = Buffer()
+    separator = "]]>]]>".encode()
+    buf.write_str("data]")
+    buf.write_str("]]>]]>more")
+    result = buf.find_bytes(separator)
+    testing.assertTrue(isinstance(result, int), "Should return int for found pattern")
+    if isinstance(result, int):
+        testing.assertEqual(result, 5, "Should find separator with ] before split")
+
+
+def _test_buffer_find_bytes_across_three_parts():
+    """Test finding pattern split across 3 buffer parts"""
+    buf = Buffer()
+    buf.write_str("ab")
+    buf.write_str("cd")
+    buf.write_str("ef")
+    result = buf.find_bytes("cde".encode())
+    testing.assertTrue(isinstance(result, int), "Should return int for found pattern")
+    if isinstance(result, int):
+        testing.assertEqual(result, 2, "Should find pattern across 3 parts")
+
+
+def _test_buffer_find_bytes_separator_four_parts():
+    """Test finding NETCONF separator split across 4 parts"""
+    buf = Buffer()
+    separator = "]]>]]>".encode()
+    buf.write_str("]")
+    buf.write_str("]>")
+    buf.write_str("]")
+    buf.write_str("]>")
+    result = buf.find_bytes(separator)
+    testing.assertTrue(isinstance(result, int), "Should return int for found pattern")
+    if isinstance(result, int):
+        testing.assertEqual(result, 0, "Should find separator split across 4 parts")
+
+
+def _test_buffer_find_bytes_empty_pattern():
+    """Test finding empty pattern returns 0"""
+    buf = Buffer()
+    buf.write_str("test")
+    result = buf.find_bytes("".encode())
+    testing.assertTrue(isinstance(result, int), "Should return int for empty pattern")
+    if isinstance(result, int):
+        testing.assertEqual(result, 0, "Empty pattern should return 0")
+
+
+def _test_buffer_find_bytes_pattern_too_long():
+    """Test pattern longer than buffer returns IncompleteReadError"""
+    buf = Buffer()
+    buf.write_str("short")
+    result = buf.find_bytes("very long pattern".encode())
+    testing.assertTrue(isinstance(result, IncompleteReadError), "Pattern longer than buffer should return IncompleteReadError")
+
+
+def _test_buffer_find_bytes_pattern_at_end():
+    """Test finding pattern at the very end of buffer"""
+    buf = Buffer()
+    buf.write_str("data]]>]]>")
+    result = buf.find_bytes("]]>]]>".encode())
+    testing.assertTrue(isinstance(result, int), "Should return int for found pattern")
+    if isinstance(result, int):
+        testing.assertEqual(result, 4, "Should find pattern at end of buffer")
+
+
+def _test_buffer_find_bytes_first_separator():
+    """Test finding first separator in buffer"""
+    buf = Buffer()
+    separator = "]]>]]>".encode()
+    buf.write_str("first]]>]]>second]]>]]>third")
+    pos = buf.find_bytes(separator)
+    testing.assertTrue(isinstance(pos, int), "Should return int for found pattern")
+    if isinstance(pos, int):
+        testing.assertEqual(pos, 5, "Should find first separator at position 5")
+
+
+def _test_buffer_find_bytes_after_consume():
+    """Test finding separator after consume operation"""
+    buf = Buffer()
+    separator = "]]>]]>".encode()
+    buf.write_str("first]]>]]>second]]>]]>third")
+
+    # Find and skip past first separator
+    pos = buf.find_bytes(separator)
+    if isinstance(pos, int):
+        skip_result = buf.skip_bytes(pos + len(separator))
+        if isinstance(skip_result, bool):
+            buf.consume()
+
+            # Find second separator
+            pos2 = buf.find_bytes(separator)
+            testing.assertTrue(isinstance(pos2, int), "Should return int for found pattern")
+            if isinstance(pos2, int):
+                testing.assertEqual(pos2, 6, "Should find second separator at position 6 after consume")
+
+
+def _test_buffer_find_bytes_performance():
+    """Test performance of finding pattern at end of large buffer with 64k chunks"""
+
+    buf = Buffer()
+    pattern = "]]>]]>".encode()
+    chunk_size = 64 * 1024  # 64KB chunks
+    total_size = 2 * 1024 * 1024  # 2MB total
+
+    # Create a chunk of data that doesn't contain the pattern
+    chunk_data = ("x" * chunk_size).encode()
+
+    # Write chunks to buffer (2MB total) and search after each chunk
+    num_chunks = total_size // chunk_size
+    for i in range(num_chunks):
+        buf.write_bytes(chunk_data)
+        # Search for pattern after each chunk (should not be found)
+        result = buf.find_bytes(pattern)
+        testing.assertTrue(isinstance(result, IncompleteReadError), f"Should not find pattern after chunk {i+1}")
+
+    # Add pattern at the very end
+    buf.write_str("]]>]]>")
+
+    # Now search for pattern (should be found at end)
+    result = buf.find_bytes(pattern)
+
+    # Verify pattern was found at correct position
+    testing.assertTrue(isinstance(result, int), "Should return int for found pattern")
+    if isinstance(result, int):
+        testing.assertEqual(result, total_size, "Should find pattern at position 2MB")

--- a/src/netconf/fixups.act
+++ b/src/netconf/fixups.act
@@ -1,0 +1,9 @@
+"""Built-in NETCONF fixups."""
+
+from netconf.fixups.base import Fixup
+from netconf.fixups.openconfig_list_keys import OpenConfigListKeyFixup
+
+# Ordered default fixup constructors used by netconf.Client
+FIXUPS: list[proc() -> Fixup] = [
+    OpenConfigListKeyFixup,
+]

--- a/src/netconf/fixups/base.act
+++ b/src/netconf/fixups/base.act
@@ -1,0 +1,26 @@
+import std.xml as xml
+
+
+class Fixup(object):
+    """Base class for NETCONF protocol fixups.
+
+    Fixups are instantiated per Client and can keep per-connection state.
+    They are activated after <hello> based on capabilities.
+    """
+    name: str
+    active: bool
+    deactivate_reason: ?str
+
+    def __init__(self, name: str):
+        self.name = name
+        self.active = True
+        self.deactivate_reason = None
+
+    def activate(self, capabilities: list[str]) -> bool:
+        return True
+
+    mut def on_request(self, op: xml.Node) -> xml.Node:
+        return op
+
+    mut def on_response(self, rpc_reply: xml.Node) -> xml.Node:
+        return rpc_reply

--- a/src/netconf/fixups/openconfig_list_keys.act
+++ b/src/netconf/fixups/openconfig_list_keys.act
@@ -1,0 +1,151 @@
+import std.xml as xml
+from netconf.fixups.base import Fixup
+
+def unwrap[T](a: ?T, msg: ?str=None) -> T:
+    if a is not None:
+        return a
+    errmsg = msg if msg is not None else "Expected non-None value"
+    raise ValueError(errmsg)
+
+
+# Prototype for xml navigation TODO: Upstream to xml module!?
+protocol XmlNav:
+    one: (str, ?str) -> xml.Node
+    many: (str, ?str) -> list[xml.Node]
+    opt: (str, ?str) -> ?xml.Node
+
+
+def find_ns(nsdefs: list[(?str, str)], prefix: ?str) -> ?str:
+    for p, uri in nsdefs:
+        if p == prefix:
+            return uri
+    return None
+
+
+def child_namespace(parent: xml.Node, child: xml.Node) -> ?str:
+    # Best-effort namespace resolution from local declarations only.
+    ns = find_ns(child.nsdefs, child.prefix)
+    if ns is not None:
+        return ns
+    return find_ns(parent.nsdefs, child.prefix)
+
+
+def child_matches(parent: xml.Node, child: xml.Node, tag: str, ns: ?str) -> bool:
+    if child.tag != tag:
+        return False
+    if ns is None:
+        return True
+    cns = child_namespace(parent, child)
+    return cns is not None and cns == ns
+
+
+def matching_children(parent: xml.Node, tag: str, ns: ?str) -> list[xml.Node]:
+    return [c for c in parent.children if child_matches(parent, c, tag, ns)]
+
+
+extension xml.Node(XmlNav):
+    def one(self, tag: str, ns: ?str=None) -> xml.Node:
+        matches = matching_children(self, tag, ns)
+        count = len(matches)
+        if count == 1:
+            return matches[0]
+        if ns is None:
+            raise ValueError("Expected one child <{tag}> under <{self.tag}>, got {count}")
+        raise ValueError("Expected one child <{tag}> in ns <{ns}> under <{self.tag}>, got {count}")
+
+    def opt(self, tag: str, ns: ?str=None) -> ?xml.Node:
+        matches = matching_children(self, tag, ns)
+        count = len(matches)
+        if count <= 1:
+            if count == 1:
+                return matches[0]
+            return None
+        if ns is None:
+            raise ValueError("Expected at most one child <{tag}> under <{self.tag}>, got {count}")
+        raise ValueError("Expected at most one child <{tag}> in ns <{ns}> under <{self.tag}>, got {count}")
+
+    def many(self, tag: str, ns: ?str=None) -> list[xml.Node]:
+        return matching_children(self, tag, ns)
+
+
+mut def ensure_key_from_config(entry: xml.Node, key_name: str) -> bool:
+    if len(entry.many(key_name, None)) > 0:
+        return False
+
+    key_text: ?str = None
+    try:
+        key_text = entry.one("config", None).one(key_name, None).text
+    except ValueError:
+        return False
+    if key_text is None:
+        return False
+
+    key_leaf = xml.Node(key_name, text=key_text)
+    entry.children.insert(0, key_leaf)
+    return True
+
+
+mut def patch_tree(n: xml.Node) -> (int, int, int):
+    patched = 0
+    relevant = 0
+    missing = 0
+    if n.tag == "interface":
+        relevant += 1
+        has_name = True
+        try:
+            has_name = n.opt("name", None) is not None
+        except ValueError:
+            has_name = True
+        if not has_name:
+            missing += 1
+            if ensure_key_from_config(n, "name"):
+                patched += 1
+    elif n.tag == "subinterface":
+        relevant += 1
+        has_index = True
+        try:
+            has_index = n.opt("index", None) is not None
+        except ValueError:
+            has_index = True
+        if not has_index:
+            missing += 1
+            if ensure_key_from_config(n, "index"):
+                patched += 1
+
+    for c in n.children:
+        child_patched, child_relevant, child_missing = patch_tree(c)
+        patched += child_patched
+        relevant += child_relevant
+        missing += child_missing
+    return patched, relevant, missing
+
+
+class OpenConfigListKeyFixup(Fixup):
+    """Fix broken OpenConfig list entries missing key leaves at list-entry level.
+
+    Some devices return list entries like:
+      <interface><config><name>...</name></config>...</interface>
+    while omitting the list key leaf:
+      <interface><name>...</name>...</interface>
+
+    This fixup mirrors key values from config/name and config/index up to
+    interface/name and subinterface/index respectively.
+    """
+    def __init__(self):
+        Fixup.__init__(self, "openconfig-list-keys")
+
+    def activate(self, capabilities: list[str]) -> bool:
+        for cap in capabilities:
+            if "openconfig-interfaces" in cap or "http://openconfig.net/yang/interfaces" in cap:
+                return True
+        return False
+
+    mut def on_response(self, rpc_reply: xml.Node) -> xml.Node:
+        patched, relevant, missing = patch_tree(rpc_reply)
+        if relevant == 0:
+            return rpc_reply
+
+        if missing == 0:
+            self.active = False
+            self.deactivate_reason = "observed clean relevant reply"
+        return rpc_reply

--- a/src/netconf/transport.act
+++ b/src/netconf/transport.act
@@ -1,0 +1,200 @@
+"""Byte stream pipe transport abstractions.
+
+NETCONF and many other protocols runs on top of a byte stream transport. It
+looks more or less as a pipe. Many underlying transport protocols provide such a
+pipe, like TCP, SSH, TLS but unix sockets or just two actors sending messages
+between them. It is useful to be able to abstract over the transport protocol
+and just use a pipe interface so that we can support multiple transport
+protocols without changing the protocol implementation.
+
+This module provides TCP Pipe adapters. SSH Pipe adapters (SshPipe,
+SshPipeListener) are provided by the ssh package's ssh.pipe module.
+"""
+
+import logging
+import net
+from pipe import Pipe
+
+class TcpPipe(Pipe):
+    _endpoint: _TcpClientPipeEndpoint
+
+    def __init__(self,
+                 connect_cap: net.TCPConnectCap,
+                 address: str,
+                 port: int,
+                 read_cb: ?action(?Exception, ?bytes) -> None=None,
+                 connect_timeout: float=10.0):
+        self._endpoint = _TcpClientPipeEndpoint(connect_cap, address, port, connect_timeout)
+        if read_cb is not None:
+            self._endpoint.read_cb(read_cb)
+
+    proc def write(self, data: bytes):
+        self._endpoint.write(data)
+
+    proc def read_cb(self, cb: action(?Exception, ?bytes) -> None):
+        self._endpoint.read_cb(cb)
+
+    proc def close(self, on_close: ?action() -> None):
+        self._endpoint.close(on_close)
+
+    proc def restart(self):
+        self._endpoint.restart()
+
+
+actor _TcpClientPipeEndpoint(connect_cap: net.TCPConnectCap, address: str, port: int, connect_timeout: float):
+    def _noop_read_cb(error: ?Exception, data: ?bytes):
+        pass
+
+    var _read_cb: action(?Exception, ?bytes) -> None = _noop_read_cb
+    var _has_read_cb = False
+    var _connected_pending = False
+    var _conn: ?net.TCPConnection = None
+
+    def _emit_connected_if_pending():
+        if _has_read_cb and _connected_pending:
+            _connected_pending = False
+            await async _read_cb(None, None)
+
+    def _ensure_connected():
+        if _conn is not None:
+            return
+
+        _conn = net.TCPConnection(connect_cap, address, port, _on_connect, _on_receive, _on_error)
+
+    def _on_connect(c: net.TCPConnection):
+        _conn = c
+        _connected_pending = True
+        _emit_connected_if_pending()
+
+    def _on_receive(c: net.TCPConnection, data: bytes):
+        if _has_read_cb:
+            await async _read_cb(None, data)
+
+    def _on_error(c: net.TCPConnection, error: str):
+        if _has_read_cb:
+            await async _read_cb(OSError(error), None)
+
+    def write(data: bytes):
+        c = _conn
+        if c is not None:
+            c.write(data)
+        else:
+            raise ValueError("Unable to write, TCP client pipe is not connected")
+
+    def read_cb(cb: action(?Exception, ?bytes) -> None):
+        _read_cb = cb
+        _has_read_cb = True
+        _ensure_connected()
+        _emit_connected_if_pending()
+
+    def close(on_close: ?action() -> None):
+        c = _conn
+        if c is not None:
+            def _on_close(_c: net.TCPConnection):
+                _conn = None
+                _connected_pending = False
+                if on_close is not None:
+                    await async on_close()
+
+            c.close(_on_close)
+        elif on_close is not None:
+            await async on_close()
+
+    def restart():
+        c = _conn
+        if c is not None:
+            c.reconnect()
+        else:
+            _ensure_connected()
+
+class TcpListenPipe(Pipe):
+    _endpoint: _TcpListenPipeEndpoint
+
+    def __init__(self,
+                 connection: net.TCPListenConnection,
+                 read_cb: ?action(?Exception, ?bytes) -> None=None):
+        self._endpoint = _TcpListenPipeEndpoint(connection)
+        if read_cb is not None:
+            self._endpoint.read_cb(read_cb)
+
+    proc def write(self, data: bytes):
+        self._endpoint.write(data)
+
+    proc def read_cb(self, cb: action(?Exception, ?bytes) -> None):
+        self._endpoint.read_cb(cb)
+
+    proc def close(self, on_close: ?action() -> None):
+        self._endpoint.close(on_close)
+
+    proc def restart(self):
+        self._endpoint.restart()
+
+
+actor _TcpListenPipeEndpoint(connection: net.TCPListenConnection):
+    def _noop_read_cb(error: ?Exception, data: ?bytes):
+        pass
+
+    var _read_cb: action(?Exception, ?bytes) -> None = _noop_read_cb
+    var _has_read_cb = False
+    var _connected_pending = True
+    var _cb_installed = False
+    var _conn = connection
+
+    def _emit_connected_if_pending():
+        if _has_read_cb and _connected_pending:
+            _connected_pending = False
+            await async _read_cb(None, None)
+
+    def _maybe_install_cb():
+        if _cb_installed:
+            return
+        _conn.cb_install(_on_receive, _on_error, _on_remote_close)
+        _cb_installed = True
+
+    def _on_receive(c: net.TCPListenConnection, data: bytes):
+        if _has_read_cb:
+            await async _read_cb(None, data)
+
+    def _on_error(c: net.TCPListenConnection, error: str):
+        if _has_read_cb:
+            await async _read_cb(OSError(error), None)
+
+    def _on_remote_close(c: net.TCPListenConnection):
+        if _has_read_cb:
+            await async _read_cb(OSError("TCP remote side closed connection"), None)
+
+    def write(data: bytes):
+        _conn.write(data)
+
+    def read_cb(cb: action(?Exception, ?bytes) -> None):
+        _read_cb = cb
+        _has_read_cb = True
+        _maybe_install_cb()
+        _emit_connected_if_pending()
+
+    def close(on_close: ?action() -> None):
+        _conn.close()
+        if on_close is not None:
+            await async on_close()
+
+    def restart():
+        raise ValueError("Unable to restart, accepted TCP listener connection cannot reconnect")
+
+
+actor TcpPipeListener(listen_cap: net.TCPListenCap,
+                      address: str,
+                      port: int,
+                      on_listen: action(TcpPipeListener, ?Exception) -> None,
+                      on_accept: action(TcpPipeListener, TcpListenPipe) -> None):
+    var listener: ?net.TCPListener = None
+
+    def _on_listen(l: net.TCPListener, error: ?str):
+        if error is not None:
+            on_listen(self, OSError(error))
+        else:
+            on_listen(self, None)
+
+    def _on_accept(c: net.TCPListenConnection):
+        on_accept(self, TcpListenPipe(connection=c))
+
+    listener = net.TCPListener(listen_cap, address, port, _on_listen, _on_accept)


### PR DESCRIPTION
Adds ncurl monitor, a new ncurl subcommand that watches operational data from a NETCONF device. Unlike the other ncurl commands it is built on the stratoweave DeviceAdapter rather than driving netconf.Client directly. This is the first step in reusing the DeviceAdapter inside ncurl, so the CLI shares the same device logic as the rest of stratoweave, such as subscriptions, the periodic-poll fallback, and runtime schema fetch.

monitor declares a periodic subscription via the adapter and renders each update as a live, in-place tree, like watch or top. It takes a poll interval in seconds via --period (default 1.0), stops after N updates with --count (0 means run until interrupted), can scope what is monitored with --filter-subtree (an XML subtree that is converted to a typed filter using the device's runtime-fetched schema), and chooses output with --format, which is tree by default (live redraw) or raw (stream the XML). Because the adapter delivers a full decoded snapshot on each update and only fires when the data changes, the tree simply re-renders, with no yang-patch or instance-identifier machinery needed.

The PR is stacked on the netconf and ncurl vendoring, so it contains four commits: vendoring the netconf library into the monorepo, vendoring ncurl into the monorepo, adding ncurl monitor (CmdMonitor plus the DeviceAdapter bootstrap, with --period, --count and --filter-subtree), and the live tree view (default in-place tree rendering, with --format raw keeping XML streaming).

It was verified live against the notconf container: it connects through the DeviceAdapter, runtime-fetches the schema, polls with get, decodes to gdata, and renders the live tree. Change-driven updates were confirmed by watching the in-rpcs counter tick between frames, and --format raw emits clean XML with no ANSI escapes.

Two follow-ups are out of scope here. First, a known gdata bug: a YANG bits leaf decodes to a set, which gdata's vals_equal does not handle, so full-datastore change-detection can crash; using --filter-subtree to scope around it avoids this for now, and a fix is tracked separately for acton-yang. Second, native YANG-push (on-change and streaming) is deferred; once the adapter gains it, monitor will benefit with no changes.
