### PR TITLE
Make NETCONF monitoring / ietf-yang-library common

### DIFF
--- a/gen_adata/src/swyang.act
+++ b/gen_adata/src/swyang.act
@@ -2287,3 +2287,5463 @@ ietf_yang_library = r"""module ietf-yang-library {
   }
 }
 """
+
+ietf_yang_push = r"""module ietf-yang-push {
+  yang-version 1.1;
+  namespace "urn:ietf:params:xml:ns:yang:ietf-yang-push";
+  prefix yp;
+
+  import ietf-yang-types {
+    prefix yang;
+    reference
+      "RFC 6991: Common YANG Data Types";
+  }
+  import ietf-subscribed-notifications {
+    prefix sn;
+    reference
+      "RFC 8639: Subscription to YANG Notifications";
+  }
+  import ietf-datastores {
+    prefix ds;
+    reference
+      "RFC 8342: Network Management Datastore Architecture (NMDA)";
+  }
+  import ietf-restconf {
+    prefix rc;
+    reference
+      "RFC 8040: RESTCONF Protocol";
+  }
+  import ietf-yang-patch {
+    prefix ypatch;
+    reference
+      "RFC 8072: YANG Patch Media Type";
+  }
+
+  organization
+    "IETF NETCONF (Network Configuration) Working Group";
+  contact
+    "WG Web:  <https:/datatracker.ietf.org/wg/netconf/>
+     WG List: <mailto:netconf@ietf.org>
+
+     Author:  Alexander Clemm
+              <mailto:ludwig@clemm.org>
+
+     Author:  Eric Voit
+              <mailto:evoit@cisco.com>";
+  description
+    "This module contains YANG specifications for YANG-Push.
+
+     The key words 'MUST', 'MUST NOT', 'REQUIRED', 'SHALL', 'SHALL
+     NOT', 'SHOULD', 'SHOULD NOT', 'RECOMMENDED', 'NOT RECOMMENDED',
+     'MAY', and 'OPTIONAL' in this document are to be interpreted as
+     described in BCP 14 (RFC 2119) (RFC 8174) when, and only when,
+     they appear in all capitals, as shown here.
+
+     Copyright (c) 2019 IETF Trust and the persons identified as
+     authors of the code.  All rights reserved.
+
+     Redistribution and use in source and binary forms, with or
+     without modification, is permitted pursuant to, and subject to
+     the license terms contained in, the Simplified BSD License set
+     forth in Section 4.c of the IETF Trust's Legal Provisions
+     Relating to IETF Documents
+     (https://trustee.ietf.org/license-info).
+
+     This version of this YANG module is part of RFC 8641; see the
+     RFC itself for full legal notices.";
+
+  revision 2019-09-09 {
+    description
+      "Initial revision.";
+    reference
+      "RFC 8641: Subscriptions to YANG Datastores";
+  }
+
+  rc:yang-data "resync-subscription-error" {
+    container resync-subscription-error {
+      description
+        "If a 'resync-subscription' RPC fails, the subscription is
+         not resynced and the RPC error response MUST indicate the
+         reason for this failure.  This yang-data MAY be inserted as
+         structured data in a subscription's RPC error response
+         to indicate the reason for the failure.";
+      leaf reason {
+        type identityref {
+          base resync-subscription-error;
+        }
+        mandatory true;
+        description
+          "Indicates the reason why the publisher has declined a
+           request for subscription resynchronization.";
+      }
+      uses hints;
+    }
+  }
+  rc:yang-data "establish-subscription-datastore-error-info" {
+    container establish-subscription-datastore-error-info {
+      description
+        "If any 'establish-subscription' RPC parameters are
+         unsupportable against the datastore, a subscription is not
+         created and the RPC error response MUST indicate the reason
+         why the subscription failed to be created.  This yang-data
+         MAY be inserted as structured data in a subscription's
+         RPC error response to indicate the reason for the failure.
+         This yang-data MUST be inserted if hints are to be provided
+         back to the subscriber.";
+      leaf reason {
+        type identityref {
+          base sn:establish-subscription-error;
+        }
+        description
+          "Indicates the reason why the subscription has failed to
+           be created to a targeted datastore.";
+      }
+      uses hints;
+    }
+  }
+  rc:yang-data "modify-subscription-datastore-error-info" {
+    container modify-subscription-datastore-error-info {
+      description
+        "This yang-data MAY be provided as part of a subscription's
+         RPC error response when there is a failure of a
+         'modify-subscription' RPC that has been made against a
+         datastore.  This yang-data MUST be used if hints are to be
+         provided back to the subscriber.";
+      leaf reason {
+        type identityref {
+          base sn:modify-subscription-error;
+        }
+        description
+          "Indicates the reason why the subscription has failed to
+           be modified.";
+      }
+      uses hints;
+    }
+  }
+
+  feature on-change {
+    description
+      "This feature indicates that on-change triggered subscriptions
+       are supported.";
+  }
+
+  identity resync-subscription-error {
+    description
+      "Problem found while attempting to fulfill a
+       'resync-subscription' RPC request.";
+  }
+
+  identity cant-exclude {
+    base sn:establish-subscription-error;
+    description
+      "Unable to remove the set of 'excluded-change' parameters.
+       This means that the publisher is unable to restrict
+       'push-change-update' notifications to just the change types
+       requested for this subscription.";
+  }
+
+  identity datastore-not-subscribable {
+    base sn:establish-subscription-error;
+    base sn:subscription-terminated-reason;
+    description
+      "This is not a subscribable datastore.";
+  }
+
+  identity no-such-subscription-resync {
+    base resync-subscription-error;
+    description
+      "The referenced subscription doesn't exist.  This may be as a
+       result of a nonexistent subscription ID, an ID that belongs to
+       another subscriber, or an ID for a configured subscription.";
+  }
+
+  identity on-change-unsupported {
+    base sn:establish-subscription-error;
+    description
+      "On-change is not supported for any objects that are
+       selectable by this filter.";
+  }
+
+  identity on-change-sync-unsupported {
+    base sn:establish-subscription-error;
+    description
+      "Neither 'sync-on-start' nor resynchronization is supported for
+       this subscription.  This error will be used for two reasons:
+       (1) if an 'establish-subscription' RPC includes
+       'sync-on-start' but the publisher can't support sending a
+       'push-update' for this subscription for reasons other than
+       'on-change-unsupported' or 'sync-too-big'
+       (2) if the 'resync-subscription' RPC is invoked for either an
+       existing periodic subscription or an on-change subscription
+       that can't support resynchronization.";
+  }
+
+  identity period-unsupported {
+    base sn:establish-subscription-error;
+    base sn:modify-subscription-error;
+    base sn:subscription-suspended-reason;
+    description
+      "The requested time period or 'dampening-period' is too short.
+       This can be for both periodic and on-change subscriptions
+       (with or without dampening).  Hints suggesting alternative
+       periods may be returned as supplemental information.";
+  }
+
+  identity update-too-big {
+    base sn:establish-subscription-error;
+    base sn:modify-subscription-error;
+    base sn:subscription-suspended-reason;
+    description
+      "Periodic or on-change push update data trees exceed a maximum
+       size limit.  Hints on the estimated size of what was too big
+       may be returned as supplemental information.";
+  }
+
+  identity sync-too-big {
+    base sn:establish-subscription-error;
+    base sn:modify-subscription-error;
+    base resync-subscription-error;
+    base sn:subscription-suspended-reason;
+    description
+      "The 'sync-on-start' or resynchronization data tree exceeds a
+       maximum size limit.  Hints on the estimated size of what was
+       too big may be returned as supplemental information.";
+  }
+
+  identity unchanging-selection {
+    base sn:establish-subscription-error;
+    base sn:modify-subscription-error;
+    base sn:subscription-terminated-reason;
+    description
+      "The selection filter is unlikely to ever select data tree
+       nodes.  This means that based on the subscriber's current
+       access rights, the publisher recognizes that the selection
+       filter is unlikely to ever select data tree nodes that change.
+       Examples for this might be that the node or subtree doesn't
+       exist, read access is not permitted for a receiver, or static
+       objects that only change at reboot have been chosen.";
+  }
+
+  typedef change-type {
+    type enumeration {
+      enum "create" {
+        description
+          "A change that refers to the creation of a new
+           datastore node.";
+      }
+      enum "delete" {
+        description
+          "A change that refers to the deletion of a
+           datastore node.";
+      }
+      enum "insert" {
+        description
+          "A change that refers to the insertion of a new
+           user-ordered datastore node.";
+      }
+      enum "move" {
+        description
+          "A change that refers to a reordering of the target
+           datastore node.";
+      }
+      enum "replace" {
+        description
+          "A change that refers to a replacement of the target
+           datastore node's value.";
+      }
+    }
+    description
+      "Specifies different types of datastore changes.
+
+       This type is based on the edit operations defined for
+       YANG Patch, with the difference that it is valid for a
+       receiver to process an update record that performs a
+       'create' operation on a datastore node the receiver believes
+       exists or to process a delete on a datastore node the
+       receiver believes is missing.";
+    reference
+      "RFC 8072: YANG Patch Media Type, Section 2.5";
+  }
+
+  typedef selection-filter-ref {
+    type leafref {
+      path "/sn:filters/yp:selection-filter/yp:filter-id";
+    }
+    description
+      "This type is used to reference a selection filter.";
+  }
+
+  typedef centiseconds {
+    type uint32;
+    description
+      "A period of time, measured in units of 0.01 seconds.";
+  }
+
+  grouping datastore-criteria {
+    description
+      "A grouping to define criteria for which selected objects from
+       a targeted datastore should be included in push updates.";
+    leaf datastore {
+      type identityref {
+        base ds:datastore;
+      }
+      mandatory true;
+      description
+        "Datastore from which to retrieve data.";
+    }
+    uses selection-filter-objects;
+  }
+
+  grouping selection-filter-types {
+    description
+      "This grouping defines the types of selectors for objects
+       from a datastore.";
+    choice filter-spec {
+      description
+        "The content filter specification for this request.";
+      anydata datastore-subtree-filter {
+        if-feature "sn:subtree";
+        description
+          "This parameter identifies the portions of the
+           target datastore to retrieve.";
+        reference
+          "RFC 6241: Network Configuration Protocol (NETCONF),
+                     Section 6";
+      }
+      leaf datastore-xpath-filter {
+        if-feature "sn:xpath";
+        type yang:xpath1.0;
+        description
+          "This parameter contains an XPath expression identifying
+           the portions of the target datastore to retrieve.
+
+           If the expression returns a node set, all nodes in the
+           node set are selected by the filter.  Otherwise, if the
+           expression does not return a node set, the filter
+           doesn't select any nodes.
+
+           The expression is evaluated in the following XPath
+           context:
+
+           o  The set of namespace declarations is the set of prefix
+              and namespace pairs for all YANG modules implemented
+              by the server, where the prefix is the YANG module
+              name and the namespace is as defined by the
+              'namespace' statement in the YANG module.
+
+              If the leaf is encoded in XML, all namespace
+              declarations in scope on the 'stream-xpath-filter'
+              leaf element are added to the set of namespace
+              declarations.  If a prefix found in the XML is
+              already present in the set of namespace declarations,
+              the namespace in the XML is used.
+
+           o  The set of variable bindings is empty.
+
+           o  The function library is comprised of the core
+              function library and the XPath functions defined in
+              Section 10 in RFC 7950.
+
+           o  The context node is the root node of the target
+              datastore.";
+        reference
+          "XML Path Language (XPath) Version 1.0
+           (https://www.w3.org/TR/1999/REC-xpath-19991116)
+           RFC 7950: The YANG 1.1 Data Modeling Language,
+                     Section 10";
+      }
+    }
+  }
+
+  grouping selection-filter-objects {
+    description
+      "This grouping defines a selector for objects from a
+       datastore.";
+    choice selection-filter {
+      description
+        "The source of the selection filter applied to the
+         subscription.  This will either (1) come referenced from a
+         global list or (2) be provided in the subscription itself.";
+      case by-reference {
+        description
+          "Incorporates a filter that has been configured
+           separately.";
+        leaf selection-filter-ref {
+          type selection-filter-ref;
+          mandatory true;
+          description
+            "References an existing selection filter that is to be
+             applied to the subscription.";
+        }
+      }
+      case within-subscription {
+        description
+          "A local definition allows a filter to have the same
+           lifecycle as the subscription.";
+        uses selection-filter-types;
+      }
+    }
+  }
+
+  grouping update-policy-modifiable {
+    description
+      "This grouping describes the datastore-specific subscription
+       conditions that can be changed during the lifetime of the
+       subscription.";
+    choice update-trigger {
+      description
+        "Defines necessary conditions for sending an event record to
+         the subscriber.";
+      case periodic {
+        container periodic {
+          presence "indicates a periodic subscription";
+          description
+            "The publisher is requested to periodically notify the
+             receiver regarding the current values of the datastore
+             as defined by the selection filter.";
+          leaf period {
+            type centiseconds;
+            mandatory true;
+            description
+              "Duration of time that should occur between periodic
+               push updates, in units of 0.01 seconds.";
+          }
+          leaf anchor-time {
+            type yang:date-and-time;
+            description
+              "Designates a timestamp before or after which a series
+               of periodic push updates are determined.  The next
+               update will take place at a point in time that is a
+               multiple of a period from the 'anchor-time'.
+               For example, for an 'anchor-time' that is set for the
+               top of a particular minute and a period interval of a
+               minute, updates will be sent at the top of every
+               minute that this subscription is active.";
+          }
+        }
+      }
+      case on-change {
+        if-feature "on-change";
+        container on-change {
+          presence "indicates an on-change subscription";
+          description
+            "The publisher is requested to notify the receiver
+             regarding changes in values in the datastore subset as
+             defined by a selection filter.";
+          leaf dampening-period {
+            type centiseconds;
+            default "0";
+            description
+              "Specifies the minimum interval between the assembly of
+               successive update records for a single receiver of a
+               subscription.  Whenever subscribed objects change and
+               a dampening-period interval (which may be zero) has
+               elapsed since the previous update record creation for
+               a receiver, any subscribed objects and properties
+               that have changed since the previous update record
+               will have their current values marshalled and placed
+               in a new update record.";
+          }
+        }
+      }
+    }
+  }
+
+  grouping update-policy {
+    description
+      "This grouping describes the datastore-specific subscription
+       conditions of a subscription.";
+    uses update-policy-modifiable {
+      augment "update-trigger/on-change/on-change" {
+        description
+          "Includes objects that are not modifiable once a
+           subscription is established.";
+        leaf sync-on-start {
+          type boolean;
+          default "true";
+          description
+            "When this object is set to 'false', (1) it restricts an
+             on-change subscription from sending 'push-update'
+             notifications and (2) pushing a full selection per the
+             terms of the selection filter MUST NOT be done for
+             this subscription.  Only updates about changes
+             (i.e., only 'push-change-update' notifications)
+             are sent.  When set to 'true' (the default behavior),
+             in order to facilitate a receiver's synchronization,
+             a full update is sent, via a 'push-update' notification,
+             when the subscription starts.  After that,
+             'push-change-update' notifications are exclusively sent,
+             unless the publisher chooses to resync the subscription
+             via a new 'push-update' notification.";
+        }
+        leaf-list excluded-change {
+          type change-type;
+          description
+            "Used to restrict which changes trigger an update.  For
+             example, if a 'replace' operation is excluded, only the
+             creation and deletion of objects are reported.";
+        }
+      }
+    }
+  }
+
+  grouping hints {
+    description
+      "Parameters associated with an error for a subscription
+       made upon a datastore.";
+    leaf period-hint {
+      type centiseconds;
+      description
+        "Returned when the requested time period is too short.  This
+         hint can assert a viable period for either a periodic push
+         cadence or an on-change dampening interval.";
+    }
+    leaf filter-failure-hint {
+      type string;
+      description
+        "Information describing where and/or why a provided filter
+         was unsupportable for a subscription.";
+    }
+    leaf object-count-estimate {
+      type uint32;
+      description
+        "If there are too many objects that could potentially be
+         returned by the selection filter, this identifies the
+         estimate of the number of objects that the filter would
+         potentially pass.";
+    }
+    leaf object-count-limit {
+      type uint32;
+      description
+        "If there are too many objects that could be returned by
+         the selection filter, this identifies the upper limit of
+         the publisher's ability to service this subscription.";
+    }
+    leaf kilobytes-estimate {
+      type uint32;
+      description
+        "If the returned information could be beyond the capacity
+         of the publisher, this would identify the estimated
+         data size that could result from this selection filter.";
+    }
+    leaf kilobytes-limit {
+      type uint32;
+      description
+        "If the returned information would be beyond the capacity
+         of the publisher, this identifies the upper limit of the
+         publisher's ability to service this subscription.";
+    }
+  }
+
+  augment "/sn:establish-subscription/sn:input" {
+    description
+      "This augmentation adds additional subscription parameters
+       that apply specifically to datastore updates to RPC input.";
+    uses update-policy;
+  }
+  augment "/sn:establish-subscription/sn:input/sn:target" {
+    description
+      "This augmentation adds the datastore as a valid target
+       for the subscription to RPC input.";
+    case datastore {
+      description
+        "Information specifying the parameters of a request for a
+         datastore subscription.";
+      uses datastore-criteria;
+    }
+  }
+  augment "/sn:modify-subscription/sn:input" {
+    description
+      "This augmentation adds additional subscription parameters
+       specific to datastore updates.";
+    uses update-policy-modifiable;
+  }
+  augment "/sn:modify-subscription/sn:input/sn:target" {
+    description
+      "This augmentation adds the datastore as a valid target
+       for the subscription to RPC input.";
+    case datastore {
+      description
+        "Information specifying the parameters of a request for a
+         datastore subscription.";
+      uses datastore-criteria;
+    }
+  }
+  augment "/sn:subscription-started" {
+    description
+      "This augmentation adds datastore-specific objects to
+       the notification that a subscription has started.";
+    uses update-policy;
+  }
+  augment "/sn:subscription-started/sn:target" {
+    description
+      "This augmentation allows the datastore to be included as
+       part of the notification that a subscription has started.";
+    case datastore {
+      uses datastore-criteria {
+        refine "selection-filter/within-subscription" {
+          description
+            "Specifies the selection filter and where it originated
+             from.  If the 'selection-filter-ref' is populated, the
+             filter in the subscription came from the 'filters'
+             container.  Otherwise, it is populated in-line as part
+             of the subscription itself.";
+        }
+      }
+    }
+  }
+  augment "/sn:subscription-modified" {
+    description
+      "This augmentation adds datastore-specific objects to
+       the notification that a subscription has been modified.";
+    uses update-policy;
+  }
+  augment "/sn:subscription-modified/sn:target" {
+    description
+      "This augmentation allows the datastore to be included as
+       part of the notification that a subscription has been
+       modified.";
+    case datastore {
+      uses datastore-criteria {
+        refine "selection-filter/within-subscription" {
+          description
+            "Specifies the selection filter and where it originated
+             from.  If the 'selection-filter-ref' is populated, the
+             filter in the subscription came from the 'filters'
+             container.  Otherwise, it is populated in-line as part
+             of the subscription itself.";
+        }
+      }
+    }
+  }
+  augment "/sn:filters" {
+    description
+      "This augmentation allows the datastore to be included as part
+       of the selection-filtering criteria for a subscription.";
+    list selection-filter {
+      key "filter-id";
+      description
+        "A list of preconfigured filters that can be applied
+         to datastore subscriptions.";
+      leaf filter-id {
+        type string;
+        description
+          "An identifier to differentiate between selection
+           filters.";
+      }
+      uses selection-filter-types;
+    }
+  }
+  augment "/sn:subscriptions/sn:subscription" {
+    when "yp:datastore";
+    description
+      "This augmentation adds objects to a subscription that are
+       specific to a datastore subscription, i.e., a subscription to
+       a stream of datastore node updates.";
+    uses update-policy;
+  }
+  augment "/sn:subscriptions/sn:subscription/sn:target" {
+    description
+      "This augmentation allows the datastore to be included as
+       part of the selection-filtering criteria for a subscription.";
+    case datastore {
+      uses datastore-criteria;
+    }
+  }
+
+  rpc resync-subscription {
+    if-feature "on-change";
+    description
+      "This RPC allows a subscriber of an active on-change
+       subscription to request a full push of objects.
+
+       A successful invocation results in a 'push-update' of all
+       datastore nodes that the subscriber is permitted to access.
+       This RPC can only be invoked on the same session on which the
+       subscription is currently active.  In the case of an error, a
+       'resync-subscription-error' is sent as part of an error
+       response.";
+
+    input {
+      leaf id {
+        type sn:subscription-id;
+        mandatory true;
+        description
+          "Identifier of the subscription that is to be resynced.";
+      }
+    }
+  }
+
+  notification push-update {
+    description
+      "This notification contains a push update that in turn contains
+       data subscribed to via a subscription.  In the case of a
+       periodic subscription, this notification is sent for periodic
+       updates.  It can also be used for synchronization updates of
+       an on-change subscription.  This notification shall only be
+       sent to receivers of a subscription.  It does not constitute
+       a general-purpose notification that would be subscribable as
+       part of the NETCONF event stream by any receiver.";
+    leaf id {
+      type sn:subscription-id;
+      description
+        "This references the subscription that drove the
+         notification to be sent.";
+    }
+    anydata datastore-contents {
+      description
+        "This contains the updated data.  It constitutes a snapshot
+         at the time of update of the set of data that has been
+         subscribed to.  The snapshot corresponds to the same
+         snapshot that would be returned in a corresponding 'get'
+         operation with the same selection filter parameters
+         applied.";
+    }
+    leaf incomplete-update {
+      type empty;
+      description
+        "This is a flag that indicates that not all datastore
+         nodes subscribed to are included with this update.  In
+         other words, the publisher has failed to fulfill its full
+         subscription obligations and, despite its best efforts, is
+         providing an incomplete set of objects.";
+    }
+  }
+  notification push-change-update {
+    if-feature "on-change";
+    description
+      "This notification contains an on-change push update.  This
+       notification shall only be sent to the receivers of a
+       subscription.  It does not constitute a general-purpose
+       notification that would be subscribable as part of the
+       NETCONF event stream by any receiver.";
+    leaf id {
+      type sn:subscription-id;
+      description
+        "This references the subscription that drove the
+         notification to be sent.";
+    }
+    container datastore-changes {
+      description
+        "This contains the set of datastore changes of the target
+         datastore, starting at the time of the previous update, per
+         the terms of the subscription.";
+      uses ypatch:yang-patch;
+    }
+    leaf incomplete-update {
+      type empty;
+      description
+        "The presence of this object indicates that not all changes
+         that have occurred since the last update are included with
+         this update.  In other words, the publisher has failed to
+         fulfill its full subscription obligations -- for example,
+         in cases where it was not able to keep up with a burst of
+         changes.";
+    }
+  }
+}
+"""
+
+ietf_subscribed_notifications = r"""module ietf-subscribed-notifications {
+  yang-version 1.1;
+  namespace "urn:ietf:params:xml:ns:yang:ietf-subscribed-notifications";
+  prefix sn;
+
+  import ietf-inet-types {
+    prefix inet;
+    reference
+      "RFC 6991: Common YANG Data Types";
+  }
+  import ietf-interfaces {
+    prefix if;
+    reference
+      "RFC 8343: A YANG Data Model for Interface Management";
+  }
+  import ietf-netconf-acm {
+    prefix nacm;
+    reference
+      "RFC 8341: Network Configuration Access Control Model";
+  }
+  import ietf-network-instance {
+    prefix ni;
+    reference
+      "RFC 8529: YANG Data Model for Network Instances";
+  }
+  import ietf-restconf {
+    prefix rc;
+    reference
+      "RFC 8040: RESTCONF Protocol";
+  }
+  import ietf-yang-types {
+    prefix yang;
+    reference
+      "RFC 6991: Common YANG Data Types";
+  }
+
+  organization
+    "IETF NETCONF (Network Configuration) Working Group";
+  contact
+    "WG Web:  <https:/datatracker.ietf.org/wg/netconf/>
+     WG List: <mailto:netconf@ietf.org>
+
+     Author:  Alexander Clemm
+              <mailto:ludwig@clemm.org>
+
+     Author:  Eric Voit
+              <mailto:evoit@cisco.com>
+
+     Author:  Alberto Gonzalez Prieto
+              <mailto:alberto.gonzalez@microsoft.com>
+
+     Author:  Einar Nilsen-Nygaard
+              <mailto:einarnn@cisco.com>
+
+     Author:  Ambika Prasad Tripathy
+              <mailto:ambtripa@cisco.com>";
+  description
+    "This module defines a YANG data model for subscribing to event
+     records and receiving matching content in notification messages.
+
+     The key words 'MUST', 'MUST NOT', 'REQUIRED', 'SHALL', 'SHALL
+     NOT', 'SHOULD', 'SHOULD NOT', 'RECOMMENDED', 'NOT RECOMMENDED',
+     'MAY', and 'OPTIONAL' in this document are to be interpreted as
+     described in BCP 14 (RFC 2119) (RFC 8174) when, and only when,
+     they appear in all capitals, as shown here.
+
+     Copyright (c) 2019 IETF Trust and the persons identified as
+     authors of the code.  All rights reserved.
+
+     Redistribution and use in source and binary forms, with or
+     without modification, is permitted pursuant to, and subject to
+     the license terms contained in, the Simplified BSD License set
+     forth in Section 4.c of the IETF Trust's Legal Provisions
+     Relating to IETF Documents
+     (https://trustee.ietf.org/license-info).
+
+     This version of this YANG module is part of RFC 8639; see the
+     RFC itself for full legal notices.";
+
+  revision 2019-09-09 {
+    description
+      "Initial version.";
+    reference
+      "RFC 8639: A YANG Data Model for Subscriptions to
+                 Event Notifications";
+  }
+
+  extension subscription-state-notification {
+    description
+      "This statement applies only to notifications.  It indicates
+       that the notification is a subscription state change
+       notification.  Therefore, it does not participate in a regular
+       event stream and does not need to be specifically subscribed
+       to in order to be received.  This statement can only occur as
+       a substatement of the YANG 'notification' statement.  This
+       statement is not for use outside of this YANG module.";
+  }
+
+  rc:yang-data "establish-subscription-stream-error-info" {
+    container establish-subscription-stream-error-info {
+      description
+        "If any 'establish-subscription' RPC parameters are
+         unsupportable against the event stream, a subscription
+         is not created and the RPC error response MUST indicate the
+         reason why the subscription failed to be created.  This
+         yang-data MAY be inserted as structured data in a
+         subscription's RPC error response to indicate the reason for
+         the failure.  This yang-data MUST be inserted if hints are
+         to be provided back to the subscriber.";
+      leaf reason {
+        type identityref {
+          base establish-subscription-error;
+        }
+        description
+          "Indicates the reason why the subscription has failed to
+           be created to a targeted event stream.";
+      }
+      leaf filter-failure-hint {
+        type string;
+        description
+          "Information describing where and/or why a provided
+           filter was unsupportable for a subscription.  The
+           syntax and semantics of this hint are
+           implementation specific.";
+      }
+    }
+  }
+  rc:yang-data "modify-subscription-stream-error-info" {
+    container modify-subscription-stream-error-info {
+      description
+        "This yang-data MAY be provided as part of a subscription's
+         RPC error response when there is a failure of a
+         'modify-subscription' RPC that has been made against an
+         event stream.  This yang-data MUST be used if hints are to
+         be provided back to the subscriber.";
+      leaf reason {
+        type identityref {
+          base modify-subscription-error;
+        }
+        description
+          "Information in a 'modify-subscription' RPC error response
+           that indicates the reason why the subscription to an event
+           stream has failed to be modified.";
+      }
+      leaf filter-failure-hint {
+        type string;
+        description
+          "Information describing where and/or why a provided
+           filter was unsupportable for a subscription.  The syntax
+           and semantics of this hint are
+           implementation specific.";
+      }
+    }
+  }
+  rc:yang-data "delete-subscription-error-info" {
+    container delete-subscription-error-info {
+      description
+        "If a 'delete-subscription' RPC or a 'kill-subscription' RPC
+         fails, the subscription is not deleted and the RPC error
+         response MUST indicate the reason for this failure.  This
+         yang-data MAY be inserted as structured data in a
+         subscription's RPC error response to indicate the reason
+         for the failure.";
+      leaf reason {
+        type identityref {
+          base delete-subscription-error;
+        }
+        mandatory true;
+        description
+          "Indicates the reason why the subscription has failed to be
+           deleted.";
+      }
+    }
+  }
+
+  feature configured {
+    description
+      "This feature indicates that configuration of subscriptions is
+       supported.";
+  }
+
+  feature dscp {
+    description
+      "This feature indicates that a publisher supports the ability
+       to set the Differentiated Services Code Point (DSCP) value in
+       outgoing packets.";
+  }
+
+  feature encode-json {
+    description
+      "This feature indicates that JSON encoding of notification
+       messages is supported.";
+  }
+
+  feature encode-xml {
+    description
+      "This feature indicates that XML encoding of notification
+       messages is supported.";
+  }
+
+  feature interface-designation {
+    description
+      "This feature indicates that a publisher supports sourcing all
+       receiver interactions for a configured subscription from a
+       single designated egress interface.";
+  }
+
+  feature qos {
+    description
+      "This feature indicates that a publisher supports absolute
+       dependencies of one subscription's traffic over another
+       as well as weighted bandwidth sharing between subscriptions.
+       Both of these are Quality of Service (QoS) features that allow
+       differentiated treatment of notification messages between a
+       publisher and a specific receiver.";
+  }
+
+  feature replay {
+    description
+      "This feature indicates that historical event record replay is
+       supported.  With replay, it is possible for past event records
+       to be streamed in chronological order.";
+  }
+
+  feature subtree {
+    description
+      "This feature indicates support for YANG subtree filtering.";
+    reference
+      "RFC 6241: Network Configuration Protocol (NETCONF),
+                 Section 6";
+  }
+
+  feature supports-vrf {
+    description
+      "This feature indicates that a publisher supports VRF
+       configuration for configured subscriptions.  VRF support for
+       dynamic subscriptions does not require this feature.";
+    reference
+      "RFC 8529: YANG Data Model for Network Instances,
+                 Section 6";
+  }
+
+  feature xpath {
+    description
+      "This feature indicates support for XPath filtering.";
+    reference
+      "XML Path Language (XPath) Version 1.0
+       (https://www.w3.org/TR/1999/REC-xpath-19991116)";
+  }
+
+  identity delete-subscription-error {
+    description
+      "Base identity for the problem found while attempting to
+       fulfill either a 'delete-subscription' RPC request or a
+       'kill-subscription' RPC request.";
+  }
+
+  identity establish-subscription-error {
+    description
+      "Base identity for the problem found while attempting to
+       fulfill an 'establish-subscription' RPC request.";
+  }
+
+  identity modify-subscription-error {
+    description
+      "Base identity for the problem found while attempting to
+       fulfill a 'modify-subscription' RPC request.";
+  }
+
+  identity subscription-suspended-reason {
+    description
+      "Base identity for the problem condition communicated to a
+       receiver as part of a 'subscription-suspended'
+       notification.";
+  }
+
+  identity subscription-terminated-reason {
+    description
+      "Base identity for the problem condition communicated to a
+       receiver as part of a 'subscription-terminated'
+       notification.";
+  }
+
+  identity dscp-unavailable {
+    if-feature "dscp";
+    base establish-subscription-error;
+    description
+      "The publisher is unable to mark notification messages with
+       prioritization information in a way that will be respected
+       during network transit.";
+  }
+
+  identity encoding-unsupported {
+    base establish-subscription-error;
+    description
+      "Unable to encode notification messages in the desired
+       format.";
+  }
+
+  identity filter-unavailable {
+    base subscription-terminated-reason;
+    description
+      "Referenced filter does not exist.  This means a receiver is
+       referencing a filter that doesn't exist or to which it
+       does not have access permissions.";
+  }
+
+  identity filter-unsupported {
+    base establish-subscription-error;
+    base modify-subscription-error;
+    description
+      "Cannot parse syntax in the filter.  This failure can be from
+       a syntax error or a syntax too complex to be processed by the
+       publisher.";
+  }
+
+  identity insufficient-resources {
+    base establish-subscription-error;
+    base modify-subscription-error;
+    base subscription-suspended-reason;
+    description
+      "The publisher does not have sufficient resources to support
+       the requested subscription.  An example might be that
+       allocated CPU is too limited to generate the desired set of
+       notification messages.";
+  }
+
+  identity no-such-subscription {
+    base modify-subscription-error;
+    base delete-subscription-error;
+    base subscription-terminated-reason;
+    description
+      "Referenced subscription doesn't exist.  This may be as a
+       result of a nonexistent subscription ID, an ID that belongs to
+       another subscriber, or an ID for a configured subscription.";
+  }
+
+  identity replay-unsupported {
+    if-feature "replay";
+    base establish-subscription-error;
+    description
+      "Replay cannot be performed for this subscription.  This means
+       the publisher will not provide the requested historic
+       information from the event stream via replay to this
+       receiver.";
+  }
+
+  identity stream-unavailable {
+    base subscription-terminated-reason;
+    description
+      "Not a subscribable event stream.  This means the referenced
+       event stream is not available for subscription by the
+       receiver.";
+  }
+
+  identity suspension-timeout {
+    base subscription-terminated-reason;
+    description
+      "Termination of a previously suspended subscription.  The
+       publisher has eliminated the subscription, as it exceeded a
+       time limit for suspension.";
+  }
+
+  identity unsupportable-volume {
+    base subscription-suspended-reason;
+    description
+      "The publisher does not have the network bandwidth needed to
+       get the volume of generated information intended for a
+       receiver.";
+  }
+
+  identity configurable-encoding {
+    description
+      "If a transport identity derives from this identity, it means
+       that it supports configurable encodings.  An example of a
+       configurable encoding might be a new identity such as
+       'encode-cbor'.  Such an identity could use
+       'configurable-encoding' as its base.  This would allow a
+       dynamic subscription encoded in JSON (RFC 8259) to request
+       that notification messages be encoded via the Concise Binary
+       Object Representation (CBOR) (RFC 7049).  Further details for
+       any specific configurable encoding would be explored in a
+       transport document based on this specification.";
+    reference
+      "RFC 8259: The JavaScript Object Notation (JSON) Data
+                 Interchange Format
+       RFC 7049: Concise Binary Object Representation (CBOR)";
+  }
+
+  identity encoding {
+    description
+      "Base identity to represent data encodings.";
+  }
+
+  identity encode-xml {
+    if-feature "encode-xml";
+    base encoding;
+    description
+      "Encode data using XML as described in RFC 7950.";
+    reference
+      "RFC 7950: The YANG 1.1 Data Modeling Language";
+  }
+
+  identity encode-json {
+    if-feature "encode-json";
+    base encoding;
+    description
+      "Encode data using JSON as described in RFC 7951.";
+    reference
+      "RFC 7951: JSON Encoding of Data Modeled with YANG";
+  }
+
+  identity transport {
+    description
+      "An identity that represents the underlying mechanism for
+       passing notification messages.";
+  }
+
+  typedef encoding {
+    type identityref {
+      base encoding;
+    }
+    description
+      "Specifies a data encoding, e.g., for a data subscription.";
+  }
+
+  typedef stream-filter-ref {
+    type leafref {
+      path "/sn:filters/sn:stream-filter/sn:name";
+    }
+    description
+      "This type is used to reference an event stream filter.";
+  }
+
+  typedef stream-ref {
+    type leafref {
+      path "/sn:streams/sn:stream/sn:name";
+    }
+    description
+      "This type is used to reference a system-provided
+       event stream.";
+  }
+
+  typedef subscription-id {
+    type uint32;
+    description
+      "A type for subscription identifiers.";
+  }
+
+  typedef transport {
+    type identityref {
+      base transport;
+    }
+    description
+      "Specifies the transport used to send notification messages
+       to a receiver.";
+  }
+
+  grouping stream-filter-elements {
+    description
+      "This grouping defines the base for filters applied to event
+       streams.";
+    choice filter-spec {
+      description
+        "The content filter specification for this request.";
+      anydata stream-subtree-filter {
+        if-feature "subtree";
+        description
+          "Event stream evaluation criteria encoded in the syntax of
+           a subtree filter as defined in RFC 6241, Section 6.
+
+           The subtree filter is applied to the representation of
+           individual, delineated event records as contained in the
+           event stream.
+
+           If the subtree filter returns a non-empty node set, the
+           filter matches the event record, and the event record is
+           included in the notification message sent to the
+           receivers.";
+        reference
+          "RFC 6241: Network Configuration Protocol (NETCONF),
+                     Section 6";
+      }
+      leaf stream-xpath-filter {
+        if-feature "xpath";
+        type yang:xpath1.0;
+        description
+          "Event stream evaluation criteria encoded in the syntax of
+           an XPath 1.0 expression.
+
+           The XPath expression is evaluated on the representation of
+           individual, delineated event records as contained in
+           the event stream.
+
+           The result of the XPath expression is converted to a
+           boolean value using the standard XPath 1.0 rules.  If the
+           boolean value is 'true', the filter matches the event
+           record, and the event record is included in the
+           notification message sent to the receivers.
+
+           The expression is evaluated in the following XPath
+           context:
+
+              o  The set of namespace declarations is the set of
+                 prefix and namespace pairs for all YANG modules
+                 implemented by the server, where the prefix is the
+                 YANG module name and the namespace is as defined by
+                 the 'namespace' statement in the YANG module.
+
+                 If the leaf is encoded in XML, all namespace
+                 declarations in scope on the 'stream-xpath-filter'
+                 leaf element are added to the set of namespace
+                 declarations.  If a prefix found in the XML is
+                 already present in the set of namespace
+                 declarations, the namespace in the XML is used.
+
+              o  The set of variable bindings is empty.
+
+              o  The function library is comprised of the core
+                 function library and the XPath functions defined in
+                 Section 10 in RFC 7950.
+
+              o  The context node is the root node.";
+        reference
+          "XML Path Language (XPath) Version 1.0
+           (https://www.w3.org/TR/1999/REC-xpath-19991116)
+           RFC 7950: The YANG 1.1 Data Modeling Language,
+                     Section 10";
+      }
+    }
+  }
+
+  grouping update-qos {
+    description
+      "This grouping describes QoS information concerning a
+       subscription.  This information is passed to lower layers
+       for transport prioritization and treatment.";
+    leaf dscp {
+      if-feature "dscp";
+      type inet:dscp;
+      default "0";
+      description
+        "The desired network transport priority level.  This is the
+         priority set on notification messages encapsulating the
+         results of the subscription.  This transport priority is
+         shared for all receivers of a given subscription.";
+    }
+    leaf weighting {
+      if-feature "qos";
+      type uint8 {
+        range "0 .. 255";
+      }
+      description
+        "Relative weighting for a subscription.  Larger weights get
+         more resources.  Allows an underlying transport layer to
+         perform informed load-balance allocations between various
+         subscriptions.";
+      reference
+        "RFC 7540: Hypertext Transfer Protocol Version 2 (HTTP/2),
+                   Section 5.3.2";
+    }
+    leaf dependency {
+      if-feature "qos";
+      type subscription-id;
+      description
+        "Provides the 'subscription-id' of a parent subscription.
+         The parent subscription has absolute precedence should
+         that parent have push updates ready to egress the publisher.
+         In other words, there should be no streaming of objects from
+         the current subscription if the parent has something ready
+         to push.
+
+         If a dependency is asserted via configuration or via an RPC
+         but the referenced 'subscription-id' does not exist, the
+         dependency is silently discarded.  If a referenced
+         subscription is deleted, this dependency is removed.";
+      reference
+        "RFC 7540: Hypertext Transfer Protocol Version 2 (HTTP/2),
+                   Section 5.3.1";
+    }
+  }
+
+  grouping subscription-policy-modifiable {
+    description
+      "This grouping describes all objects that may be changed
+       in a subscription.";
+    choice target {
+      mandatory true;
+      description
+        "Identifies the source of information against which a
+         subscription is being applied as well as specifics on the
+         subset of information desired from that source.";
+      case stream {
+        choice stream-filter {
+          description
+            "An event stream filter can be applied to a subscription.
+             That filter will either come referenced from a global
+             list or be provided in the subscription itself.";
+          case by-reference {
+            description
+              "Apply a filter that has been configured separately.";
+            leaf stream-filter-name {
+              type stream-filter-ref;
+              mandatory true;
+              description
+                "References an existing event stream filter that is
+                 to be applied to an event stream for the
+                 subscription.";
+            }
+          }
+          case within-subscription {
+            description
+              "A local definition allows a filter to have the same
+               lifecycle as the subscription.";
+            uses stream-filter-elements;
+          }
+        }
+      }
+    }
+    leaf stop-time {
+      type yang:date-and-time;
+      description
+        "Identifies a time after which notification messages for a
+         subscription should not be sent.  If 'stop-time' is not
+         present, the notification messages will continue until the
+         subscription is terminated.  If 'replay-start-time' exists,
+         'stop-time' must be for a subsequent time.  If
+         'replay-start-time' doesn't exist, 'stop-time', when
+         established, must be for a future time.";
+    }
+  }
+
+  grouping subscription-policy-dynamic {
+    description
+      "This grouping describes the only information concerning a
+       subscription that can be passed over the RPCs defined in this
+       data model.";
+    uses subscription-policy-modifiable {
+      augment "target/stream" {
+        description
+          "Adds additional objects that can be modified by an RPC.";
+        leaf stream {
+          type stream-ref {
+            require-instance false;
+          }
+          mandatory true;
+          description
+            "Indicates the event stream to be considered for
+             this subscription.";
+        }
+        leaf replay-start-time {
+          if-feature "replay";
+          type yang:date-and-time;
+          config false;
+          description
+            "Used to trigger the 'replay' feature for a dynamic
+             subscription, where event records that are selected
+             need to be at or after the specified starting time.  If
+             'replay-start-time' is not present, this is not a replay
+             subscription and event record push should start
+             immediately.  It is never valid to specify start times
+             that are later than or equal to the current time.";
+        }
+      }
+    }
+    uses update-qos;
+  }
+
+  grouping subscription-policy {
+    description
+      "This grouping describes the full set of policy information
+       concerning both dynamic and configured subscriptions, with the
+       exclusion of both receivers and networking information
+       specific to the publisher, such as what interface should be
+       used to transmit notification messages.";
+    uses subscription-policy-dynamic;
+    leaf transport {
+      if-feature "configured";
+      type transport;
+      description
+        "For a configured subscription, this leaf specifies the
+         transport used to deliver messages destined for all
+         receivers of that subscription.";
+    }
+    leaf encoding {
+      when "not(../transport) or derived-from(../transport,
+        \"sn:configurable-encoding\")";
+      type encoding;
+      description
+        "The type of encoding for notification messages.  For a
+         dynamic subscription, if not included as part of an
+         'establish-subscription' RPC, the encoding will be populated
+         with the encoding used by that RPC.  For a configured
+         subscription, if not explicitly configured, the encoding
+         will be the default encoding for an underlying transport.";
+    }
+    leaf purpose {
+      if-feature "configured";
+      type string;
+      description
+        "Open text allowing a configuring entity to embed the
+         originator or other specifics of this subscription.";
+    }
+  }
+
+  container streams {
+    config false;
+    description
+      "Contains information on the built-in event streams provided by
+       the publisher.";
+    list stream {
+      key "name";
+      description
+        "Identifies the built-in event streams that are supported by
+         the publisher.";
+      leaf name {
+        type string;
+        description
+          "A handle for a system-provided event stream made up of a
+           sequential set of event records, each of which is
+           characterized by its own domain and semantics.";
+      }
+      leaf description {
+        type string;
+        description
+          "A description of the event stream, including such
+           information as the type of event records that are
+           available in this event stream.";
+      }
+      leaf replay-support {
+        if-feature "replay";
+        type empty;
+        description
+          "Indicates that event record replay is available on this
+           event stream.";
+      }
+      leaf replay-log-creation-time {
+        when "../replay-support";
+        if-feature "replay";
+        type yang:date-and-time;
+        mandatory true;
+        description
+          "The timestamp of the creation of the log used to support
+           the replay function on this event stream.  This time
+           might be earlier than the earliest available information
+           contained in the log.  This object is updated if the log
+           resets for some reason.";
+      }
+      leaf replay-log-aged-time {
+        when "../replay-support";
+        if-feature "replay";
+        type yang:date-and-time;
+        description
+          "The timestamp associated with the last event record that
+           has been aged out of the log.  This timestamp identifies
+           how far back in history this replay log extends, if it
+           doesn't extend back to the 'replay-log-creation-time'.
+           This object MUST be present if replay is supported and any
+           event records have been aged out of the log.";
+      }
+    }
+  }
+  container filters {
+    description
+      "Contains a list of configurable filters that can be applied to
+       subscriptions.  This facilitates the reuse of complex filters
+       once defined.";
+    list stream-filter {
+      key "name";
+      description
+        "A list of preconfigured filters that can be applied to
+         subscriptions.";
+      leaf name {
+        type string;
+        description
+          "A name to differentiate between filters.";
+      }
+      uses stream-filter-elements;
+    }
+  }
+  container subscriptions {
+    description
+      "Contains the list of currently active subscriptions, i.e.,
+       subscriptions that are currently in effect, used for
+       subscription management and monitoring purposes.  This
+       includes subscriptions that have been set up via
+       RPC primitives as well as subscriptions that have been
+       established via configuration.";
+    list subscription {
+      key "id";
+      description
+        "The identity and specific parameters of a subscription.
+         Subscriptions in this list can be created using a control
+         channel or RPC or can be established through configuration.
+
+         If the 'kill-subscription' RPC or configuration operations
+         are used to delete a subscription, a
+         'subscription-terminated' message is sent to any active or
+         suspended receivers.";
+      leaf id {
+        type subscription-id;
+        description
+          "Identifier of a subscription; unique in a given
+           publisher.";
+      }
+      uses subscription-policy {
+        refine "target/stream/stream" {
+          description
+            "Indicates the event stream to be considered for this
+             subscription.  If an event stream has been removed
+             and can no longer be referenced by an active
+             subscription, send a 'subscription-terminated'
+             notification with 'stream-unavailable' as the reason.
+             If a configured subscription refers to a nonexistent
+             event stream, move that subscription to the
+             'invalid' state.";
+        }
+        refine "transport" {
+          description
+            "For a configured subscription, this leaf specifies the
+             transport used to deliver messages destined for all
+             receivers of that subscription.  This object is
+             mandatory for subscriptions in the configuration
+             datastore.  This object (1) is not mandatory for dynamic
+             subscriptions in the operational state datastore and
+             (2) should not be present for other types of dynamic
+             subscriptions.";
+        }
+        augment "target/stream" {
+          description
+            "Enables objects to be added to a configured stream
+             subscription.";
+          leaf configured-replay {
+            if-feature "configured";
+            if-feature "replay";
+            type empty;
+            description
+              "The presence of this leaf indicates that replay for
+               the configured subscription should start at the
+               earliest time in the event log or at the publisher
+               boot time, whichever is later.";
+          }
+        }
+      }
+      choice notification-message-origin {
+        if-feature "configured";
+        description
+          "Identifies the egress interface on the publisher
+           from which notification messages are to be sent.";
+        case interface-originated {
+          description
+            "When notification messages are to egress a specific,
+             designated interface on the publisher.";
+          leaf source-interface {
+            if-feature "interface-designation";
+            type if:interface-ref;
+            description
+              "References the interface for notification messages.";
+          }
+        }
+        case address-originated {
+          description
+            "When notification messages are to depart from a
+             publisher using a specific originating address and/or
+             routing context information.";
+          leaf source-vrf {
+            if-feature "supports-vrf";
+            type leafref {
+              path "/ni:network-instances/ni:network-instance/ni:name";
+            }
+            description
+              "VRF from which notification messages should egress a
+               publisher.";
+          }
+          leaf source-address {
+            type inet:ip-address-no-zone;
+            description
+              "The source address for the notification messages.
+               If a source VRF exists but this object doesn't, a
+               publisher's default address for that VRF must
+               be used.";
+          }
+        }
+      }
+      leaf configured-subscription-state {
+        if-feature "configured";
+        type enumeration {
+          enum "valid" {
+            value 1;
+            description
+              "The subscription is supportable with its current
+               parameters.";
+          }
+          enum "invalid" {
+            value 2;
+            description
+              "The subscription as a whole is unsupportable with its
+               current parameters.";
+          }
+          enum "concluded" {
+            value 3;
+            description
+              "A subscription is inactive, as it has hit a
+               stop time.  It no longer has receivers in the
+               'active' or 'suspended' state, but the subscription
+               has not yet been removed from configuration.";
+          }
+        }
+        config false;
+        description
+          "The presence of this leaf indicates that the subscription
+           originated from configuration, not through a control
+           channel or RPC.  The value indicates the state of the
+           subscription as established by the publisher.";
+      }
+      container receivers {
+        description
+          "Set of receivers in a subscription.";
+        list receiver {
+          key "name";
+          min-elements 1;
+          description
+            "A host intended as a recipient for the notification
+             messages of a subscription.  For configured
+             subscriptions, transport-specific network parameters
+             (or a leafref to those parameters) may be augmented to a
+             specific receiver in this list.";
+          leaf name {
+            type string;
+            description
+              "Identifies a unique receiver for a subscription.";
+          }
+          leaf sent-event-records {
+            type yang:zero-based-counter64;
+            config false;
+            description
+              "The number of event records sent to the receiver.  The
+               count is initialized when a dynamic subscription is
+               established or when a configured receiver
+               transitions to the 'valid' state.";
+          }
+          leaf excluded-event-records {
+            type yang:zero-based-counter64;
+            config false;
+            description
+              "The number of event records explicitly removed via
+               either an event stream filter or an access control
+               filter so that they are not passed to a receiver.
+               This count is set to zero each time
+               'sent-event-records' is initialized.";
+          }
+          leaf state {
+            type enumeration {
+              enum "active" {
+                value 1;
+                description
+                  "The receiver is currently being sent any
+                   applicable notification messages for the
+                   subscription.";
+              }
+              enum "suspended" {
+                value 2;
+                description
+                  "The receiver state is 'suspended', so the
+                   publisher is currently unable to provide
+                   notification messages for the subscription.";
+              }
+              enum "connecting" {
+                if-feature "configured";
+                value 3;
+                description
+                  "A subscription has been configured, but a
+                   'subscription-started' subscription state change
+                   notification needs to be successfully received
+                   before notification messages are sent.
+
+                   If the 'reset' action is invoked for a receiver of
+                   an active configured subscription, the state
+                   must be moved to 'connecting'.";
+              }
+              enum "disconnected" {
+                if-feature "configured";
+                value 4;
+                description
+                  "A subscription has failed to send a
+                   'subscription-started' state change to the
+                   receiver.  Additional connection attempts are not
+                   currently being made.";
+              }
+            }
+            config false;
+            mandatory true;
+            description
+              "Specifies the state of a subscription from the
+               perspective of a particular receiver.  With this
+               information, it is possible to determine whether a
+               publisher is currently generating notification
+               messages intended for that receiver.";
+          }
+          action reset {
+            if-feature "configured";
+            description
+              "Allows the reset of this configured subscription's
+               receiver to the 'connecting' state.  This enables the
+               connection process to be reinitiated.";
+
+            output {
+              leaf time {
+                type yang:date-and-time;
+                mandatory true;
+                description
+                  "Time at which a publisher returned the receiver to
+                   the 'connecting' state.";
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+
+  rpc establish-subscription {
+    description
+      "This RPC allows a subscriber to create (and possibly
+       negotiate) a subscription on its own behalf.  If successful,
+       the subscription remains in effect for the duration of the
+       subscriber's association with the publisher or until the
+       subscription is terminated.  If an error occurs or the
+       publisher cannot meet the terms of a subscription, an RPC
+       error is returned, and the subscription is not created.
+       In that case, the RPC reply's 'error-info' MAY include
+       suggested parameter settings that would have a higher
+       likelihood of succeeding in a subsequent
+       'establish-subscription' request.";
+
+    input {
+      uses subscription-policy-dynamic;
+      leaf encoding {
+        type encoding;
+        description
+          "The type of encoding for the subscribed data.  If not
+           included as part of the RPC, the encoding MUST be set by
+           the publisher to be the encoding used by this RPC.";
+      }
+    }
+    output {
+      leaf id {
+        type subscription-id;
+        mandatory true;
+        description
+          "Identifier used for this subscription.";
+      }
+      leaf replay-start-time-revision {
+        if-feature "replay";
+        type yang:date-and-time;
+        description
+          "If a replay has been requested, this object represents
+           the earliest time covered by the event buffer for the
+           requested event stream.  The value of this object is the
+           'replay-log-aged-time' if it exists.  Otherwise, it is
+           the 'replay-log-creation-time'.  All buffered event
+           records after this time will be replayed to a receiver.
+           This object will only be sent if the starting time has
+           been revised to be later than the time requested by the
+           subscriber.";
+      }
+    }
+  }
+  rpc modify-subscription {
+    description
+      "This RPC allows a subscriber to modify a dynamic
+       subscription's parameters.  If successful, the changed
+       subscription parameters remain in effect for the duration of
+       the subscription, until the subscription is again modified, or
+       until the subscription is terminated.  In the case of an error
+       or an inability to meet the modified parameters, the
+       subscription is not modified and the original subscription
+       parameters remain in effect.  In that case, the RPC error MAY
+       include 'error-info' suggested parameter hints that would have
+       a high likelihood of succeeding in a subsequent
+       'modify-subscription' request.  A successful
+       'modify-subscription' will return a suspended subscription to
+       the 'active' state.";
+
+    input {
+      leaf id {
+        type subscription-id;
+        mandatory true;
+        description
+          "Identifier to use for this subscription.";
+      }
+      uses subscription-policy-modifiable;
+    }
+  }
+  rpc delete-subscription {
+    description
+      "This RPC allows a subscriber to delete a subscription that
+       was previously created by that same subscriber using the
+       'establish-subscription' RPC.
+
+       If an error occurs, the server replies with an 'rpc-error'
+       where the 'error-info' field MAY contain a
+       'delete-subscription-error-info' structure.";
+
+    input {
+      leaf id {
+        type subscription-id;
+        mandatory true;
+        description
+          "Identifier of the subscription that is to be deleted.
+           Only subscriptions that were created using
+           'establish-subscription' from the same origin as this RPC
+           can be deleted via this RPC.";
+      }
+    }
+  }
+  rpc kill-subscription {
+    nacm:default-deny-all;
+    description
+      "This RPC allows an operator to delete a dynamic subscription
+       without restrictions on the originating subscriber or
+       underlying transport session.
+
+       If an error occurs, the server replies with an 'rpc-error'
+       where the 'error-info' field MAY contain a
+       'delete-subscription-error-info' structure.";
+
+    input {
+      leaf id {
+        type subscription-id;
+        mandatory true;
+        description
+          "Identifier of the subscription that is to be deleted.
+           Only subscriptions that were created using
+           'establish-subscription' can be deleted via this RPC.";
+      }
+    }
+  }
+
+  notification replay-completed {
+    sn:subscription-state-notification;
+    if-feature "replay";
+    description
+      "This notification is sent to indicate that all of the replay
+       notifications have been sent.";
+    leaf id {
+      type subscription-id;
+      mandatory true;
+      description
+        "This references the affected subscription.";
+    }
+  }
+  notification subscription-completed {
+    sn:subscription-state-notification;
+    if-feature "configured";
+    description
+      "This notification is sent to indicate that a subscription has
+       finished passing event records, as the 'stop-time' has been
+       reached.";
+    leaf id {
+      type subscription-id;
+      mandatory true;
+      description
+        "This references the gracefully completed subscription.";
+    }
+  }
+  notification subscription-modified {
+    sn:subscription-state-notification;
+    description
+      "This notification indicates that a subscription has been
+       modified.  Notification messages sent from this point on will
+       conform to the modified terms of the subscription.  For
+       completeness, this subscription state change notification
+       includes both modified and unmodified aspects of a
+       subscription.";
+    leaf id {
+      type subscription-id;
+      mandatory true;
+      description
+        "This references the affected subscription.";
+    }
+    uses subscription-policy {
+      refine "target/stream/stream-filter/within-subscription" {
+        description
+          "Filter applied to the subscription.  If the
+           'stream-filter-name' is populated, the filter in the
+           subscription came from the 'filters' container.
+           Otherwise, it is populated in-line as part of the
+           subscription.";
+      }
+    }
+  }
+  notification subscription-resumed {
+    sn:subscription-state-notification;
+    description
+      "This notification indicates that a subscription that had
+       previously been suspended has resumed.  Notifications will
+       once again be sent.  In addition, a 'subscription-resumed'
+       indicates that no modification of parameters has occurred
+       since the last time event records have been sent.";
+    leaf id {
+      type subscription-id;
+      mandatory true;
+      description
+        "This references the affected subscription.";
+    }
+  }
+  notification subscription-started {
+    sn:subscription-state-notification;
+    if-feature "configured";
+    description
+      "This notification indicates that a subscription has started
+       and notifications will now be sent.";
+    leaf id {
+      type subscription-id;
+      mandatory true;
+      description
+        "This references the affected subscription.";
+    }
+    uses subscription-policy {
+      refine "target/stream/replay-start-time" {
+        description
+          "Indicates the time that a replay is using for the
+           streaming of buffered event records.  This will be
+           populated with the most recent of the following:
+           the event time of the previous event record sent to a
+           receiver, the 'replay-log-creation-time', the
+           'replay-log-aged-time', or the most recent publisher
+           boot time.";
+      }
+      refine "target/stream/stream-filter/within-subscription" {
+        description
+          "Filter applied to the subscription.  If the
+           'stream-filter-name' is populated, the filter in the
+           subscription came from the 'filters' container.
+           Otherwise, it is populated in-line as part of the
+           subscription.";
+      }
+      augment "target/stream" {
+        description
+          "This augmentation adds additional parameters specific to a
+           'subscription-started' notification.";
+        leaf replay-previous-event-time {
+          when "../replay-start-time";
+          if-feature "replay";
+          type yang:date-and-time;
+          description
+            "If there is at least one event in the replay buffer
+             prior to 'replay-start-time', this gives the time of
+             the event generated immediately prior to the
+             'replay-start-time'.
+
+             If a receiver previously received event records for
+             this configured subscription, it can compare this time
+             to the last event record previously received.  If the
+             two are not the same (perhaps due to a reboot), then a
+             dynamic replay can be initiated to acquire any missing
+             event records.";
+        }
+      }
+    }
+  }
+  notification subscription-suspended {
+    sn:subscription-state-notification;
+    description
+      "This notification indicates that a suspension of the
+       subscription by the publisher has occurred.  No further
+       notifications will be sent until the subscription resumes.
+       This notification shall only be sent to receivers of a
+       subscription; it does not constitute a general-purpose
+       notification.";
+    leaf id {
+      type subscription-id;
+      mandatory true;
+      description
+        "This references the affected subscription.";
+    }
+    leaf reason {
+      type identityref {
+        base subscription-suspended-reason;
+      }
+      mandatory true;
+      description
+        "Identifies the condition that resulted in the suspension.";
+    }
+  }
+  notification subscription-terminated {
+    sn:subscription-state-notification;
+    description
+      "This notification indicates that a subscription has been
+       terminated.";
+    leaf id {
+      type subscription-id;
+      mandatory true;
+      description
+        "This references the affected subscription.";
+    }
+    leaf reason {
+      type identityref {
+        base subscription-terminated-reason;
+      }
+      mandatory true;
+      description
+        "Identifies the condition that resulted in the termination.";
+    }
+  }
+}
+"""
+
+ietf_restconf = r"""module ietf-restconf {
+  yang-version 1.1;
+  namespace "urn:ietf:params:xml:ns:yang:ietf-restconf";
+  prefix rc;
+
+  organization
+    "IETF NETCONF (Network Configuration) Working Group";
+  contact
+    "WG Web:   <https://datatracker.ietf.org/wg/netconf/>
+     WG List:  <mailto:netconf@ietf.org>
+
+     Author:   Andy Bierman
+               <mailto:andy@yumaworks.com>
+
+     Author:   Martin Bjorklund
+               <mailto:mbj@tail-f.com>
+
+     Author:   Kent Watsen
+               <mailto:kwatsen@juniper.net>";
+  description
+    "This module contains conceptual YANG specifications
+     for basic RESTCONF media type definitions used in
+     RESTCONF protocol messages.
+
+     Note that the YANG definitions within this module do not
+     represent configuration data of any kind.
+     The 'restconf-media-type' YANG extension statement
+     provides a normative syntax for XML and JSON
+     message-encoding purposes.
+
+     Copyright (c) 2017 IETF Trust and the persons identified as
+     authors of the code.  All rights reserved.
+
+     Redistribution and use in source and binary forms, with or
+     without modification, is permitted pursuant to, and subject
+     to the license terms contained in, the Simplified BSD License
+     set forth in Section 4.c of the IETF Trust's Legal Provisions
+     Relating to IETF Documents
+     (http://trustee.ietf.org/license-info).
+
+     This version of this YANG module is part of RFC 8040; see
+     the RFC itself for full legal notices.";
+
+  revision 2017-01-26 {
+    description
+      "Initial revision.";
+    reference
+      "RFC 8040: RESTCONF Protocol.";
+  }
+
+  extension yang-data {
+    argument name {
+      yin-element true;
+    }
+    description
+      "This extension is used to specify a YANG data template that
+       represents conceptual data defined in YANG.  It is
+       intended to describe hierarchical data independent of
+       protocol context or specific message-encoding format.
+       Data definition statements within a yang-data extension
+       specify the generic syntax for the specific YANG data
+       template, whose name is the argument of the 'yang-data'
+       extension statement.
+
+       Note that this extension does not define a media type.
+       A specification using this extension MUST specify the
+       message-encoding rules, including the content media type.
+
+       The mandatory 'name' parameter value identifies the YANG
+       data template that is being defined.  It contains the
+       template name.
+
+       This extension is ignored unless it appears as a top-level
+       statement.  It MUST contain data definition statements
+       that result in exactly one container data node definition.
+       An instance of a YANG data template can thus be translated
+       into an XML instance document, whose top-level element
+       corresponds to the top-level container.
+       The module name and namespace values for the YANG module using
+       the extension statement are assigned to instance document data
+       conforming to the data definition statements within
+       this extension.
+
+       The substatements of this extension MUST follow the
+       'data-def-stmt' rule in the YANG ABNF.
+
+       The XPath document root is the extension statement itself,
+       such that the child nodes of the document root are
+       represented by the data-def-stmt substatements within
+       this extension.  This conceptual document is the context
+       for the following YANG statements:
+
+         - must-stmt
+         - when-stmt
+         - path-stmt
+         - min-elements-stmt
+         - max-elements-stmt
+         - mandatory-stmt
+         - unique-stmt
+         - ordered-by
+         - instance-identifier data type
+
+       The following data-def-stmt substatements are constrained
+       when used within a 'yang-data' extension statement.
+
+         - The list-stmt is not required to have a key-stmt defined.
+         - The if-feature-stmt is ignored if present.
+         - The config-stmt is ignored if present.
+         - The available identity values for any 'identityref'
+           leaf or leaf-list nodes are limited to the module
+           containing this extension statement and the modules
+           imported into that module.
+       ";
+  }
+
+  rc:yang-data "yang-errors" {
+    uses errors;
+  }
+  rc:yang-data "yang-api" {
+    uses restconf;
+  }
+
+  grouping errors {
+    description
+      "A grouping that contains a YANG container
+       representing the syntax and semantics of a
+       YANG Patch error report within a response message.";
+    container errors {
+      description
+        "Represents an error report returned by the server if
+         a request results in an error.";
+      list error {
+        description
+          "An entry containing information about one
+           specific error that occurred while processing
+           a RESTCONF request.";
+        reference
+          "RFC 6241, Section 4.3.";
+        leaf error-type {
+          type enumeration {
+            enum "transport" {
+              description
+                "The transport layer.";
+            }
+            enum "rpc" {
+              description
+                "The rpc or notification layer.";
+            }
+            enum "protocol" {
+              description
+                "The protocol operation layer.";
+            }
+            enum "application" {
+              description
+                "The server application layer.";
+            }
+          }
+          mandatory true;
+          description
+            "The protocol layer where the error occurred.";
+        }
+        leaf error-tag {
+          type string;
+          mandatory true;
+          description
+            "The enumerated error-tag.";
+        }
+        leaf error-app-tag {
+          type string;
+          description
+            "The application-specific error-tag.";
+        }
+        leaf error-path {
+          type instance-identifier;
+          description
+            "The YANG instance identifier associated
+             with the error node.";
+        }
+        leaf error-message {
+          type string;
+          description
+            "A message describing the error.";
+        }
+        anydata error-info {
+          description
+            "This anydata value MUST represent a container with
+             zero or more data nodes representing additional
+             error information.";
+        }
+      }
+    }
+  }
+
+  grouping restconf {
+    description
+      "Conceptual grouping representing the RESTCONF
+       root resource.";
+    container restconf {
+      description
+        "Conceptual container representing the RESTCONF
+         root resource.";
+      container data {
+        description
+          "Container representing the datastore resource.
+           Represents the conceptual root of all state data
+           and configuration data supported by the server.
+           The child nodes of this container can be any data
+           resources that are defined as top-level data nodes
+           from the YANG modules advertised by the server in
+           the 'ietf-yang-library' module.";
+      }
+      container operations {
+        description
+          "Container for all operation resources.
+
+           Each resource is represented as an empty leaf with the
+           name of the RPC operation from the YANG 'rpc' statement.
+
+           For example, the 'system-restart' RPC operation defined
+           in the 'ietf-system' module would be represented as
+           an empty leaf in the 'ietf-system' namespace.  This is
+           a conceptual leaf and will not actually be found in
+           the module:
+
+              module ietf-system {
+                leaf system-reset {
+                  type empty;
+                }
+              }
+
+           To invoke the 'system-restart' RPC operation:
+
+              POST /restconf/operations/ietf-system:system-restart
+
+           To discover the RPC operations supported by the server:
+
+              GET /restconf/operations
+
+           In XML, the YANG module namespace identifies the module:
+
+             <system-restart
+                xmlns='urn:ietf:params:xml:ns:yang:ietf-system'/>
+
+           In JSON, the YANG module name identifies the module:
+
+             { 'ietf-system:system-restart' : [null] }
+           ";
+      }
+      leaf yang-library-version {
+        type string {
+          pattern '\d{4}-\d{2}-\d{2}';
+        }
+        config false;
+        mandatory true;
+        description
+          "Identifies the revision date of the 'ietf-yang-library'
+           module that is implemented by this RESTCONF server.
+           Indicates the year, month, and day in YYYY-MM-DD
+           numeric format.";
+      }
+    }
+  }
+}
+"""
+
+ietf_yang_patch = r"""module ietf-yang-patch {
+  yang-version 1.1;
+  namespace "urn:ietf:params:xml:ns:yang:ietf-yang-patch";
+  prefix ypatch;
+
+  import ietf-restconf {
+    prefix rc;
+  }
+
+  organization
+    "IETF NETCONF (Network Configuration) Working Group";
+  contact
+    "WG Web:   <https://datatracker.ietf.org/wg/netconf/>
+     WG List:  <mailto:netconf@ietf.org>
+
+     Author:   Andy Bierman
+               <mailto:andy@yumaworks.com>
+
+     Author:   Martin Bjorklund
+               <mailto:mbj@tail-f.com>
+
+     Author:   Kent Watsen
+               <mailto:kwatsen@juniper.net>";
+  description
+    "This module contains conceptual YANG specifications
+     for the YANG Patch and YANG Patch Status data structures.
+
+     Note that the YANG definitions within this module do not
+     represent configuration data of any kind.
+     The YANG grouping statements provide a normative syntax
+     for XML and JSON message-encoding purposes.
+
+     Copyright (c) 2017 IETF Trust and the persons identified as
+     authors of the code.  All rights reserved.
+
+     Redistribution and use in source and binary forms, with or
+     without modification, is permitted pursuant to, and subject
+     to the license terms contained in, the Simplified BSD License
+     set forth in Section 4.c of the IETF Trust's Legal Provisions
+     Relating to IETF Documents
+     (http://trustee.ietf.org/license-info).
+
+     This version of this YANG module is part of RFC 8072; see
+     the RFC itself for full legal notices.";
+
+  revision 2017-02-22 {
+    description
+      "Initial revision.";
+    reference
+      "RFC 8072: YANG Patch Media Type.";
+  }
+
+  rc:yang-data "yang-patch" {
+    uses yang-patch;
+  }
+  rc:yang-data "yang-patch-status" {
+    uses yang-patch-status;
+  }
+
+  typedef target-resource-offset {
+    type string;
+    description
+      "Contains a data resource identifier string representing
+       a sub-resource within the target resource.
+       The document root for this expression is the
+       target resource that is specified in the
+       protocol operation (e.g., the URI for the PATCH request).
+
+       This string is encoded according to the same rules as those
+       for a data resource identifier in a RESTCONF request URI.";
+    reference
+      "RFC 8040, Section 3.5.3.";
+  }
+
+  grouping yang-patch {
+    description
+      "A grouping that contains a YANG container representing the
+       syntax and semantics of a YANG Patch edit request message.";
+    container yang-patch {
+      description
+        "Represents a conceptual sequence of datastore edits,
+         called a patch.  Each patch is given a client-assigned
+         patch identifier.  Each edit MUST be applied
+         in ascending order, and all edits MUST be applied.
+         If any errors occur, then the target datastore MUST NOT
+         be changed by the YANG Patch operation.
+
+         It is possible for a datastore constraint violation to occur
+         due to any node in the datastore, including nodes not
+         included in the 'edit' list.  Any validation errors MUST
+         be reported in the reply message.";
+      reference
+        "RFC 7950, Section 8.3.";
+      leaf patch-id {
+        type string;
+        mandatory true;
+        description
+          "An arbitrary string provided by the client to identify
+           the entire patch.  Error messages returned by the server
+           that pertain to this patch will be identified by this
+           'patch-id' value.  A client SHOULD attempt to generate
+           unique 'patch-id' values to distinguish between
+           transactions from multiple clients in any audit logs
+           maintained by the server.";
+      }
+      leaf comment {
+        type string;
+        description
+          "An arbitrary string provided by the client to describe
+           the entire patch.  This value SHOULD be present in any
+           audit logging records generated by the server for the
+           patch.";
+      }
+      list edit {
+        key "edit-id";
+        ordered-by user;
+        description
+          "Represents one edit within the YANG Patch request message.
+           The 'edit' list is applied in the following manner:
+
+             - The first edit is conceptually applied to a copy
+               of the existing target datastore, e.g., the
+               running configuration datastore.
+             - Each ascending edit is conceptually applied to
+               the result of the previous edit(s).
+             - After all edits have been successfully processed,
+               the result is validated according to YANG constraints.
+             - If successful, the server will attempt to apply
+               the result to the target datastore.";
+        leaf edit-id {
+          type string;
+          description
+            "Arbitrary string index for the edit.
+             Error messages returned by the server that pertain
+             to a specific edit will be identified by this value.";
+        }
+        leaf operation {
+          type enumeration {
+            enum "create" {
+              description
+                "The target data node is created using the supplied
+                 value, only if it does not already exist.  The
+                 'target' leaf identifies the data node to be
+                 created, not the parent data node.";
+            }
+            enum "delete" {
+              description
+                "Delete the target node, only if the data resource
+                 currently exists; otherwise, return an error.";
+            }
+            enum "insert" {
+              description
+                "Insert the supplied value into a user-ordered
+                 list or leaf-list entry.  The target node must
+                 represent a new data resource.  If the 'where'
+                 parameter is set to 'before' or 'after', then
+                 the 'point' parameter identifies the insertion
+                 point for the target node.";
+            }
+            enum "merge" {
+              description
+                "The supplied value is merged with the target data
+                 node.";
+            }
+            enum "move" {
+              description
+                "Move the target node.  Reorder a user-ordered
+                 list or leaf-list.  The target node must represent
+                 an existing data resource.  If the 'where' parameter
+                 is set to 'before' or 'after', then the 'point'
+                 parameter identifies the insertion point to move
+                 the target node.";
+            }
+            enum "replace" {
+              description
+                "The supplied value is used to replace the target
+                 data node.";
+            }
+            enum "remove" {
+              description
+                "Delete the target node if it currently exists.";
+            }
+          }
+          mandatory true;
+          description
+            "The datastore operation requested for the associated
+             'edit' entry.";
+        }
+        leaf target {
+          type target-resource-offset;
+          mandatory true;
+          description
+            "Identifies the target data node for the edit
+             operation.  If the target has the value '/', then
+             the target data node is the target resource.
+             The target node MUST identify a data resource,
+             not the datastore resource.";
+        }
+        leaf point {
+          when "(../operation = 'insert' or ../operation = 'move')and (../where = 'before' or ../where = 'after')" {
+            description
+              "This leaf only applies for 'insert' or 'move'
+               operations, before or after an existing entry.";
+          }
+          type target-resource-offset;
+          description
+            "The absolute URL path for the data node that is being
+             used as the insertion point or move point for the
+             target of this 'edit' entry.";
+        }
+        leaf where {
+          when "../operation = 'insert' or ../operation = 'move'" {
+            description
+              "This leaf only applies for 'insert' or 'move'
+               operations.";
+          }
+          type enumeration {
+            enum "before" {
+              description
+                "Insert or move a data node before the data resource
+                 identified by the 'point' parameter.";
+            }
+            enum "after" {
+              description
+                "Insert or move a data node after the data resource
+                 identified by the 'point' parameter.";
+            }
+            enum "first" {
+              description
+                "Insert or move a data node so it becomes ordered
+                 as the first entry.";
+            }
+            enum "last" {
+              description
+                "Insert or move a data node so it becomes ordered
+                 as the last entry.";
+            }
+          }
+          default "last";
+          description
+            "Identifies where a data resource will be inserted
+             or moved.  YANG only allows these operations for
+             list and leaf-list data nodes that are
+             'ordered-by user'.";
+        }
+        anydata value {
+          when "../operation = 'create' or ../operation = 'merge' or ../operation = 'replace' or ../operation = 'insert'" {
+            description
+              "The anydata 'value' is only used for 'create',
+               'merge', 'replace', and 'insert' operations.";
+          }
+          description
+            "Value used for this edit operation.  The anydata 'value'
+             contains the target resource associated with the
+             'target' leaf.
+
+             For example, suppose the target node is a YANG container
+             named foo:
+
+                 container foo {
+                   leaf a { type string; }
+                   leaf b { type int32; }
+                 }
+
+             The 'value' node contains one instance of foo:
+
+                 <value>
+                    <foo xmlns='example-foo-namespace'>
+                       <a>some value</a>
+                       <b>42</b>
+                    </foo>
+                 </value>
+              ";
+        }
+      }
+    }
+  }
+
+  grouping yang-patch-status {
+    description
+      "A grouping that contains a YANG container representing the
+       syntax and semantics of a YANG Patch Status response
+       message.";
+    container yang-patch-status {
+      description
+        "A container representing the response message sent by the
+         server after a YANG Patch edit request message has been
+         processed.";
+      leaf patch-id {
+        type string;
+        mandatory true;
+        description
+          "The 'patch-id' value used in the request.";
+      }
+      choice global-status {
+        description
+          "Report global errors or complete success.
+           If there is no case selected, then errors
+           are reported in the 'edit-status' container.";
+        case global-errors {
+          description
+            "This container will be present if global errors that
+             are unrelated to a specific edit occurred.";
+          uses rc:errors;
+        }
+        leaf ok {
+          type empty;
+          description
+            "This leaf will be present if the request succeeded
+             and there are no errors reported in the 'edit-status'
+             container.";
+        }
+      }
+      container edit-status {
+        description
+          "This container will be present if there are
+           edit-specific status responses to report.
+           If all edits succeeded and the 'global-status'
+           returned is 'ok', then a server MAY omit this
+           container.";
+        list edit {
+          key "edit-id";
+          description
+            "Represents a list of status responses,
+             corresponding to edits in the YANG Patch
+             request message.  If an 'edit' entry was
+             skipped or not reached by the server,
+             then this list will not contain a corresponding
+             entry for that edit.";
+          leaf edit-id {
+            type string;
+            description
+              "Response status is for the 'edit' list entry
+               with this 'edit-id' value.";
+          }
+          choice edit-status-choice {
+            description
+              "A choice between different types of status
+               responses for each 'edit' entry.";
+            leaf ok {
+              type empty;
+              description
+                "This 'edit' entry was invoked without any
+                 errors detected by the server associated
+                 with this edit.";
+            }
+            case errors {
+              description
+                "The server detected errors associated with the
+                 edit identified by the same 'edit-id' value.";
+              uses rc:errors;
+            }
+          }
+        }
+      }
+    }
+  }
+}
+"""
+
+ietf_interfaces = r"""module ietf-interfaces {
+  yang-version 1.1;
+  namespace "urn:ietf:params:xml:ns:yang:ietf-interfaces";
+  prefix if;
+
+  import ietf-yang-types {
+    prefix yang;
+  }
+
+  organization
+    "IETF NETMOD (Network Modeling) Working Group";
+  contact
+    "WG Web:   <https://datatracker.ietf.org/wg/netmod/>
+     WG List:  <mailto:netmod@ietf.org>
+
+     Editor:   Martin Bjorklund
+               <mailto:mbj@tail-f.com>";
+  description
+    "This module contains a collection of YANG definitions for
+     managing network interfaces.
+
+     Copyright (c) 2018 IETF Trust and the persons identified as
+     authors of the code.  All rights reserved.
+
+     Redistribution and use in source and binary forms, with or
+     without modification, is permitted pursuant to, and subject
+     to the license terms contained in, the Simplified BSD License
+     set forth in Section 4.c of the IETF Trust's Legal Provisions
+     Relating to IETF Documents
+     (https://trustee.ietf.org/license-info).
+
+     This version of this YANG module is part of RFC 8343; see
+     the RFC itself for full legal notices.";
+
+  revision 2018-02-20 {
+    description
+      "Updated to support NMDA.";
+    reference
+      "RFC 8343: A YANG Data Model for Interface Management";
+  }
+  revision 2014-05-08 {
+    description
+      "Initial revision.";
+    reference
+      "RFC 7223: A YANG Data Model for Interface Management";
+  }
+
+  feature arbitrary-names {
+    description
+      "This feature indicates that the device allows user-controlled
+       interfaces to be named arbitrarily.";
+  }
+
+  feature pre-provisioning {
+    description
+      "This feature indicates that the device supports
+       pre-provisioning of interface configuration, i.e., it is
+       possible to configure an interface whose physical interface
+       hardware is not present on the device.";
+  }
+
+  feature if-mib {
+    description
+      "This feature indicates that the device implements
+       the IF-MIB.";
+    reference
+      "RFC 2863: The Interfaces Group MIB";
+  }
+
+  identity interface-type {
+    description
+      "Base identity from which specific interface types are
+       derived.";
+  }
+
+  typedef interface-ref {
+    type leafref {
+      path "/if:interfaces/if:interface/if:name";
+    }
+    description
+      "This type is used by data models that need to reference
+       interfaces.";
+  }
+
+  typedef interface-state-ref {
+    type leafref {
+      path "/if:interfaces-state/if:interface/if:name";
+    }
+    status deprecated;
+    description
+      "This type is used by data models that need to reference
+       the operationally present interfaces.";
+  }
+
+  container interfaces {
+    description
+      "Interface parameters.";
+    list interface {
+      key "name";
+      description
+        "The list of interfaces on the device.
+
+         The status of an interface is available in this list in the
+         operational state.  If the configuration of a
+         system-controlled interface cannot be used by the system
+         (e.g., the interface hardware present does not match the
+         interface type), then the configuration is not applied to
+         the system-controlled interface shown in the operational
+         state.  If the configuration of a user-controlled interface
+         cannot be used by the system, the configured interface is
+         not instantiated in the operational state.
+
+         System-controlled interfaces created by the system are
+         always present in this list in the operational state,
+         whether or not they are configured.";
+      leaf name {
+        type string;
+        description
+          "The name of the interface.
+
+           A device MAY restrict the allowed values for this leaf,
+           possibly depending on the type of the interface.
+           For system-controlled interfaces, this leaf is the
+           device-specific name of the interface.
+
+           If a client tries to create configuration for a
+           system-controlled interface that is not present in the
+           operational state, the server MAY reject the request if
+           the implementation does not support pre-provisioning of
+           interfaces or if the name refers to an interface that can
+           never exist in the system.  A Network Configuration
+           Protocol (NETCONF) server MUST reply with an rpc-error
+           with the error-tag 'invalid-value' in this case.
+
+           If the device supports pre-provisioning of interface
+           configuration, the 'pre-provisioning' feature is
+           advertised.
+
+           If the device allows arbitrarily named user-controlled
+           interfaces, the 'arbitrary-names' feature is advertised.
+
+           When a configured user-controlled interface is created by
+           the system, it is instantiated with the same name in the
+           operational state.
+
+           A server implementation MAY map this leaf to the ifName
+           MIB object.  Such an implementation needs to use some
+           mechanism to handle the differences in size and characters
+           allowed between this leaf and ifName.  The definition of
+           such a mechanism is outside the scope of this document.";
+        reference
+          "RFC 2863: The Interfaces Group MIB - ifName";
+      }
+      leaf description {
+        type string;
+        description
+          "A textual description of the interface.
+
+           A server implementation MAY map this leaf to the ifAlias
+           MIB object.  Such an implementation needs to use some
+           mechanism to handle the differences in size and characters
+           allowed between this leaf and ifAlias.  The definition of
+           such a mechanism is outside the scope of this document.
+
+           Since ifAlias is defined to be stored in non-volatile
+           storage, the MIB implementation MUST map ifAlias to the
+           value of 'description' in the persistently stored
+           configuration.";
+        reference
+          "RFC 2863: The Interfaces Group MIB - ifAlias";
+      }
+      leaf type {
+        type identityref {
+          base interface-type;
+        }
+        mandatory true;
+        description
+          "The type of the interface.
+
+           When an interface entry is created, a server MAY
+           initialize the type leaf with a valid value, e.g., if it
+           is possible to derive the type from the name of the
+           interface.
+
+           If a client tries to set the type of an interface to a
+           value that can never be used by the system, e.g., if the
+           type is not supported or if the type does not match the
+           name of the interface, the server MUST reject the request.
+           A NETCONF server MUST reply with an rpc-error with the
+           error-tag 'invalid-value' in this case.";
+        reference
+          "RFC 2863: The Interfaces Group MIB - ifType";
+      }
+      leaf enabled {
+        type boolean;
+        default "true";
+        description
+          "This leaf contains the configured, desired state of the
+           interface.
+
+           Systems that implement the IF-MIB use the value of this
+           leaf in the intended configuration to set
+           IF-MIB.ifAdminStatus to 'up' or 'down' after an ifEntry
+           has been initialized, as described in RFC 2863.
+
+           Changes in this leaf in the intended configuration are
+           reflected in ifAdminStatus.";
+        reference
+          "RFC 2863: The Interfaces Group MIB - ifAdminStatus";
+      }
+      leaf link-up-down-trap-enable {
+        if-feature "if-mib";
+        type enumeration {
+          enum "enabled" {
+            value 1;
+            description
+              "The device will generate linkUp/linkDown SNMP
+               notifications for this interface.";
+          }
+          enum "disabled" {
+            value 2;
+            description
+              "The device will not generate linkUp/linkDown SNMP
+               notifications for this interface.";
+          }
+        }
+        description
+          "Controls whether linkUp/linkDown SNMP notifications
+           should be generated for this interface.
+
+           If this node is not configured, the value 'enabled' is
+           operationally used by the server for interfaces that do
+           not operate on top of any other interface (i.e., there are
+           no 'lower-layer-if' entries), and 'disabled' otherwise.";
+        reference
+          "RFC 2863: The Interfaces Group MIB -
+                     ifLinkUpDownTrapEnable";
+      }
+      leaf admin-status {
+        if-feature "if-mib";
+        type enumeration {
+          enum "up" {
+            value 1;
+            description
+              "Ready to pass packets.";
+          }
+          enum "down" {
+            value 2;
+            description
+              "Not ready to pass packets and not in some test mode.";
+          }
+          enum "testing" {
+            value 3;
+            description
+              "In some test mode.";
+          }
+        }
+        config false;
+        mandatory true;
+        description
+          "The desired state of the interface.
+
+           This leaf has the same read semantics as ifAdminStatus.";
+        reference
+          "RFC 2863: The Interfaces Group MIB - ifAdminStatus";
+      }
+      leaf oper-status {
+        type enumeration {
+          enum "up" {
+            value 1;
+            description
+              "Ready to pass packets.";
+          }
+          enum "down" {
+            value 2;
+            description
+              "The interface does not pass any packets.";
+          }
+          enum "testing" {
+            value 3;
+            description
+              "In some test mode.  No operational packets can
+               be passed.";
+          }
+          enum "unknown" {
+            value 4;
+            description
+              "Status cannot be determined for some reason.";
+          }
+          enum "dormant" {
+            value 5;
+            description
+              "Waiting for some external event.";
+          }
+          enum "not-present" {
+            value 6;
+            description
+              "Some component (typically hardware) is missing.";
+          }
+          enum "lower-layer-down" {
+            value 7;
+            description
+              "Down due to state of lower-layer interface(s).";
+          }
+        }
+        config false;
+        mandatory true;
+        description
+          "The current operational state of the interface.
+
+           This leaf has the same semantics as ifOperStatus.";
+        reference
+          "RFC 2863: The Interfaces Group MIB - ifOperStatus";
+      }
+      leaf last-change {
+        type yang:date-and-time;
+        config false;
+        description
+          "The time the interface entered its current operational
+           state.  If the current state was entered prior to the
+           last re-initialization of the local network management
+           subsystem, then this node is not present.";
+        reference
+          "RFC 2863: The Interfaces Group MIB - ifLastChange";
+      }
+      leaf if-index {
+        if-feature "if-mib";
+        type int32 {
+          range "1..2147483647";
+        }
+        config false;
+        mandatory true;
+        description
+          "The ifIndex value for the ifEntry represented by this
+           interface.";
+        reference
+          "RFC 2863: The Interfaces Group MIB - ifIndex";
+      }
+      leaf phys-address {
+        type yang:phys-address;
+        config false;
+        description
+          "The interface's address at its protocol sub-layer.  For
+           example, for an 802.x interface, this object normally
+           contains a Media Access Control (MAC) address.  The
+           interface's media-specific modules must define the bit
+           and byte ordering and the format of the value of this
+           object.  For interfaces that do not have such an address
+           (e.g., a serial line), this node is not present.";
+        reference
+          "RFC 2863: The Interfaces Group MIB - ifPhysAddress";
+      }
+      leaf-list higher-layer-if {
+        type interface-ref;
+        config false;
+        description
+          "A list of references to interfaces layered on top of this
+           interface.";
+        reference
+          "RFC 2863: The Interfaces Group MIB - ifStackTable";
+      }
+      leaf-list lower-layer-if {
+        type interface-ref;
+        config false;
+        description
+          "A list of references to interfaces layered underneath this
+           interface.";
+        reference
+          "RFC 2863: The Interfaces Group MIB - ifStackTable";
+      }
+      leaf speed {
+        type yang:gauge64;
+        units "bits/second";
+        config false;
+        description
+          "An estimate of the interface's current bandwidth in bits
+           per second.  For interfaces that do not vary in
+           bandwidth or for those where no accurate estimation can
+           be made, this node should contain the nominal bandwidth.
+           For interfaces that have no concept of bandwidth, this
+           node is not present.";
+        reference
+          "RFC 2863: The Interfaces Group MIB -
+                     ifSpeed, ifHighSpeed";
+      }
+      container statistics {
+        config false;
+        description
+          "A collection of interface-related statistics objects.";
+        leaf discontinuity-time {
+          type yang:date-and-time;
+          mandatory true;
+          description
+            "The time on the most recent occasion at which any one or
+             more of this interface's counters suffered a
+             discontinuity.  If no such discontinuities have occurred
+             since the last re-initialization of the local management
+             subsystem, then this node contains the time the local
+             management subsystem re-initialized itself.";
+        }
+        leaf in-octets {
+          type yang:counter64;
+          description
+            "The total number of octets received on the interface,
+             including framing characters.
+
+             Discontinuities in the value of this counter can occur
+             at re-initialization of the management system and at
+             other times as indicated by the value of
+             'discontinuity-time'.";
+          reference
+            "RFC 2863: The Interfaces Group MIB - ifHCInOctets";
+        }
+        leaf in-unicast-pkts {
+          type yang:counter64;
+          description
+            "The number of packets, delivered by this sub-layer to a
+             higher (sub-)layer, that were not addressed to a
+             multicast or broadcast address at this sub-layer.
+
+             Discontinuities in the value of this counter can occur
+             at re-initialization of the management system and at
+             other times as indicated by the value of
+             'discontinuity-time'.";
+          reference
+            "RFC 2863: The Interfaces Group MIB - ifHCInUcastPkts";
+        }
+        leaf in-broadcast-pkts {
+          type yang:counter64;
+          description
+            "The number of packets, delivered by this sub-layer to a
+             higher (sub-)layer, that were addressed to a broadcast
+             address at this sub-layer.
+
+             Discontinuities in the value of this counter can occur
+             at re-initialization of the management system and at
+             other times as indicated by the value of
+             'discontinuity-time'.";
+          reference
+            "RFC 2863: The Interfaces Group MIB -
+                       ifHCInBroadcastPkts";
+        }
+        leaf in-multicast-pkts {
+          type yang:counter64;
+          description
+            "The number of packets, delivered by this sub-layer to a
+             higher (sub-)layer, that were addressed to a multicast
+             address at this sub-layer.  For a MAC-layer protocol,
+             this includes both Group and Functional addresses.
+
+             Discontinuities in the value of this counter can occur
+             at re-initialization of the management system and at
+             other times as indicated by the value of
+             'discontinuity-time'.";
+          reference
+            "RFC 2863: The Interfaces Group MIB -
+                       ifHCInMulticastPkts";
+        }
+        leaf in-discards {
+          type yang:counter32;
+          description
+            "The number of inbound packets that were chosen to be
+             discarded even though no errors had been detected to
+             prevent their being deliverable to a higher-layer
+             protocol.  One possible reason for discarding such a
+             packet could be to free up buffer space.
+
+             Discontinuities in the value of this counter can occur
+             at re-initialization of the management system and at
+             other times as indicated by the value of
+             'discontinuity-time'.";
+          reference
+            "RFC 2863: The Interfaces Group MIB - ifInDiscards";
+        }
+        leaf in-errors {
+          type yang:counter32;
+          description
+            "For packet-oriented interfaces, the number of inbound
+             packets that contained errors preventing them from being
+             deliverable to a higher-layer protocol.  For character-
+             oriented or fixed-length interfaces, the number of
+             inbound transmission units that contained errors
+             preventing them from being deliverable to a higher-layer
+             protocol.
+
+             Discontinuities in the value of this counter can occur
+             at re-initialization of the management system and at
+             other times as indicated by the value of
+             'discontinuity-time'.";
+          reference
+            "RFC 2863: The Interfaces Group MIB - ifInErrors";
+        }
+        leaf in-unknown-protos {
+          type yang:counter32;
+          description
+            "For packet-oriented interfaces, the number of packets
+             received via the interface that were discarded because
+             of an unknown or unsupported protocol.  For
+             character-oriented or fixed-length interfaces that
+             support protocol multiplexing, the number of
+             transmission units received via the interface that were
+             discarded because of an unknown or unsupported protocol.
+             For any interface that does not support protocol
+             multiplexing, this counter is not present.
+
+             Discontinuities in the value of this counter can occur
+             at re-initialization of the management system and at
+             other times as indicated by the value of
+             'discontinuity-time'.";
+          reference
+            "RFC 2863: The Interfaces Group MIB - ifInUnknownProtos";
+        }
+        leaf out-octets {
+          type yang:counter64;
+          description
+            "The total number of octets transmitted out of the
+             interface, including framing characters.
+
+             Discontinuities in the value of this counter can occur
+             at re-initialization of the management system and at
+             other times as indicated by the value of
+             'discontinuity-time'.";
+          reference
+            "RFC 2863: The Interfaces Group MIB - ifHCOutOctets";
+        }
+        leaf out-unicast-pkts {
+          type yang:counter64;
+          description
+            "The total number of packets that higher-level protocols
+             requested be transmitted and that were not addressed
+             to a multicast or broadcast address at this sub-layer,
+             including those that were discarded or not sent.
+
+             Discontinuities in the value of this counter can occur
+             at re-initialization of the management system and at
+             other times as indicated by the value of
+             'discontinuity-time'.";
+          reference
+            "RFC 2863: The Interfaces Group MIB - ifHCOutUcastPkts";
+        }
+        leaf out-broadcast-pkts {
+          type yang:counter64;
+          description
+            "The total number of packets that higher-level protocols
+             requested be transmitted and that were addressed to a
+             broadcast address at this sub-layer, including those
+             that were discarded or not sent.
+
+             Discontinuities in the value of this counter can occur
+             at re-initialization of the management system and at
+             other times as indicated by the value of
+             'discontinuity-time'.";
+          reference
+            "RFC 2863: The Interfaces Group MIB -
+                       ifHCOutBroadcastPkts";
+        }
+        leaf out-multicast-pkts {
+          type yang:counter64;
+          description
+            "The total number of packets that higher-level protocols
+             requested be transmitted and that were addressed to a
+             multicast address at this sub-layer, including those
+             that were discarded or not sent.  For a MAC-layer
+             protocol, this includes both Group and Functional
+             addresses.
+
+             Discontinuities in the value of this counter can occur
+             at re-initialization of the management system and at
+             other times as indicated by the value of
+             'discontinuity-time'.";
+          reference
+            "RFC 2863: The Interfaces Group MIB -
+                       ifHCOutMulticastPkts";
+        }
+        leaf out-discards {
+          type yang:counter32;
+          description
+            "The number of outbound packets that were chosen to be
+             discarded even though no errors had been detected to
+             prevent their being transmitted.  One possible reason
+             for discarding such a packet could be to free up buffer
+             space.
+
+             Discontinuities in the value of this counter can occur
+             at re-initialization of the management system and at
+             other times as indicated by the value of
+             'discontinuity-time'.";
+          reference
+            "RFC 2863: The Interfaces Group MIB - ifOutDiscards";
+        }
+        leaf out-errors {
+          type yang:counter32;
+          description
+            "For packet-oriented interfaces, the number of outbound
+             packets that could not be transmitted because of errors.
+             For character-oriented or fixed-length interfaces, the
+             number of outbound transmission units that could not be
+             transmitted because of errors.
+
+             Discontinuities in the value of this counter can occur
+             at re-initialization of the management system and at
+             other times as indicated by the value of
+             'discontinuity-time'.";
+          reference
+            "RFC 2863: The Interfaces Group MIB - ifOutErrors";
+        }
+      }
+    }
+  }
+  container interfaces-state {
+    config false;
+    status deprecated;
+    description
+      "Data nodes for the operational state of interfaces.";
+    list interface {
+      key "name";
+      status deprecated;
+      description
+        "The list of interfaces on the device.
+
+         System-controlled interfaces created by the system are
+         always present in this list, whether or not they are
+         configured.";
+      leaf name {
+        type string;
+        status deprecated;
+        description
+          "The name of the interface.
+
+           A server implementation MAY map this leaf to the ifName
+           MIB object.  Such an implementation needs to use some
+           mechanism to handle the differences in size and characters
+           allowed between this leaf and ifName.  The definition of
+           such a mechanism is outside the scope of this document.";
+        reference
+          "RFC 2863: The Interfaces Group MIB - ifName";
+      }
+      leaf type {
+        type identityref {
+          base interface-type;
+        }
+        mandatory true;
+        status deprecated;
+        description
+          "The type of the interface.";
+        reference
+          "RFC 2863: The Interfaces Group MIB - ifType";
+      }
+      leaf admin-status {
+        if-feature "if-mib";
+        type enumeration {
+          enum "up" {
+            value 1;
+            description
+              "Ready to pass packets.";
+          }
+          enum "down" {
+            value 2;
+            description
+              "Not ready to pass packets and not in some test mode.";
+          }
+          enum "testing" {
+            value 3;
+            description
+              "In some test mode.";
+          }
+        }
+        mandatory true;
+        status deprecated;
+        description
+          "The desired state of the interface.
+
+           This leaf has the same read semantics as ifAdminStatus.";
+        reference
+          "RFC 2863: The Interfaces Group MIB - ifAdminStatus";
+      }
+      leaf oper-status {
+        type enumeration {
+          enum "up" {
+            value 1;
+            description
+              "Ready to pass packets.";
+          }
+          enum "down" {
+            value 2;
+            description
+              "The interface does not pass any packets.";
+          }
+          enum "testing" {
+            value 3;
+            description
+              "In some test mode.  No operational packets can
+               be passed.";
+          }
+          enum "unknown" {
+            value 4;
+            description
+              "Status cannot be determined for some reason.";
+          }
+          enum "dormant" {
+            value 5;
+            description
+              "Waiting for some external event.";
+          }
+          enum "not-present" {
+            value 6;
+            description
+              "Some component (typically hardware) is missing.";
+          }
+          enum "lower-layer-down" {
+            value 7;
+            description
+              "Down due to state of lower-layer interface(s).";
+          }
+        }
+        mandatory true;
+        status deprecated;
+        description
+          "The current operational state of the interface.
+
+           This leaf has the same semantics as ifOperStatus.";
+        reference
+          "RFC 2863: The Interfaces Group MIB - ifOperStatus";
+      }
+      leaf last-change {
+        type yang:date-and-time;
+        status deprecated;
+        description
+          "The time the interface entered its current operational
+           state.  If the current state was entered prior to the
+           last re-initialization of the local network management
+           subsystem, then this node is not present.";
+        reference
+          "RFC 2863: The Interfaces Group MIB - ifLastChange";
+      }
+      leaf if-index {
+        if-feature "if-mib";
+        type int32 {
+          range "1..2147483647";
+        }
+        mandatory true;
+        status deprecated;
+        description
+          "The ifIndex value for the ifEntry represented by this
+           interface.";
+        reference
+          "RFC 2863: The Interfaces Group MIB - ifIndex";
+      }
+      leaf phys-address {
+        type yang:phys-address;
+        status deprecated;
+        description
+          "The interface's address at its protocol sub-layer.  For
+           example, for an 802.x interface, this object normally
+           contains a Media Access Control (MAC) address.  The
+           interface's media-specific modules must define the bit
+           and byte ordering and the format of the value of this
+           object.  For interfaces that do not have such an address
+           (e.g., a serial line), this node is not present.";
+        reference
+          "RFC 2863: The Interfaces Group MIB - ifPhysAddress";
+      }
+      leaf-list higher-layer-if {
+        type interface-state-ref;
+        status deprecated;
+        description
+          "A list of references to interfaces layered on top of this
+           interface.";
+        reference
+          "RFC 2863: The Interfaces Group MIB - ifStackTable";
+      }
+      leaf-list lower-layer-if {
+        type interface-state-ref;
+        status deprecated;
+        description
+          "A list of references to interfaces layered underneath this
+           interface.";
+        reference
+          "RFC 2863: The Interfaces Group MIB - ifStackTable";
+      }
+      leaf speed {
+        type yang:gauge64;
+        units "bits/second";
+        status deprecated;
+        description
+          "An estimate of the interface's current bandwidth in bits
+           per second.  For interfaces that do not vary in
+           bandwidth or for those where no accurate estimation can
+
+           be made, this node should contain the nominal bandwidth.
+           For interfaces that have no concept of bandwidth, this
+           node is not present.";
+        reference
+          "RFC 2863: The Interfaces Group MIB -
+                     ifSpeed, ifHighSpeed";
+      }
+      container statistics {
+        status deprecated;
+        description
+          "A collection of interface-related statistics objects.";
+        leaf discontinuity-time {
+          type yang:date-and-time;
+          mandatory true;
+          status deprecated;
+          description
+            "The time on the most recent occasion at which any one or
+             more of this interface's counters suffered a
+             discontinuity.  If no such discontinuities have occurred
+             since the last re-initialization of the local management
+             subsystem, then this node contains the time the local
+             management subsystem re-initialized itself.";
+        }
+        leaf in-octets {
+          type yang:counter64;
+          status deprecated;
+          description
+            "The total number of octets received on the interface,
+             including framing characters.
+
+             Discontinuities in the value of this counter can occur
+             at re-initialization of the management system and at
+             other times as indicated by the value of
+             'discontinuity-time'.";
+          reference
+            "RFC 2863: The Interfaces Group MIB - ifHCInOctets";
+        }
+        leaf in-unicast-pkts {
+          type yang:counter64;
+          status deprecated;
+          description
+            "The number of packets, delivered by this sub-layer to a
+             higher (sub-)layer, that were not addressed to a
+             multicast or broadcast address at this sub-layer.
+             Discontinuities in the value of this counter can occur
+             at re-initialization of the management system and at
+             other times as indicated by the value of
+             'discontinuity-time'.";
+          reference
+            "RFC 2863: The Interfaces Group MIB - ifHCInUcastPkts";
+        }
+        leaf in-broadcast-pkts {
+          type yang:counter64;
+          status deprecated;
+          description
+            "The number of packets, delivered by this sub-layer to a
+             higher (sub-)layer, that were addressed to a broadcast
+             address at this sub-layer.
+
+             Discontinuities in the value of this counter can occur
+             at re-initialization of the management system and at
+             other times as indicated by the value of
+             'discontinuity-time'.";
+          reference
+            "RFC 2863: The Interfaces Group MIB -
+                       ifHCInBroadcastPkts";
+        }
+        leaf in-multicast-pkts {
+          type yang:counter64;
+          status deprecated;
+          description
+            "The number of packets, delivered by this sub-layer to a
+             higher (sub-)layer, that were addressed to a multicast
+             address at this sub-layer.  For a MAC-layer protocol,
+             this includes both Group and Functional addresses.
+
+             Discontinuities in the value of this counter can occur
+             at re-initialization of the management system and at
+             other times as indicated by the value of
+             'discontinuity-time'.";
+          reference
+            "RFC 2863: The Interfaces Group MIB -
+                       ifHCInMulticastPkts";
+        }
+        leaf in-discards {
+          type yang:counter32;
+          status deprecated;
+          description
+            "The number of inbound packets that were chosen to be
+             discarded even though no errors had been detected to
+             prevent their being deliverable to a higher-layer
+             protocol.  One possible reason for discarding such a
+             packet could be to free up buffer space.
+
+             Discontinuities in the value of this counter can occur
+             at re-initialization of the management system and at
+             other times as indicated by the value of
+             'discontinuity-time'.";
+          reference
+            "RFC 2863: The Interfaces Group MIB - ifInDiscards";
+        }
+        leaf in-errors {
+          type yang:counter32;
+          status deprecated;
+          description
+            "For packet-oriented interfaces, the number of inbound
+             packets that contained errors preventing them from being
+             deliverable to a higher-layer protocol.  For character-
+             oriented or fixed-length interfaces, the number of
+             inbound transmission units that contained errors
+             preventing them from being deliverable to a higher-layer
+             protocol.
+
+             Discontinuities in the value of this counter can occur
+             at re-initialization of the management system and at
+             other times as indicated by the value of
+             'discontinuity-time'.";
+          reference
+            "RFC 2863: The Interfaces Group MIB - ifInErrors";
+        }
+        leaf in-unknown-protos {
+          type yang:counter32;
+          status deprecated;
+          description
+            "For packet-oriented interfaces, the number of packets
+             received via the interface that were discarded because
+             of an unknown or unsupported protocol.  For
+             character-oriented or fixed-length interfaces that
+             support protocol multiplexing, the number of
+             transmission units received via the interface that were
+             discarded because of an unknown or unsupported protocol.
+             For any interface that does not support protocol
+             multiplexing, this counter is not present.
+             Discontinuities in the value of this counter can occur
+             at re-initialization of the management system and at
+             other times as indicated by the value of
+             'discontinuity-time'.";
+          reference
+            "RFC 2863: The Interfaces Group MIB - ifInUnknownProtos";
+        }
+        leaf out-octets {
+          type yang:counter64;
+          status deprecated;
+          description
+            "The total number of octets transmitted out of the
+             interface, including framing characters.
+
+             Discontinuities in the value of this counter can occur
+             at re-initialization of the management system and at
+             other times as indicated by the value of
+             'discontinuity-time'.";
+          reference
+            "RFC 2863: The Interfaces Group MIB - ifHCOutOctets";
+        }
+        leaf out-unicast-pkts {
+          type yang:counter64;
+          status deprecated;
+          description
+            "The total number of packets that higher-level protocols
+             requested be transmitted and that were not addressed
+             to a multicast or broadcast address at this sub-layer,
+             including those that were discarded or not sent.
+
+             Discontinuities in the value of this counter can occur
+             at re-initialization of the management system and at
+             other times as indicated by the value of
+             'discontinuity-time'.";
+          reference
+            "RFC 2863: The Interfaces Group MIB - ifHCOutUcastPkts";
+        }
+        leaf out-broadcast-pkts {
+          type yang:counter64;
+          status deprecated;
+          description
+            "The total number of packets that higher-level protocols
+             requested be transmitted and that were addressed to a
+             broadcast address at this sub-layer, including those
+             that were discarded or not sent.
+
+             Discontinuities in the value of this counter can occur
+             at re-initialization of the management system and at
+             other times as indicated by the value of
+             'discontinuity-time'.";
+          reference
+            "RFC 2863: The Interfaces Group MIB -
+                       ifHCOutBroadcastPkts";
+        }
+        leaf out-multicast-pkts {
+          type yang:counter64;
+          status deprecated;
+          description
+            "The total number of packets that higher-level protocols
+             requested be transmitted and that were addressed to a
+             multicast address at this sub-layer, including those
+             that were discarded or not sent.  For a MAC-layer
+             protocol, this includes both Group and Functional
+             addresses.
+
+             Discontinuities in the value of this counter can occur
+             at re-initialization of the management system and at
+             other times as indicated by the value of
+             'discontinuity-time'.";
+          reference
+            "RFC 2863: The Interfaces Group MIB -
+                       ifHCOutMulticastPkts";
+        }
+        leaf out-discards {
+          type yang:counter32;
+          status deprecated;
+          description
+            "The number of outbound packets that were chosen to be
+             discarded even though no errors had been detected to
+             prevent their being transmitted.  One possible reason
+             for discarding such a packet could be to free up buffer
+             space.
+
+             Discontinuities in the value of this counter can occur
+             at re-initialization of the management system and at
+             other times as indicated by the value of
+             'discontinuity-time'.";
+          reference
+            "RFC 2863: The Interfaces Group MIB - ifOutDiscards";
+        }
+        leaf out-errors {
+          type yang:counter32;
+          status deprecated;
+          description
+            "For packet-oriented interfaces, the number of outbound
+             packets that could not be transmitted because of errors.
+             For character-oriented or fixed-length interfaces, the
+             number of outbound transmission units that could not be
+             transmitted because of errors.
+
+             Discontinuities in the value of this counter can occur
+             at re-initialization of the management system and at
+             other times as indicated by the value of
+             'discontinuity-time'.";
+          reference
+            "RFC 2863: The Interfaces Group MIB - ifOutErrors";
+        }
+      }
+    }
+  }
+}
+"""
+
+ietf_netconf_acm = r"""module ietf-netconf-acm {
+  namespace "urn:ietf:params:xml:ns:yang:ietf-netconf-acm";
+  prefix nacm;
+
+  import ietf-yang-types {
+    prefix yang;
+  }
+
+  organization
+    "IETF NETCONF (Network Configuration) Working Group";
+  contact
+    "WG Web:   <https://datatracker.ietf.org/wg/netconf/>
+     WG List:  <mailto:netconf@ietf.org>
+
+     Author:   Andy Bierman
+               <mailto:andy@yumaworks.com>
+
+     Author:   Martin Bjorklund
+               <mailto:mbj@tail-f.com>";
+  description
+    "Network Configuration Access Control Model.
+
+     Copyright (c) 2012 - 2018 IETF Trust and the persons
+     identified as authors of the code.  All rights reserved.
+
+     Redistribution and use in source and binary forms, with or
+     without modification, is permitted pursuant to, and subject
+     to the license terms contained in, the Simplified BSD
+     License set forth in Section 4.c of the IETF Trust's
+     Legal Provisions Relating to IETF Documents
+     (https://trustee.ietf.org/license-info).
+
+     This version of this YANG module is part of RFC 8341; see
+     the RFC itself for full legal notices.";
+
+  revision 2018-02-14 {
+    description
+      "Added support for YANG 1.1 actions and notifications tied to
+       data nodes.  Clarified how NACM extensions can be used by
+       other data models.";
+    reference
+      "RFC 8341: Network Configuration Access Control Model";
+  }
+  revision 2012-02-22 {
+    description
+      "Initial version.";
+    reference
+      "RFC 6536: Network Configuration Protocol (NETCONF)
+                 Access Control Model";
+  }
+
+  extension default-deny-write {
+    description
+      "Used to indicate that the data model node
+       represents a sensitive security system parameter.
+
+       If present, the NETCONF server will only allow the designated
+       'recovery session' to have write access to the node.  An
+       explicit access control rule is required for all other users.
+
+       If the NACM module is used, then it must be enabled (i.e.,
+       /nacm/enable-nacm object equals 'true'), or this extension
+       is ignored.
+
+       The 'default-deny-write' extension MAY appear within a data
+       definition statement.  It is ignored otherwise.";
+  }
+  extension default-deny-all {
+    description
+      "Used to indicate that the data model node
+       controls a very sensitive security system parameter.
+
+       If present, the NETCONF server will only allow the designated
+       'recovery session' to have read, write, or execute access to
+       the node.  An explicit access control rule is required for all
+       other users.
+
+       If the NACM module is used, then it must be enabled (i.e.,
+       /nacm/enable-nacm object equals 'true'), or this extension
+       is ignored.
+
+       The 'default-deny-all' extension MAY appear within a data
+       definition statement, 'rpc' statement, or 'notification'
+       statement.  It is ignored otherwise.";
+  }
+
+  typedef user-name-type {
+    type string {
+      length "1..max";
+    }
+    description
+      "General-purpose username string.";
+  }
+
+  typedef matchall-string-type {
+    type string {
+      pattern '\*';
+    }
+    description
+      "The string containing a single asterisk '*' is used
+       to conceptually represent all possible values
+       for the particular leaf using this data type.";
+  }
+
+  typedef access-operations-type {
+    type bits {
+      bit create {
+        description
+          "Any protocol operation that creates a
+           new data node.";
+      }
+      bit read {
+        description
+          "Any protocol operation or notification that
+           returns the value of a data node.";
+      }
+      bit update {
+        description
+          "Any protocol operation that alters an existing
+           data node.";
+      }
+      bit delete {
+        description
+          "Any protocol operation that removes a data node.";
+      }
+      bit exec {
+        description
+          "Execution access to the specified protocol operation.";
+      }
+    }
+    description
+      "Access operation.";
+  }
+
+  typedef group-name-type {
+    type string {
+      length "1..max";
+      pattern '[^\*].*';
+    }
+    description
+      "Name of administrative group to which
+       users can be assigned.";
+  }
+
+  typedef action-type {
+    type enumeration {
+      enum "permit" {
+        description
+          "Requested action is permitted.";
+      }
+      enum "deny" {
+        description
+          "Requested action is denied.";
+      }
+    }
+    description
+      "Action taken by the server when a particular
+       rule matches.";
+  }
+
+  typedef node-instance-identifier {
+    type yang:xpath1.0;
+    description
+      "Path expression used to represent a special
+       data node, action, or notification instance-identifier
+       string.
+
+       A node-instance-identifier value is an
+       unrestricted YANG instance-identifier expression.
+       All the same rules as an instance-identifier apply,
+       except that predicates for keys are optional.  If a key
+       predicate is missing, then the node-instance-identifier
+       represents all possible server instances for that key.
+
+       This XML Path Language (XPath) expression is evaluated in the
+       following context:
+
+          o  The set of namespace declarations are those in scope on
+             the leaf element where this type is used.
+
+          o  The set of variable bindings contains one variable,
+             'USER', which contains the name of the user of the
+             current session.
+
+          o  The function library is the core function library, but
+             note that due to the syntax restrictions of an
+             instance-identifier, no functions are allowed.
+
+          o  The context node is the root node in the data tree.
+
+       The accessible tree includes actions and notifications tied
+       to data nodes.";
+  }
+
+  container nacm {
+    nacm:default-deny-all;
+    description
+      "Parameters for NETCONF access control model.";
+    leaf enable-nacm {
+      type boolean;
+      default "true";
+      description
+        "Enables or disables all NETCONF access control
+         enforcement.  If 'true', then enforcement
+         is enabled.  If 'false', then enforcement
+         is disabled.";
+    }
+    leaf read-default {
+      type action-type;
+      default "permit";
+      description
+        "Controls whether read access is granted if
+         no appropriate rule is found for a
+         particular read request.";
+    }
+    leaf write-default {
+      type action-type;
+      default "deny";
+      description
+        "Controls whether create, update, or delete access
+         is granted if no appropriate rule is found for a
+         particular write request.";
+    }
+    leaf exec-default {
+      type action-type;
+      default "permit";
+      description
+        "Controls whether exec access is granted if no appropriate
+         rule is found for a particular protocol operation request.";
+    }
+    leaf enable-external-groups {
+      type boolean;
+      default "true";
+      description
+        "Controls whether the server uses the groups reported by the
+         NETCONF transport layer when it assigns the user to a set of
+         NACM groups.  If this leaf has the value 'false', any group
+         names reported by the transport layer are ignored by the
+         server.";
+    }
+    leaf denied-operations {
+      type yang:zero-based-counter32;
+      config false;
+      mandatory true;
+      description
+        "Number of times since the server last restarted that a
+         protocol operation request was denied.";
+    }
+    leaf denied-data-writes {
+      type yang:zero-based-counter32;
+      config false;
+      mandatory true;
+      description
+        "Number of times since the server last restarted that a
+         protocol operation request to alter
+         a configuration datastore was denied.";
+    }
+    leaf denied-notifications {
+      type yang:zero-based-counter32;
+      config false;
+      mandatory true;
+      description
+        "Number of times since the server last restarted that
+         a notification was dropped for a subscription because
+         access to the event type was denied.";
+    }
+    container groups {
+      description
+        "NETCONF access control groups.";
+      list group {
+        key "name";
+        description
+          "One NACM group entry.  This list will only contain
+           configured entries, not any entries learned from
+           any transport protocols.";
+        leaf name {
+          type group-name-type;
+          description
+            "Group name associated with this entry.";
+        }
+        leaf-list user-name {
+          type user-name-type;
+          description
+            "Each entry identifies the username of
+             a member of the group associated with
+             this entry.";
+        }
+      }
+    }
+    list rule-list {
+      key "name";
+      ordered-by user;
+      description
+        "An ordered collection of access control rules.";
+      leaf name {
+        type string {
+          length "1..max";
+        }
+        description
+          "Arbitrary name assigned to the rule-list.";
+      }
+      leaf-list group {
+        type union {
+          type matchall-string-type;
+          type group-name-type;
+        }
+        description
+          "List of administrative groups that will be
+           assigned the associated access rights
+           defined by the 'rule' list.
+
+           The string '*' indicates that all groups apply to the
+           entry.";
+      }
+      list rule {
+        key "name";
+        ordered-by user;
+        description
+          "One access control rule.
+
+           Rules are processed in user-defined order until a match is
+           found.  A rule matches if 'module-name', 'rule-type', and
+           'access-operations' match the request.  If a rule
+           matches, the 'action' leaf determines whether or not
+           access is granted.";
+        leaf name {
+          type string {
+            length "1..max";
+          }
+          description
+            "Arbitrary name assigned to the rule.";
+        }
+        leaf module-name {
+          type union {
+            type matchall-string-type;
+            type string;
+          }
+          default "*";
+          description
+            "Name of the module associated with this rule.
+
+             This leaf matches if it has the value '*' or if the
+             object being accessed is defined in the module with the
+             specified module name.";
+        }
+        choice rule-type {
+          description
+            "This choice matches if all leafs present in the rule
+             match the request.  If no leafs are present, the
+             choice matches all requests.";
+          case protocol-operation {
+            leaf rpc-name {
+              type union {
+                type matchall-string-type;
+                type string;
+              }
+              description
+                "This leaf matches if it has the value '*' or if
+                 its value equals the requested protocol operation
+                 name.";
+            }
+          }
+          case notification {
+            leaf notification-name {
+              type union {
+                type matchall-string-type;
+                type string;
+              }
+              description
+                "This leaf matches if it has the value '*' or if its
+                 value equals the requested notification name.";
+            }
+          }
+          case data-node {
+            leaf path {
+              type node-instance-identifier;
+              mandatory true;
+              description
+                "Data node instance-identifier associated with the
+                 data node, action, or notification controlled by
+                 this rule.
+
+                 Configuration data or state data
+                 instance-identifiers start with a top-level
+                 data node.  A complete instance-identifier is
+                 required for this type of path value.
+
+                 The special value '/' refers to all possible
+                 datastore contents.";
+            }
+          }
+        }
+        leaf access-operations {
+          type union {
+            type matchall-string-type;
+            type access-operations-type;
+          }
+          default "*";
+          description
+            "Access operations associated with this rule.
+
+             This leaf matches if it has the value '*' or if the
+             bit corresponding to the requested operation is set.";
+        }
+        leaf action {
+          type action-type;
+          mandatory true;
+          description
+            "The access control action associated with the
+             rule.  If a rule has been determined to match a
+             particular request, then this object is used
+             to determine whether to permit or deny the
+             request.";
+        }
+        leaf comment {
+          type string;
+          description
+            "A textual description of the access rule.";
+        }
+      }
+    }
+  }
+}
+"""
+
+ietf_network_instance = r"""module ietf-network-instance {
+  yang-version 1.1;
+  namespace "urn:ietf:params:xml:ns:yang:ietf-network-instance";
+  prefix ni;
+
+  import ietf-interfaces {
+    prefix if;
+    reference
+      "RFC 8343: A YANG Data Model for Interface Management";
+  }
+  import ietf-ip {
+    prefix ip;
+    reference
+      "RFC 8344: A YANG Data Model for IP Management";
+  }
+  import ietf-yang-schema-mount {
+    prefix yangmnt;
+    reference
+      "RFC 8528: YANG Schema Mount";
+  }
+
+  organization
+    "IETF Routing Area (rtgwg) Working Group";
+  contact
+    "WG Web:   <https://datatracker.ietf.org/wg/rtgwg>
+     WG List:  <mailto:rtgwg@ietf.org>
+
+     Author:   Lou Berger
+               <mailto:lberger@labn.net>
+     Author:   Christian Hopps
+               <mailto:chopps@chopps.org>
+     Author:   Acee Lindem
+               <mailto:acee@cisco.com>
+     Author:   Dean Bogdanovic
+               <mailto:ivandean@gmail.com>";
+  description
+    "This module is used to support multiple network instances
+     within a single physical or virtual device.  Network
+     instances are commonly known as VRFs (VPN Routing and
+     Forwarding) and VSIs (Virtual Switching Instances).
+     The key words 'MUST', 'MUST NOT', 'REQUIRED', 'SHALL',
+     'SHALL NOT', 'SHOULD', 'SHOULD NOT', 'RECOMMENDED',
+     'NOT RECOMMENDED', 'MAY', and 'OPTIONAL' in this document
+     are to be interpreted as described in BCP 14 (RFC 2119)
+     (RFC 8174) when, and only when, they appear in all capitals,
+      as shown here.
+
+     Copyright (c) 2019 IETF Trust and the persons identified as
+     authors of the code.  All rights reserved.
+
+     Redistribution and use in source and binary forms, with or
+     without modification, is permitted pursuant to, and subject
+     to the license terms contained in, the Simplified BSD
+     License set forth in Section 4.c of the IETF Trust's Legal
+     Provisions Relating to IETF Documents
+     (https://trustee.ietf.org/license-info).
+
+     This version of this YANG module is part of RFC 8529; see
+     the RFC itself for full legal notices.";
+
+  revision 2019-01-21 {
+    description
+      "Initial revision.";
+    reference
+      "RFC 8529";
+  }
+
+  container network-instances {
+    description
+      "Network instances, each of which consists of
+       VRFs and/or VSIs.";
+    reference
+      "RFC 8349: A YANG Data Model for Routing Management";
+    list network-instance {
+      key "name";
+      description
+        "List of network instances.";
+      leaf name {
+        type string;
+        mandatory true;
+        description
+          "device-scoped identifier for the network
+           instance.";
+      }
+      leaf enabled {
+        type boolean;
+        default "true";
+        description
+          "Flag indicating whether or not the network
+           instance is enabled.";
+      }
+      leaf description {
+        type string;
+        description
+          "Description of the network instance
+           and its intended purpose.";
+      }
+      choice ni-type {
+        description
+          "This node serves as an anchor point for different types
+           of network instances.  Each 'case' is expected to
+           differ in terms of the information needed in the
+           parent/core to support the NI and may differ in their
+           mounted-schema definition.  When the mounted schema is
+           not expected to be the same for a specific type of NI,
+           a mount point should be defined.";
+      }
+      choice root-type {
+        mandatory true;
+        description
+          "Well-known mount points.";
+        container vrf-root {
+          yangmnt:mount-point "vrf-root" {
+            description
+              "Root for L3VPN-type models.  This will typically
+               not be an inline-type mount point.";
+          }
+          description
+            "Container for mount point.";
+        }
+        container vsi-root {
+          yangmnt:mount-point "vsi-root" {
+            description
+              "Root for L2VPN-type models.  This will typically
+               not be an inline-type mount point.";
+          }
+          description
+            "Container for mount point.";
+        }
+        container vv-root {
+          yangmnt:mount-point "vv-root" {
+            description
+              "Root models that support both L2VPN-type bridging
+               and L3VPN-type routing.  This will typically
+               not be an inline-type mount point.";
+          }
+          description
+            "Container for mount point.";
+        }
+      }
+    }
+  }
+
+  augment "/if:interfaces/if:interface" {
+    description
+      "Add a node for the identification of the network
+       instance associated with the information configured
+       on a interface.
+
+       Note that a standard error will be returned if the
+       identified leafref isn't present.  If an interface cannot
+       be assigned for any other reason, the operation SHALL fail
+       with an error-tag of 'operation-failed' and an
+       error-app-tag of 'ni-assignment-failed'.  A meaningful
+       error-info that indicates the source of the assignment
+       failure SHOULD also be provided.";
+    leaf bind-ni-name {
+      type leafref {
+        path "/network-instances/network-instance/name";
+      }
+      description
+        "Network instance to which an interface is bound.";
+    }
+  }
+  augment "/if:interfaces/if:interface/ip:ipv4" {
+    description
+      "Add a node for the identification of the network
+       instance associated with the information configured
+       on an IPv4 interface.
+
+       Note that a standard error will be returned if the
+       identified leafref isn't present.  If an interface cannot
+       be assigned for any other reason, the operation SHALL fail
+       with an error-tag of 'operation-failed' and an
+       error-app-tag of 'ni-assignment-failed'.  A meaningful
+       error-info that indicates the source of the assignment
+       failure SHOULD also be provided.";
+    leaf bind-ni-name {
+      type leafref {
+        path "/network-instances/network-instance/name";
+      }
+      description
+        "Network instance to which IPv4 interface is bound.";
+    }
+  }
+  augment "/if:interfaces/if:interface/ip:ipv6" {
+    description
+      "Add a node for the identification of the network
+       instance associated with the information configured
+       on an IPv6 interface.
+
+       Note that a standard error will be returned if the
+       identified leafref isn't present.  If an interface cannot
+       be assigned for any other reason, the operation SHALL fail
+       with an error-tag of 'operation-failed' and an
+       error-app-tag of 'ni-assignment-failed'.  A meaningful
+       error-info that indicates the source of the assignment
+       failure SHOULD also be provided.";
+    leaf bind-ni-name {
+      type leafref {
+        path "/network-instances/network-instance/name";
+      }
+      description
+        "Network instance to which IPv6 interface is bound.";
+    }
+  }
+
+  notification bind-ni-name-failed {
+    description
+      "Indicates an error in the association of an interface to an
+       NI.  Only generated after success is initially returned when
+       bind-ni-name is set.
+
+       Note: Some errors may need to be reported for multiple
+       associations, e.g., a single error may need to be reported
+       for an IPv4 and an IPv6 bind-ni-name.
+
+       At least one container with a bind-ni-name leaf MUST be
+       included in this notification.";
+    leaf name {
+      type leafref {
+        path "/if:interfaces/if:interface/if:name";
+      }
+      mandatory true;
+      description
+        "Contains the interface name associated with the
+         failure.";
+    }
+    container interface {
+      description
+        "Generic interface type.";
+      leaf bind-ni-name {
+        type leafref {
+          path "/if:interfaces/if:interface/ni:bind-ni-name";
+        }
+        description
+          "Contains the bind-ni-name associated with the
+           failure.";
+      }
+    }
+    container ipv4 {
+      description
+        "IPv4 interface type.";
+      leaf bind-ni-name {
+        type leafref {
+          path "/if:interfaces/if:interface/ip:ipv4/ni:bind-ni-name";
+        }
+        description
+          "Contains the bind-ni-name associated with the
+           failure.";
+      }
+    }
+    container ipv6 {
+      description
+        "IPv6 interface type.";
+      leaf bind-ni-name {
+        type leafref {
+          path "/if:interfaces/if:interface/ip:ipv6/ni:bind-ni-name";
+        }
+        description
+          "Contains the bind-ni-name associated with the
+           failure.";
+      }
+    }
+    leaf error-info {
+      type string;
+      description
+        "Optionally, indicates the source of the assignment
+         failure.";
+    }
+  }
+}
+"""
+
+ietf_ip = r"""module ietf-ip {
+  yang-version 1.1;
+  namespace "urn:ietf:params:xml:ns:yang:ietf-ip";
+  prefix ip;
+
+  import ietf-interfaces {
+    prefix if;
+  }
+  import ietf-inet-types {
+    prefix inet;
+  }
+  import ietf-yang-types {
+    prefix yang;
+  }
+
+  organization
+    "IETF NETMOD (Network Modeling) Working Group";
+  contact
+    "WG Web:   <https://datatracker.ietf.org/wg/netmod/>
+     WG List:  <mailto:netmod@ietf.org>
+
+     Editor:   Martin Bjorklund
+               <mailto:mbj@tail-f.com>";
+  description
+    "This module contains a collection of YANG definitions for
+     managing IP implementations.
+
+     Copyright (c) 2018 IETF Trust and the persons identified as
+     authors of the code.  All rights reserved.
+
+     Redistribution and use in source and binary forms, with or
+     without modification, is permitted pursuant to, and subject
+     to the license terms contained in, the Simplified BSD License
+     set forth in Section 4.c of the IETF Trust's Legal Provisions
+     Relating to IETF Documents
+     (https://trustee.ietf.org/license-info).
+
+     This version of this YANG module is part of RFC 8344; see
+     the RFC itself for full legal notices.";
+
+  revision 2018-02-22 {
+    description
+      "Updated to support NMDA.";
+    reference
+      "RFC 8344: A YANG Data Model for IP Management";
+  }
+  revision 2014-06-16 {
+    description
+      "Initial revision.";
+    reference
+      "RFC 7277: A YANG Data Model for IP Management";
+  }
+
+  feature ipv4-non-contiguous-netmasks {
+    description
+      "Indicates support for configuring non-contiguous
+       subnet masks.";
+  }
+
+  feature ipv6-privacy-autoconf {
+    description
+      "Indicates support for privacy extensions for stateless address
+       autoconfiguration in IPv6.";
+    reference
+      "RFC 4941: Privacy Extensions for Stateless Address
+                 Autoconfiguration in IPv6";
+  }
+
+  typedef ip-address-origin {
+    type enumeration {
+      enum "other" {
+        description
+          "None of the following.";
+      }
+      enum "static" {
+        description
+          "Indicates that the address has been statically
+           configured -- for example, using the Network Configuration
+           Protocol (NETCONF) or a command line interface.";
+      }
+      enum "dhcp" {
+        description
+          "Indicates an address that has been assigned to this
+           system by a DHCP server.";
+      }
+      enum "link-layer" {
+        description
+          "Indicates an address created by IPv6 stateless
+           autoconfiguration that embeds a link-layer address in its
+           interface identifier.";
+      }
+      enum "random" {
+        description
+          "Indicates an address chosen by the system at
+           random, e.g., an IPv4 address within 169.254/16, a
+           temporary address as described in RFC 4941, or a
+           semantically opaque address as described in RFC 7217.";
+        reference
+          "RFC 4941: Privacy Extensions for Stateless Address
+                     Autoconfiguration in IPv6
+           RFC 7217: A Method for Generating Semantically Opaque
+                     Interface Identifiers with IPv6 Stateless
+                     Address Autoconfiguration (SLAAC)";
+      }
+    }
+    description
+      "The origin of an address.";
+  }
+
+  typedef neighbor-origin {
+    type enumeration {
+      enum "other" {
+        description
+          "None of the following.";
+      }
+      enum "static" {
+        description
+          "Indicates that the mapping has been statically
+           configured -- for example, using NETCONF or a command line
+           interface.";
+      }
+      enum "dynamic" {
+        description
+          "Indicates that the mapping has been dynamically resolved
+           using, for example, IPv4 ARP or the IPv6 Neighbor
+           Discovery protocol.";
+      }
+    }
+    description
+      "The origin of a neighbor entry.";
+  }
+
+  augment "/if:interfaces/if:interface" {
+    description
+      "IP parameters on interfaces.
+
+       If an interface is not capable of running IP, the server
+       must not allow the client to configure these parameters.";
+    container ipv4 {
+      presence "Enables IPv4 unless the 'enabled' leaf
+       (which defaults to 'true') is set to 'false'";
+      description
+        "Parameters for the IPv4 address family.";
+      leaf enabled {
+        type boolean;
+        default "true";
+        description
+          "Controls whether IPv4 is enabled or disabled on this
+           interface.  When IPv4 is enabled, this interface is
+           connected to an IPv4 stack, and the interface can send
+           and receive IPv4 packets.";
+      }
+      leaf forwarding {
+        type boolean;
+        default "false";
+        description
+          "Controls IPv4 packet forwarding of datagrams received by,
+           but not addressed to, this interface.  IPv4 routers
+           forward datagrams.  IPv4 hosts do not (except those
+           source-routed via the host).";
+      }
+      leaf mtu {
+        type uint16 {
+          range "68..max";
+        }
+        units "octets";
+        description
+          "The size, in octets, of the largest IPv4 packet that the
+           interface will send and receive.
+
+           The server may restrict the allowed values for this leaf,
+           depending on the interface's type.
+
+           If this leaf is not configured, the operationally used MTU
+           depends on the interface's type.";
+        reference
+          "RFC 791: Internet Protocol";
+      }
+      list address {
+        key "ip";
+        description
+          "The list of IPv4 addresses on the interface.";
+        leaf ip {
+          type inet:ipv4-address-no-zone;
+          description
+            "The IPv4 address on the interface.";
+        }
+        choice subnet {
+          mandatory true;
+          description
+            "The subnet can be specified as a prefix length or,
+             if the server supports non-contiguous netmasks, as
+             a netmask.";
+          leaf prefix-length {
+            type uint8 {
+              range "0..32";
+            }
+            description
+              "The length of the subnet prefix.";
+          }
+          leaf netmask {
+            if-feature "ipv4-non-contiguous-netmasks";
+            type yang:dotted-quad;
+            description
+              "The subnet specified as a netmask.";
+          }
+        }
+        leaf origin {
+          type ip-address-origin;
+          config false;
+          description
+            "The origin of this address.";
+        }
+      }
+      list neighbor {
+        key "ip";
+        description
+          "A list of mappings from IPv4 addresses to
+           link-layer addresses.
+
+           Entries in this list in the intended configuration are
+           used as static entries in the ARP Cache.
+
+           In the operational state, this list represents the ARP
+           Cache.";
+        reference
+          "RFC 826: An Ethernet Address Resolution Protocol";
+        leaf ip {
+          type inet:ipv4-address-no-zone;
+          description
+            "The IPv4 address of the neighbor node.";
+        }
+        leaf link-layer-address {
+          type yang:phys-address;
+          mandatory true;
+          description
+            "The link-layer address of the neighbor node.";
+        }
+        leaf origin {
+          type neighbor-origin;
+          config false;
+          description
+            "The origin of this neighbor entry.";
+        }
+      }
+    }
+    container ipv6 {
+      presence "Enables IPv6 unless the 'enabled' leaf
+       (which defaults to 'true') is set to 'false'";
+      description
+        "Parameters for the IPv6 address family.";
+      leaf enabled {
+        type boolean;
+        default "true";
+        description
+          "Controls whether IPv6 is enabled or disabled on this
+           interface.  When IPv6 is enabled, this interface is
+           connected to an IPv6 stack, and the interface can send
+           and receive IPv6 packets.";
+      }
+      leaf forwarding {
+        type boolean;
+        default "false";
+        description
+          "Controls IPv6 packet forwarding of datagrams received by,
+           but not addressed to, this interface.  IPv6 routers
+           forward datagrams.  IPv6 hosts do not (except those
+           source-routed via the host).";
+        reference
+          "RFC 4861: Neighbor Discovery for IP version 6 (IPv6)
+                     Section 6.2.1, IsRouter";
+      }
+      leaf mtu {
+        type uint32 {
+          range "1280..max";
+        }
+        units "octets";
+        description
+          "The size, in octets, of the largest IPv6 packet that the
+           interface will send and receive.
+
+           The server may restrict the allowed values for this leaf,
+           depending on the interface's type.
+
+           If this leaf is not configured, the operationally used MTU
+           depends on the interface's type.";
+        reference
+          "RFC 8200: Internet Protocol, Version 6 (IPv6)
+                     Specification
+                     Section 5";
+      }
+      list address {
+        key "ip";
+        description
+          "The list of IPv6 addresses on the interface.";
+        leaf ip {
+          type inet:ipv6-address-no-zone;
+          description
+            "The IPv6 address on the interface.";
+        }
+        leaf prefix-length {
+          type uint8 {
+            range "0..128";
+          }
+          mandatory true;
+          description
+            "The length of the subnet prefix.";
+        }
+        leaf origin {
+          type ip-address-origin;
+          config false;
+          description
+            "The origin of this address.";
+        }
+        leaf status {
+          type enumeration {
+            enum "preferred" {
+              description
+                "This is a valid address that can appear as the
+                 destination or source address of a packet.";
+            }
+            enum "deprecated" {
+              description
+                "This is a valid but deprecated address that should
+                 no longer be used as a source address in new
+                 communications, but packets addressed to such an
+                 address are processed as expected.";
+            }
+            enum "invalid" {
+              description
+                "This isn't a valid address, and it shouldn't appear
+                 as the destination or source address of a packet.";
+            }
+            enum "inaccessible" {
+              description
+                "The address is not accessible because the interface
+                 to which this address is assigned is not
+                 operational.";
+            }
+            enum "unknown" {
+              description
+                "The status cannot be determined for some reason.";
+            }
+            enum "tentative" {
+              description
+                "The uniqueness of the address on the link is being
+                 verified.  Addresses in this state should not be
+                 used for general communication and should only be
+                 used to determine the uniqueness of the address.";
+            }
+            enum "duplicate" {
+              description
+                "The address has been determined to be non-unique on
+                 the link and so must not be used.";
+            }
+            enum "optimistic" {
+              description
+                "The address is available for use, subject to
+                 restrictions, while its uniqueness on a link is
+                 being verified.";
+            }
+          }
+          config false;
+          description
+            "The status of an address.  Most of the states correspond
+             to states from the IPv6 Stateless Address
+             Autoconfiguration protocol.";
+          reference
+            "RFC 4293: Management Information Base for the
+                       Internet Protocol (IP)
+                       - IpAddressStatusTC
+             RFC 4862: IPv6 Stateless Address Autoconfiguration";
+        }
+      }
+      list neighbor {
+        key "ip";
+        description
+          "A list of mappings from IPv6 addresses to
+           link-layer addresses.
+
+           Entries in this list in the intended configuration are
+           used as static entries in the Neighbor Cache.
+
+           In the operational state, this list represents the
+           Neighbor Cache.";
+        reference
+          "RFC 4861: Neighbor Discovery for IP version 6 (IPv6)";
+        leaf ip {
+          type inet:ipv6-address-no-zone;
+          description
+            "The IPv6 address of the neighbor node.";
+        }
+        leaf link-layer-address {
+          type yang:phys-address;
+          mandatory true;
+          description
+            "The link-layer address of the neighbor node.
+
+             In the operational state, if the neighbor's 'state' leaf
+             is 'incomplete', this leaf is not instantiated.";
+        }
+        leaf origin {
+          type neighbor-origin;
+          config false;
+          description
+            "The origin of this neighbor entry.";
+        }
+        leaf is-router {
+          type empty;
+          config false;
+          description
+            "Indicates that the neighbor node acts as a router.";
+        }
+        leaf state {
+          type enumeration {
+            enum "incomplete" {
+              description
+                "Address resolution is in progress, and the
+                 link-layer address of the neighbor has not yet been
+                 determined.";
+            }
+            enum "reachable" {
+              description
+                "Roughly speaking, the neighbor is known to have been
+                 reachable recently (within tens of seconds ago).";
+            }
+            enum "stale" {
+              description
+                "The neighbor is no longer known to be reachable, but
+                 until traffic is sent to the neighbor no attempt
+                 should be made to verify its reachability.";
+            }
+            enum "delay" {
+              description
+                "The neighbor is no longer known to be reachable, and
+                 traffic has recently been sent to the neighbor.
+                 Rather than probe the neighbor immediately, however,
+                 delay sending probes for a short while in order to
+                 give upper-layer protocols a chance to provide
+                 reachability confirmation.";
+            }
+            enum "probe" {
+              description
+                "The neighbor is no longer known to be reachable, and
+                 unicast Neighbor Solicitation probes are being sent
+                 to verify reachability.";
+            }
+          }
+          config false;
+          description
+            "The Neighbor Unreachability Detection state of this
+             entry.";
+          reference
+            "RFC 4861: Neighbor Discovery for IP version 6 (IPv6)
+                       Section 7.3.2";
+        }
+      }
+      leaf dup-addr-detect-transmits {
+        type uint32;
+        default "1";
+        description
+          "The number of consecutive Neighbor Solicitation messages
+           sent while performing Duplicate Address Detection on a
+           tentative address.  A value of zero indicates that
+           Duplicate Address Detection is not performed on
+           tentative addresses.  A value of one indicates a single
+           transmission with no follow-up retransmissions.";
+        reference
+          "RFC 4862: IPv6 Stateless Address Autoconfiguration";
+      }
+      container autoconf {
+        description
+          "Parameters to control the autoconfiguration of IPv6
+           addresses, as described in RFC 4862.";
+        reference
+          "RFC 4862: IPv6 Stateless Address Autoconfiguration";
+        leaf create-global-addresses {
+          type boolean;
+          default "true";
+          description
+            "If enabled, the host creates global addresses as
+             described in RFC 4862.";
+          reference
+            "RFC 4862: IPv6 Stateless Address Autoconfiguration
+                       Section 5.5";
+        }
+        leaf create-temporary-addresses {
+          if-feature "ipv6-privacy-autoconf";
+          type boolean;
+          default "false";
+          description
+            "If enabled, the host creates temporary addresses as
+             described in RFC 4941.";
+          reference
+            "RFC 4941: Privacy Extensions for Stateless Address
+                       Autoconfiguration in IPv6";
+        }
+        leaf temporary-valid-lifetime {
+          if-feature "ipv6-privacy-autoconf";
+          type uint32;
+          units "seconds";
+          default "604800";
+          description
+            "The time period during which the temporary address
+             is valid.";
+          reference
+            "RFC 4941: Privacy Extensions for Stateless Address
+                       Autoconfiguration in IPv6
+                       - TEMP_VALID_LIFETIME";
+        }
+        leaf temporary-preferred-lifetime {
+          if-feature "ipv6-privacy-autoconf";
+          type uint32;
+          units "seconds";
+          default "86400";
+          description
+            "The time period during which the temporary address is
+             preferred.";
+          reference
+            "RFC 4941: Privacy Extensions for Stateless Address
+                       Autoconfiguration in IPv6
+                       - TEMP_PREFERRED_LIFETIME";
+        }
+      }
+    }
+  }
+  augment "/if:interfaces-state/if:interface" {
+    status deprecated;
+    description
+      "Data nodes for the operational state of IP on interfaces.";
+    container ipv4 {
+      presence "Present if IPv4 is enabled on this interface";
+      config false;
+      status deprecated;
+      description
+        "Interface-specific parameters for the IPv4 address family.";
+      leaf forwarding {
+        type boolean;
+        status deprecated;
+        description
+          "Indicates whether IPv4 packet forwarding is enabled or
+           disabled on this interface.";
+      }
+      leaf mtu {
+        type uint16 {
+          range "68..max";
+        }
+        units "octets";
+        status deprecated;
+        description
+          "The size, in octets, of the largest IPv4 packet that the
+           interface will send and receive.";
+        reference
+          "RFC 791: Internet Protocol";
+      }
+      list address {
+        key "ip";
+        status deprecated;
+        description
+          "The list of IPv4 addresses on the interface.";
+        leaf ip {
+          type inet:ipv4-address-no-zone;
+          status deprecated;
+          description
+            "The IPv4 address on the interface.";
+        }
+        choice subnet {
+          status deprecated;
+          description
+            "The subnet can be specified as a prefix length or,
+             if the server supports non-contiguous netmasks, as
+             a netmask.";
+          leaf prefix-length {
+            type uint8 {
+              range "0..32";
+            }
+            status deprecated;
+            description
+              "The length of the subnet prefix.";
+          }
+          leaf netmask {
+            if-feature "ipv4-non-contiguous-netmasks";
+            type yang:dotted-quad;
+            status deprecated;
+            description
+              "The subnet specified as a netmask.";
+          }
+        }
+        leaf origin {
+          type ip-address-origin;
+          status deprecated;
+          description
+            "The origin of this address.";
+        }
+      }
+      list neighbor {
+        key "ip";
+        status deprecated;
+        description
+          "A list of mappings from IPv4 addresses to
+           link-layer addresses.
+
+           This list represents the ARP Cache.";
+        reference
+          "RFC 826: An Ethernet Address Resolution Protocol";
+        leaf ip {
+          type inet:ipv4-address-no-zone;
+          status deprecated;
+          description
+            "The IPv4 address of the neighbor node.";
+        }
+        leaf link-layer-address {
+          type yang:phys-address;
+          status deprecated;
+          description
+            "The link-layer address of the neighbor node.";
+        }
+        leaf origin {
+          type neighbor-origin;
+          status deprecated;
+          description
+            "The origin of this neighbor entry.";
+        }
+      }
+    }
+    container ipv6 {
+      presence "Present if IPv6 is enabled on this interface";
+      config false;
+      status deprecated;
+      description
+        "Parameters for the IPv6 address family.";
+      leaf forwarding {
+        type boolean;
+        default "false";
+        status deprecated;
+        description
+          "Indicates whether IPv6 packet forwarding is enabled or
+           disabled on this interface.";
+        reference
+          "RFC 4861: Neighbor Discovery for IP version 6 (IPv6)
+                     Section 6.2.1, IsRouter";
+      }
+      leaf mtu {
+        type uint32 {
+          range "1280..max";
+        }
+        units "octets";
+        status deprecated;
+        description
+          "The size, in octets, of the largest IPv6 packet that the
+           interface will send and receive.";
+        reference
+          "RFC 8200: Internet Protocol, Version 6 (IPv6)
+                     Specification
+                     Section 5";
+      }
+      list address {
+        key "ip";
+        status deprecated;
+        description
+          "The list of IPv6 addresses on the interface.";
+        leaf ip {
+          type inet:ipv6-address-no-zone;
+          status deprecated;
+          description
+            "The IPv6 address on the interface.";
+        }
+        leaf prefix-length {
+          type uint8 {
+            range "0..128";
+          }
+          mandatory true;
+          status deprecated;
+          description
+            "The length of the subnet prefix.";
+        }
+        leaf origin {
+          type ip-address-origin;
+          status deprecated;
+          description
+            "The origin of this address.";
+        }
+        leaf status {
+          type enumeration {
+            enum "preferred" {
+              description
+                "This is a valid address that can appear as the
+                 destination or source address of a packet.";
+            }
+            enum "deprecated" {
+              description
+                "This is a valid but deprecated address that should
+                 no longer be used as a source address in new
+                 communications, but packets addressed to such an
+                 address are processed as expected.";
+            }
+            enum "invalid" {
+              description
+                "This isn't a valid address, and it shouldn't appear
+                 as the destination or source address of a packet.";
+            }
+            enum "inaccessible" {
+              description
+                "The address is not accessible because the interface
+                 to which this address is assigned is not
+                 operational.";
+            }
+            enum "unknown" {
+              description
+                "The status cannot be determined for some reason.";
+            }
+            enum "tentative" {
+              description
+                "The uniqueness of the address on the link is being
+                 verified.  Addresses in this state should not be
+                 used for general communication and should only be
+                 used to determine the uniqueness of the address.";
+            }
+            enum "duplicate" {
+              description
+                "The address has been determined to be non-unique on
+                 the link and so must not be used.";
+            }
+            enum "optimistic" {
+              description
+                "The address is available for use, subject to
+                 restrictions, while its uniqueness on a link is
+                 being verified.";
+            }
+          }
+          status deprecated;
+          description
+            "The status of an address.  Most of the states correspond
+             to states from the IPv6 Stateless Address
+             Autoconfiguration protocol.";
+          reference
+            "RFC 4293: Management Information Base for the
+                       Internet Protocol (IP)
+                       - IpAddressStatusTC
+             RFC 4862: IPv6 Stateless Address Autoconfiguration";
+        }
+      }
+      list neighbor {
+        key "ip";
+        status deprecated;
+        description
+          "A list of mappings from IPv6 addresses to
+           link-layer addresses.
+
+           This list represents the Neighbor Cache.";
+        reference
+          "RFC 4861: Neighbor Discovery for IP version 6 (IPv6)";
+        leaf ip {
+          type inet:ipv6-address-no-zone;
+          status deprecated;
+          description
+            "The IPv6 address of the neighbor node.";
+        }
+        leaf link-layer-address {
+          type yang:phys-address;
+          status deprecated;
+          description
+            "The link-layer address of the neighbor node.";
+        }
+        leaf origin {
+          type neighbor-origin;
+          status deprecated;
+          description
+            "The origin of this neighbor entry.";
+        }
+        leaf is-router {
+          type empty;
+          status deprecated;
+          description
+            "Indicates that the neighbor node acts as a router.";
+        }
+        leaf state {
+          type enumeration {
+            enum "incomplete" {
+              description
+                "Address resolution is in progress, and the
+                 link-layer address of the neighbor has not yet been
+                 determined.";
+            }
+            enum "reachable" {
+              description
+                "Roughly speaking, the neighbor is known to have been
+                 reachable recently (within tens of seconds ago).";
+            }
+            enum "stale" {
+              description
+                "The neighbor is no longer known to be reachable, but
+                 until traffic is sent to the neighbor no attempt
+                 should be made to verify its reachability.";
+            }
+            enum "delay" {
+              description
+                "The neighbor is no longer known to be reachable, and
+                 traffic has recently been sent to the neighbor.
+                 Rather than probe the neighbor immediately, however,
+                 delay sending probes for a short while in order to
+                 give upper-layer protocols a chance to provide
+                 reachability confirmation.";
+            }
+            enum "probe" {
+              description
+                "The neighbor is no longer known to be reachable, and
+                 unicast Neighbor Solicitation probes are being sent
+                 to verify reachability.";
+            }
+          }
+          status deprecated;
+          description
+            "The Neighbor Unreachability Detection state of this
+             entry.";
+          reference
+            "RFC 4861: Neighbor Discovery for IP version 6 (IPv6)
+                       Section 7.3.2";
+        }
+      }
+    }
+  }
+}
+"""
+
+ietf_yang_schema_mount = r"""module ietf-yang-schema-mount {
+  yang-version 1.1;
+  namespace "urn:ietf:params:xml:ns:yang:ietf-yang-schema-mount";
+  prefix yangmnt;
+
+  import ietf-inet-types {
+    prefix inet;
+    reference
+      "RFC 6991: Common YANG Data Types";
+  }
+  import ietf-yang-types {
+    prefix yang;
+    reference
+      "RFC 6991: Common YANG Data Types";
+  }
+
+  organization
+    "IETF NETMOD (NETCONF Data Modeling Language) Working Group";
+  contact
+    "WG Web:   <https://datatracker.ietf.org/wg/netmod/>
+     WG List:  <mailto:netmod@ietf.org>
+
+     Editor:   Martin Bjorklund
+               <mailto:mbj@tail-f.com>
+
+     Editor:   Ladislav Lhotka
+               <mailto:lhotka@nic.cz>";
+  description
+    "This module defines a YANG extension statement that can be used
+     to incorporate data models defined in other YANG modules in a
+     module.  It also defines operational state data that specify the
+     overall structure of the data model.
+
+     The key words 'MUST', 'MUST NOT', 'REQUIRED', 'SHALL', 'SHALL
+     NOT', 'SHOULD', 'SHOULD NOT', 'RECOMMENDED', 'NOT RECOMMENDED',
+     'MAY', and 'OPTIONAL' in this document are to be interpreted as
+     described in BCP 14 (RFC 2119) (RFC 8174) when, and only when,
+     they appear in all capitals, as shown here.
+
+     Copyright (c) 2019 IETF Trust and the persons identified as
+     authors of the code.  All rights reserved.
+
+     Redistribution and use in source and binary forms, with or
+     without modification, is permitted pursuant to, and subject to
+     the license terms contained in, the Simplified BSD License set
+     forth in Section 4.c of the IETF Trust's Legal Provisions
+     Relating to IETF Documents
+     (https://trustee.ietf.org/license-info).
+
+     This version of this YANG module is part of RFC 8528;
+     see the RFC itself for full legal notices.";
+
+  revision 2019-01-14 {
+    description
+      "Initial revision.";
+    reference
+      "RFC 8528: YANG Schema Mount";
+  }
+
+  extension mount-point {
+    argument label;
+    description
+      "The argument 'label' is a YANG identifier, i.e., it is of the
+       type 'yang:yang-identifier'.
+
+       The 'mount-point' statement MUST NOT be used in a YANG
+       version 1 module, neither explicitly nor via a 'uses'
+       statement.
+       The 'mount-point' statement MAY be present as a substatement
+       of 'container' and 'list' and MUST NOT be present elsewhere.
+       There MUST NOT be more than one 'mount-point' statement in a
+       given 'container' or 'list' statement.
+
+       If a mount point is defined within a grouping, its label is
+       bound to the module where the grouping is used.
+
+       A mount point defines a place in the node hierarchy where
+       other data models may be attached.  A server that implements a
+       module with a mount point populates the
+       '/schema-mounts/mount-point' list with detailed information on
+       which data models are mounted at each mount point.
+
+       Note that the 'mount-point' statement does not define a new
+       data node.";
+  }
+
+  container schema-mounts {
+    config false;
+    description
+      "Contains information about the structure of the overall
+       mounted data model implemented in the server.";
+    list namespace {
+      key "prefix";
+      description
+        "This list provides a mapping of namespace prefixes that are
+         used in XPath expressions of 'parent-reference' leafs to the
+         corresponding namespace URI references.";
+      leaf prefix {
+        type yang:yang-identifier;
+        description
+          "Namespace prefix.";
+      }
+      leaf uri {
+        type inet:uri;
+        description
+          "Namespace URI reference.";
+      }
+    }
+    list mount-point {
+      key "module label";
+      description
+        "Each entry of this list specifies a schema for a particular
+         mount point.
+
+         Each mount point MUST be defined using the 'mount-point'
+         extension in one of the modules listed in the server's
+         YANG library instance with conformance type 'implement'.";
+      leaf module {
+        type yang:yang-identifier;
+        description
+          "Name of a module containing the mount point.";
+      }
+      leaf label {
+        type yang:yang-identifier;
+        description
+          "Label of the mount point defined using the 'mount-point'
+           extension.";
+      }
+      leaf config {
+        type boolean;
+        default "true";
+        description
+          "If this leaf is set to 'false', then all data nodes in the
+           mounted schema are read-only ('config false'), regardless
+           of their 'config' property.";
+      }
+      choice schema-ref {
+        mandatory true;
+        description
+          "Alternatives for specifying the schema.";
+        container inline {
+          presence "A complete self-contained schema is mounted at the
+           mount point.";
+          description
+            "This node indicates that the server has mounted at least
+             the module 'ietf-yang-library' at the mount point, and
+             its instantiation provides the information about the
+             mounted schema.
+
+             Different instances of the mount point may have
+             different schemas mounted.";
+        }
+        container shared-schema {
+          presence "The mounted schema together with the 'parent-reference'
+           make up the schema for this mount point.";
+          description
+            "This node indicates that the server has mounted at least
+             the module 'ietf-yang-library' at the mount point, and
+             its instantiation provides the information about the
+             mounted schema.  When XPath expressions in the mounted
+             schema are evaluated, the 'parent-reference' leaf-list
+             is taken into account.
+
+             Different instances of the mount point MUST have the
+             same schema mounted.";
+          leaf-list parent-reference {
+            type yang:xpath1.0;
+            description
+              "Entries of this leaf-list are XPath 1.0 expressions
+               that are evaluated in the following context:
+
+               - The context node is the node in the parent data tree
+                 where the mount-point is defined.
+
+               - The accessible tree is the parent data tree
+                 *without* any nodes defined in modules that are
+                 mounted inside the parent schema.
+
+               - The context position and context size are both equal
+                 to 1.
+
+               - The set of variable bindings is empty.
+
+               - The function library is the core function library
+                 defined in the W3C XPath 1.0 document
+                 (http://www.w3.org/TR/1999/REC-xpath-19991116) and
+                 the functions defined in Section 10 of RFC 7950.
+
+               - The set of namespace declarations is defined by the
+                 'namespace' list under 'schema-mounts'.
+
+               Each XPath expression MUST evaluate to a node-set
+               (possibly empty).  For the purposes of evaluating
+               XPath expressions whose context nodes are defined in
+               the mounted schema, the union of all these node-sets
+               together with ancestor nodes are added to the
+               accessible data tree.
+
+               Note that in the case 'ietf-yang-schema-mount' is
+               itself mounted, a 'parent-reference' in the mounted
+               module may refer to nodes that were brought into the
+               accessible tree through a 'parent-reference' in the
+               parent schema.";
+          }
+        }
+      }
+    }
+  }
+}
+"""

--- a/src/adapters/netconf.act
+++ b/src/adapters/netconf.act
@@ -37,9 +37,6 @@ def extract_txid(conf: ?xml.Node) -> ?str:
                     return attr_value
 
 
-NS_YANG_LIBRARY = "urn:ietf:params:xml:ns:yang:ietf-yang-library"
-
-
 def _mock_capabilities_from_dmc(new_dmc: DeviceMetaConfig) -> list[str]:
     """True protocol capabilities for the mock device hello exchange.
     """
@@ -80,43 +77,6 @@ actor NetconfMockServer(pipe, log_handler: logging.Handler, capabilities: list[s
     var rpc_log: list[(message_id: str, op: xml.Node)] = []
     NS_NC_1_0 = "urn:ietf:params:xml:ns:netconf:base:1.0"
 
-    def _bundled_caps(module_metadata: dict[str, (module: str, revision: ?str)]) -> list[str]:
-        """YANG module capability URIs (`<namespace>?module=<name>&revision=<rev>`)
-        for every module in `module_metadata`."""
-        caps = []
-        for ns, meta in module_metadata.items():
-            cap = ns + "?module=" + meta.module
-            rev = meta.revision
-            if rev is not None:
-                cap = cap + "&revision=" + rev
-            caps.append(cap)
-        return caps
-
-    def _merge_module_metadata(schemas: list[yschema.DRoot]) -> dict[str, (module: str, revision: ?str)]:
-        """The device's advertised module inventory: every schema's modules."""
-        merged = {}
-        for s in schemas:
-            for ns, meta in s.module_metadata.items():
-                merged[ns] = meta
-        return merged
-
-    def _build_yl_view(config_schema: yschema.DRoot, operational_schema: yschema.DRoot) -> ?(root: ygdata.Node, content_id: str):
-        """The ietf-yang-library view to serve, or None when the inventory doesn't
-        implement it. Recomputed whenever the served schema changes so the library
-        and its content-id track the current module set."""
-        inventory = _merge_module_metadata([config_schema, operational_schema])
-        if NS_YANG_LIBRARY in inventory:
-            return monitoring.build_yang_library([config_schema, operational_schema])
-        return None
-
-    def _advertised_module_caps(schemas: list[yschema.DRoot],
-                                yl_view: ?(root: ygdata.Node, content_id: str)) -> list[str]:
-        """Capabilities for the hello, either protocl+ietf-yang-library or every module as capability"""
-        if yl_view is not None:
-            yl_rev = yl.SRC_DNODE.module_metadata[NS_YANG_LIBRARY].revision
-            return ["urn:ietf:params:netconf:capability:yang-library:1.1?{"revision={yl_rev}&" if yl_rev is not None else ""}content-id={yl_view.content_id}"]
-        return _bundled_caps(_merge_module_metadata(schemas))
-
     def _merged_schema(schemas: list[yschema.DRoot]) -> yschema.DRoot:
         children = []
         identities = []
@@ -143,8 +103,8 @@ actor NetconfMockServer(pipe, log_handler: logging.Handler, capabilities: list[s
 
     # Serve ietf-yang-library only when the device's inventory implements it.
     # Otherwise the modules are advertised as additiona "?module=..." capabilities.
-    var yl_view = _build_yl_view(config_schema, operational_schema)
-    all_capabilities = capabilities + _advertised_module_caps([config_schema, operational_schema], yl_view)
+    var yl_view = monitoring.build_yl_view([config_schema, operational_schema])
+    all_capabilities = capabilities + monitoring.module_capabilities([config_schema, operational_schema], yl_view)
 
     def send_reply_with_log(s: netconf.Server, message_id: str, children: list[xml.Node]):
         rpc_reply = xml.Node("rpc-reply", [(None, NS_NC_1_0)], None, [("message-id", message_id)], children)
@@ -298,14 +258,14 @@ actor NetconfMockServer(pipe, log_handler: logging.Handler, capabilities: list[s
         oper_ds = new_oper_ds
         if schema is not None:
             oper_schema = schema
-            yl_view = _build_yl_view(conf_schema, oper_schema)
+            yl_view = monitoring.build_yl_view([conf_schema, oper_schema])
 
     def set_conf_ds(new_conf_ds: ygdata.Node, schema: ?yschema.DRoot=None):
         """Set the configuration datastore (and optionally its schema) for <get-config>."""
         conf_ds = new_conf_ds
         if schema is not None:
             conf_schema = schema
-            yl_view = _build_yl_view(conf_schema, oper_schema)
+            yl_view = monitoring.build_yl_view([conf_schema, oper_schema])
 
 
 actor NetconfDriver(dev: swdev.DeviceMgr, bundled_schema: DeviceSchema, init_dmc: DeviceMetaConfig, schema_registry: swdev.SchemaRegistry, log_handler: logging.Handler, connect_cap: ?net.TCPConnectCap):

--- a/src/monitoring.act
+++ b/src/monitoring.act
@@ -1,8 +1,13 @@
+import std.xml as xml
 import hash.wyhash as wyhash
 
 import ietf_yang_library as yl
 import yang.gdata as ygdata
 import yang.schema as yschema
+
+
+NS_YANG_LIBRARY = "urn:ietf:params:xml:ns:yang:ietf-yang-library"
+NS_NETCONF_MONITORING = "urn:ietf:params:xml:ns:yang:ietf-netconf-monitoring"
 
 
 def build_yang_library(schemas: list[yschema.DRoot]) -> (root: ygdata.Node, content_id: str):
@@ -81,3 +86,65 @@ def build_yang_library(schemas: list[yschema.DRoot]) -> (root: ygdata.Node, cont
     content_id = str(wyhash.hash(0, root.to_gdata().prsrc(deterministic=True).encode()))
     yang_library.content_id = content_id
     return (root=root.to_gdata(), content_id=content_id)
+
+
+def merge_module_metadata(schemas: list[yschema.DRoot]) -> dict[str, (module: str, revision: ?str)]:
+    """The merged module inventory (namespace -> module, revision) of every schema."""
+    merged = {}
+    for s in schemas:
+        for ns, meta in s.module_metadata.items():
+            merged[ns] = meta
+    return merged
+
+
+def build_yl_view(schemas: list[yschema.DRoot]) -> ?(root: ygdata.Node, content_id: str):
+    """The ietf-yang-library view to serve (gdata tree + content-id), or None when
+    the inventory doesn't implement ietf-yang-library. Recompute whenever the served
+    schema changes so the library and its content-id track the current module set."""
+    if NS_YANG_LIBRARY in merge_module_metadata(schemas):
+        return build_yang_library(schemas)
+    return None
+
+
+def bundled_module_caps(module_metadata: dict[str, (module: str, revision: ?str)]) -> list[str]:
+    """One `<namespace>?module=<name>&revision=<rev>` capability per module."""
+    caps = []
+    for ns, meta in module_metadata.items():
+        cap = ns + "?module=" + meta.module
+        rev = meta.revision
+        if rev is not None:
+            cap = cap + "&revision=" + rev
+        caps.append(cap)
+    return caps
+
+
+def module_capabilities(schemas: list[yschema.DRoot],
+                        yl_view: ?(root: ygdata.Node, content_id: str)) -> list[str]:
+    """The module-inventory capabilities for a <hello>: a single yang-library:1.1
+    capability carrying the content-id when the inventory implements
+    ietf-yang-library, else one ?module= capability per module."""
+    if yl_view is not None:
+        yl_rev = yl.SRC_DNODE.module_metadata[NS_YANG_LIBRARY].revision
+        return ["urn:ietf:params:netconf:capability:yang-library:1.1?{"revision={yl_rev}&" if yl_rev is not None else ""}content-id={yl_view.content_id}"]
+    return bundled_module_caps(merge_module_metadata(schemas))
+
+
+def get_schema_identifier(op: xml.Node) -> ?str:
+    """The <identifier> (module name) of a <get-schema> request, or None."""
+    for c in op.children:
+        if c.tag == "identifier":
+            return c.text
+    return None
+
+
+def get_schema_reply(op: xml.Node, sources: dict[str, str]) -> ?xml.Node:
+    """The <data> reply node for a <get-schema> (RFC 6022, ietf-netconf-monitoring),
+    given a module-name -> YANG source map, or None when the requested module is
+    unknown (the caller then sends an rpc-error). get-schema is otherwise unserved in
+    this codebase, so this lets any mock/server answer it from a source corpus."""
+    ident = get_schema_identifier(op)
+    if ident is not None:
+        src = sources.get(ident)
+        if src is not None:
+            return xml.Node("data", nsdefs=[(None, NS_NETCONF_MONITORING)], text=src)
+    return None

--- a/src/swyang.act
+++ b/src/swyang.act
@@ -2287,3 +2287,5463 @@ ietf_yang_library = r"""module ietf-yang-library {
   }
 }
 """
+
+ietf_yang_push = r"""module ietf-yang-push {
+  yang-version 1.1;
+  namespace "urn:ietf:params:xml:ns:yang:ietf-yang-push";
+  prefix yp;
+
+  import ietf-yang-types {
+    prefix yang;
+    reference
+      "RFC 6991: Common YANG Data Types";
+  }
+  import ietf-subscribed-notifications {
+    prefix sn;
+    reference
+      "RFC 8639: Subscription to YANG Notifications";
+  }
+  import ietf-datastores {
+    prefix ds;
+    reference
+      "RFC 8342: Network Management Datastore Architecture (NMDA)";
+  }
+  import ietf-restconf {
+    prefix rc;
+    reference
+      "RFC 8040: RESTCONF Protocol";
+  }
+  import ietf-yang-patch {
+    prefix ypatch;
+    reference
+      "RFC 8072: YANG Patch Media Type";
+  }
+
+  organization
+    "IETF NETCONF (Network Configuration) Working Group";
+  contact
+    "WG Web:  <https:/datatracker.ietf.org/wg/netconf/>
+     WG List: <mailto:netconf@ietf.org>
+
+     Author:  Alexander Clemm
+              <mailto:ludwig@clemm.org>
+
+     Author:  Eric Voit
+              <mailto:evoit@cisco.com>";
+  description
+    "This module contains YANG specifications for YANG-Push.
+
+     The key words 'MUST', 'MUST NOT', 'REQUIRED', 'SHALL', 'SHALL
+     NOT', 'SHOULD', 'SHOULD NOT', 'RECOMMENDED', 'NOT RECOMMENDED',
+     'MAY', and 'OPTIONAL' in this document are to be interpreted as
+     described in BCP 14 (RFC 2119) (RFC 8174) when, and only when,
+     they appear in all capitals, as shown here.
+
+     Copyright (c) 2019 IETF Trust and the persons identified as
+     authors of the code.  All rights reserved.
+
+     Redistribution and use in source and binary forms, with or
+     without modification, is permitted pursuant to, and subject to
+     the license terms contained in, the Simplified BSD License set
+     forth in Section 4.c of the IETF Trust's Legal Provisions
+     Relating to IETF Documents
+     (https://trustee.ietf.org/license-info).
+
+     This version of this YANG module is part of RFC 8641; see the
+     RFC itself for full legal notices.";
+
+  revision 2019-09-09 {
+    description
+      "Initial revision.";
+    reference
+      "RFC 8641: Subscriptions to YANG Datastores";
+  }
+
+  rc:yang-data "resync-subscription-error" {
+    container resync-subscription-error {
+      description
+        "If a 'resync-subscription' RPC fails, the subscription is
+         not resynced and the RPC error response MUST indicate the
+         reason for this failure.  This yang-data MAY be inserted as
+         structured data in a subscription's RPC error response
+         to indicate the reason for the failure.";
+      leaf reason {
+        type identityref {
+          base resync-subscription-error;
+        }
+        mandatory true;
+        description
+          "Indicates the reason why the publisher has declined a
+           request for subscription resynchronization.";
+      }
+      uses hints;
+    }
+  }
+  rc:yang-data "establish-subscription-datastore-error-info" {
+    container establish-subscription-datastore-error-info {
+      description
+        "If any 'establish-subscription' RPC parameters are
+         unsupportable against the datastore, a subscription is not
+         created and the RPC error response MUST indicate the reason
+         why the subscription failed to be created.  This yang-data
+         MAY be inserted as structured data in a subscription's
+         RPC error response to indicate the reason for the failure.
+         This yang-data MUST be inserted if hints are to be provided
+         back to the subscriber.";
+      leaf reason {
+        type identityref {
+          base sn:establish-subscription-error;
+        }
+        description
+          "Indicates the reason why the subscription has failed to
+           be created to a targeted datastore.";
+      }
+      uses hints;
+    }
+  }
+  rc:yang-data "modify-subscription-datastore-error-info" {
+    container modify-subscription-datastore-error-info {
+      description
+        "This yang-data MAY be provided as part of a subscription's
+         RPC error response when there is a failure of a
+         'modify-subscription' RPC that has been made against a
+         datastore.  This yang-data MUST be used if hints are to be
+         provided back to the subscriber.";
+      leaf reason {
+        type identityref {
+          base sn:modify-subscription-error;
+        }
+        description
+          "Indicates the reason why the subscription has failed to
+           be modified.";
+      }
+      uses hints;
+    }
+  }
+
+  feature on-change {
+    description
+      "This feature indicates that on-change triggered subscriptions
+       are supported.";
+  }
+
+  identity resync-subscription-error {
+    description
+      "Problem found while attempting to fulfill a
+       'resync-subscription' RPC request.";
+  }
+
+  identity cant-exclude {
+    base sn:establish-subscription-error;
+    description
+      "Unable to remove the set of 'excluded-change' parameters.
+       This means that the publisher is unable to restrict
+       'push-change-update' notifications to just the change types
+       requested for this subscription.";
+  }
+
+  identity datastore-not-subscribable {
+    base sn:establish-subscription-error;
+    base sn:subscription-terminated-reason;
+    description
+      "This is not a subscribable datastore.";
+  }
+
+  identity no-such-subscription-resync {
+    base resync-subscription-error;
+    description
+      "The referenced subscription doesn't exist.  This may be as a
+       result of a nonexistent subscription ID, an ID that belongs to
+       another subscriber, or an ID for a configured subscription.";
+  }
+
+  identity on-change-unsupported {
+    base sn:establish-subscription-error;
+    description
+      "On-change is not supported for any objects that are
+       selectable by this filter.";
+  }
+
+  identity on-change-sync-unsupported {
+    base sn:establish-subscription-error;
+    description
+      "Neither 'sync-on-start' nor resynchronization is supported for
+       this subscription.  This error will be used for two reasons:
+       (1) if an 'establish-subscription' RPC includes
+       'sync-on-start' but the publisher can't support sending a
+       'push-update' for this subscription for reasons other than
+       'on-change-unsupported' or 'sync-too-big'
+       (2) if the 'resync-subscription' RPC is invoked for either an
+       existing periodic subscription or an on-change subscription
+       that can't support resynchronization.";
+  }
+
+  identity period-unsupported {
+    base sn:establish-subscription-error;
+    base sn:modify-subscription-error;
+    base sn:subscription-suspended-reason;
+    description
+      "The requested time period or 'dampening-period' is too short.
+       This can be for both periodic and on-change subscriptions
+       (with or without dampening).  Hints suggesting alternative
+       periods may be returned as supplemental information.";
+  }
+
+  identity update-too-big {
+    base sn:establish-subscription-error;
+    base sn:modify-subscription-error;
+    base sn:subscription-suspended-reason;
+    description
+      "Periodic or on-change push update data trees exceed a maximum
+       size limit.  Hints on the estimated size of what was too big
+       may be returned as supplemental information.";
+  }
+
+  identity sync-too-big {
+    base sn:establish-subscription-error;
+    base sn:modify-subscription-error;
+    base resync-subscription-error;
+    base sn:subscription-suspended-reason;
+    description
+      "The 'sync-on-start' or resynchronization data tree exceeds a
+       maximum size limit.  Hints on the estimated size of what was
+       too big may be returned as supplemental information.";
+  }
+
+  identity unchanging-selection {
+    base sn:establish-subscription-error;
+    base sn:modify-subscription-error;
+    base sn:subscription-terminated-reason;
+    description
+      "The selection filter is unlikely to ever select data tree
+       nodes.  This means that based on the subscriber's current
+       access rights, the publisher recognizes that the selection
+       filter is unlikely to ever select data tree nodes that change.
+       Examples for this might be that the node or subtree doesn't
+       exist, read access is not permitted for a receiver, or static
+       objects that only change at reboot have been chosen.";
+  }
+
+  typedef change-type {
+    type enumeration {
+      enum "create" {
+        description
+          "A change that refers to the creation of a new
+           datastore node.";
+      }
+      enum "delete" {
+        description
+          "A change that refers to the deletion of a
+           datastore node.";
+      }
+      enum "insert" {
+        description
+          "A change that refers to the insertion of a new
+           user-ordered datastore node.";
+      }
+      enum "move" {
+        description
+          "A change that refers to a reordering of the target
+           datastore node.";
+      }
+      enum "replace" {
+        description
+          "A change that refers to a replacement of the target
+           datastore node's value.";
+      }
+    }
+    description
+      "Specifies different types of datastore changes.
+
+       This type is based on the edit operations defined for
+       YANG Patch, with the difference that it is valid for a
+       receiver to process an update record that performs a
+       'create' operation on a datastore node the receiver believes
+       exists or to process a delete on a datastore node the
+       receiver believes is missing.";
+    reference
+      "RFC 8072: YANG Patch Media Type, Section 2.5";
+  }
+
+  typedef selection-filter-ref {
+    type leafref {
+      path "/sn:filters/yp:selection-filter/yp:filter-id";
+    }
+    description
+      "This type is used to reference a selection filter.";
+  }
+
+  typedef centiseconds {
+    type uint32;
+    description
+      "A period of time, measured in units of 0.01 seconds.";
+  }
+
+  grouping datastore-criteria {
+    description
+      "A grouping to define criteria for which selected objects from
+       a targeted datastore should be included in push updates.";
+    leaf datastore {
+      type identityref {
+        base ds:datastore;
+      }
+      mandatory true;
+      description
+        "Datastore from which to retrieve data.";
+    }
+    uses selection-filter-objects;
+  }
+
+  grouping selection-filter-types {
+    description
+      "This grouping defines the types of selectors for objects
+       from a datastore.";
+    choice filter-spec {
+      description
+        "The content filter specification for this request.";
+      anydata datastore-subtree-filter {
+        if-feature "sn:subtree";
+        description
+          "This parameter identifies the portions of the
+           target datastore to retrieve.";
+        reference
+          "RFC 6241: Network Configuration Protocol (NETCONF),
+                     Section 6";
+      }
+      leaf datastore-xpath-filter {
+        if-feature "sn:xpath";
+        type yang:xpath1.0;
+        description
+          "This parameter contains an XPath expression identifying
+           the portions of the target datastore to retrieve.
+
+           If the expression returns a node set, all nodes in the
+           node set are selected by the filter.  Otherwise, if the
+           expression does not return a node set, the filter
+           doesn't select any nodes.
+
+           The expression is evaluated in the following XPath
+           context:
+
+           o  The set of namespace declarations is the set of prefix
+              and namespace pairs for all YANG modules implemented
+              by the server, where the prefix is the YANG module
+              name and the namespace is as defined by the
+              'namespace' statement in the YANG module.
+
+              If the leaf is encoded in XML, all namespace
+              declarations in scope on the 'stream-xpath-filter'
+              leaf element are added to the set of namespace
+              declarations.  If a prefix found in the XML is
+              already present in the set of namespace declarations,
+              the namespace in the XML is used.
+
+           o  The set of variable bindings is empty.
+
+           o  The function library is comprised of the core
+              function library and the XPath functions defined in
+              Section 10 in RFC 7950.
+
+           o  The context node is the root node of the target
+              datastore.";
+        reference
+          "XML Path Language (XPath) Version 1.0
+           (https://www.w3.org/TR/1999/REC-xpath-19991116)
+           RFC 7950: The YANG 1.1 Data Modeling Language,
+                     Section 10";
+      }
+    }
+  }
+
+  grouping selection-filter-objects {
+    description
+      "This grouping defines a selector for objects from a
+       datastore.";
+    choice selection-filter {
+      description
+        "The source of the selection filter applied to the
+         subscription.  This will either (1) come referenced from a
+         global list or (2) be provided in the subscription itself.";
+      case by-reference {
+        description
+          "Incorporates a filter that has been configured
+           separately.";
+        leaf selection-filter-ref {
+          type selection-filter-ref;
+          mandatory true;
+          description
+            "References an existing selection filter that is to be
+             applied to the subscription.";
+        }
+      }
+      case within-subscription {
+        description
+          "A local definition allows a filter to have the same
+           lifecycle as the subscription.";
+        uses selection-filter-types;
+      }
+    }
+  }
+
+  grouping update-policy-modifiable {
+    description
+      "This grouping describes the datastore-specific subscription
+       conditions that can be changed during the lifetime of the
+       subscription.";
+    choice update-trigger {
+      description
+        "Defines necessary conditions for sending an event record to
+         the subscriber.";
+      case periodic {
+        container periodic {
+          presence "indicates a periodic subscription";
+          description
+            "The publisher is requested to periodically notify the
+             receiver regarding the current values of the datastore
+             as defined by the selection filter.";
+          leaf period {
+            type centiseconds;
+            mandatory true;
+            description
+              "Duration of time that should occur between periodic
+               push updates, in units of 0.01 seconds.";
+          }
+          leaf anchor-time {
+            type yang:date-and-time;
+            description
+              "Designates a timestamp before or after which a series
+               of periodic push updates are determined.  The next
+               update will take place at a point in time that is a
+               multiple of a period from the 'anchor-time'.
+               For example, for an 'anchor-time' that is set for the
+               top of a particular minute and a period interval of a
+               minute, updates will be sent at the top of every
+               minute that this subscription is active.";
+          }
+        }
+      }
+      case on-change {
+        if-feature "on-change";
+        container on-change {
+          presence "indicates an on-change subscription";
+          description
+            "The publisher is requested to notify the receiver
+             regarding changes in values in the datastore subset as
+             defined by a selection filter.";
+          leaf dampening-period {
+            type centiseconds;
+            default "0";
+            description
+              "Specifies the minimum interval between the assembly of
+               successive update records for a single receiver of a
+               subscription.  Whenever subscribed objects change and
+               a dampening-period interval (which may be zero) has
+               elapsed since the previous update record creation for
+               a receiver, any subscribed objects and properties
+               that have changed since the previous update record
+               will have their current values marshalled and placed
+               in a new update record.";
+          }
+        }
+      }
+    }
+  }
+
+  grouping update-policy {
+    description
+      "This grouping describes the datastore-specific subscription
+       conditions of a subscription.";
+    uses update-policy-modifiable {
+      augment "update-trigger/on-change/on-change" {
+        description
+          "Includes objects that are not modifiable once a
+           subscription is established.";
+        leaf sync-on-start {
+          type boolean;
+          default "true";
+          description
+            "When this object is set to 'false', (1) it restricts an
+             on-change subscription from sending 'push-update'
+             notifications and (2) pushing a full selection per the
+             terms of the selection filter MUST NOT be done for
+             this subscription.  Only updates about changes
+             (i.e., only 'push-change-update' notifications)
+             are sent.  When set to 'true' (the default behavior),
+             in order to facilitate a receiver's synchronization,
+             a full update is sent, via a 'push-update' notification,
+             when the subscription starts.  After that,
+             'push-change-update' notifications are exclusively sent,
+             unless the publisher chooses to resync the subscription
+             via a new 'push-update' notification.";
+        }
+        leaf-list excluded-change {
+          type change-type;
+          description
+            "Used to restrict which changes trigger an update.  For
+             example, if a 'replace' operation is excluded, only the
+             creation and deletion of objects are reported.";
+        }
+      }
+    }
+  }
+
+  grouping hints {
+    description
+      "Parameters associated with an error for a subscription
+       made upon a datastore.";
+    leaf period-hint {
+      type centiseconds;
+      description
+        "Returned when the requested time period is too short.  This
+         hint can assert a viable period for either a periodic push
+         cadence or an on-change dampening interval.";
+    }
+    leaf filter-failure-hint {
+      type string;
+      description
+        "Information describing where and/or why a provided filter
+         was unsupportable for a subscription.";
+    }
+    leaf object-count-estimate {
+      type uint32;
+      description
+        "If there are too many objects that could potentially be
+         returned by the selection filter, this identifies the
+         estimate of the number of objects that the filter would
+         potentially pass.";
+    }
+    leaf object-count-limit {
+      type uint32;
+      description
+        "If there are too many objects that could be returned by
+         the selection filter, this identifies the upper limit of
+         the publisher's ability to service this subscription.";
+    }
+    leaf kilobytes-estimate {
+      type uint32;
+      description
+        "If the returned information could be beyond the capacity
+         of the publisher, this would identify the estimated
+         data size that could result from this selection filter.";
+    }
+    leaf kilobytes-limit {
+      type uint32;
+      description
+        "If the returned information would be beyond the capacity
+         of the publisher, this identifies the upper limit of the
+         publisher's ability to service this subscription.";
+    }
+  }
+
+  augment "/sn:establish-subscription/sn:input" {
+    description
+      "This augmentation adds additional subscription parameters
+       that apply specifically to datastore updates to RPC input.";
+    uses update-policy;
+  }
+  augment "/sn:establish-subscription/sn:input/sn:target" {
+    description
+      "This augmentation adds the datastore as a valid target
+       for the subscription to RPC input.";
+    case datastore {
+      description
+        "Information specifying the parameters of a request for a
+         datastore subscription.";
+      uses datastore-criteria;
+    }
+  }
+  augment "/sn:modify-subscription/sn:input" {
+    description
+      "This augmentation adds additional subscription parameters
+       specific to datastore updates.";
+    uses update-policy-modifiable;
+  }
+  augment "/sn:modify-subscription/sn:input/sn:target" {
+    description
+      "This augmentation adds the datastore as a valid target
+       for the subscription to RPC input.";
+    case datastore {
+      description
+        "Information specifying the parameters of a request for a
+         datastore subscription.";
+      uses datastore-criteria;
+    }
+  }
+  augment "/sn:subscription-started" {
+    description
+      "This augmentation adds datastore-specific objects to
+       the notification that a subscription has started.";
+    uses update-policy;
+  }
+  augment "/sn:subscription-started/sn:target" {
+    description
+      "This augmentation allows the datastore to be included as
+       part of the notification that a subscription has started.";
+    case datastore {
+      uses datastore-criteria {
+        refine "selection-filter/within-subscription" {
+          description
+            "Specifies the selection filter and where it originated
+             from.  If the 'selection-filter-ref' is populated, the
+             filter in the subscription came from the 'filters'
+             container.  Otherwise, it is populated in-line as part
+             of the subscription itself.";
+        }
+      }
+    }
+  }
+  augment "/sn:subscription-modified" {
+    description
+      "This augmentation adds datastore-specific objects to
+       the notification that a subscription has been modified.";
+    uses update-policy;
+  }
+  augment "/sn:subscription-modified/sn:target" {
+    description
+      "This augmentation allows the datastore to be included as
+       part of the notification that a subscription has been
+       modified.";
+    case datastore {
+      uses datastore-criteria {
+        refine "selection-filter/within-subscription" {
+          description
+            "Specifies the selection filter and where it originated
+             from.  If the 'selection-filter-ref' is populated, the
+             filter in the subscription came from the 'filters'
+             container.  Otherwise, it is populated in-line as part
+             of the subscription itself.";
+        }
+      }
+    }
+  }
+  augment "/sn:filters" {
+    description
+      "This augmentation allows the datastore to be included as part
+       of the selection-filtering criteria for a subscription.";
+    list selection-filter {
+      key "filter-id";
+      description
+        "A list of preconfigured filters that can be applied
+         to datastore subscriptions.";
+      leaf filter-id {
+        type string;
+        description
+          "An identifier to differentiate between selection
+           filters.";
+      }
+      uses selection-filter-types;
+    }
+  }
+  augment "/sn:subscriptions/sn:subscription" {
+    when "yp:datastore";
+    description
+      "This augmentation adds objects to a subscription that are
+       specific to a datastore subscription, i.e., a subscription to
+       a stream of datastore node updates.";
+    uses update-policy;
+  }
+  augment "/sn:subscriptions/sn:subscription/sn:target" {
+    description
+      "This augmentation allows the datastore to be included as
+       part of the selection-filtering criteria for a subscription.";
+    case datastore {
+      uses datastore-criteria;
+    }
+  }
+
+  rpc resync-subscription {
+    if-feature "on-change";
+    description
+      "This RPC allows a subscriber of an active on-change
+       subscription to request a full push of objects.
+
+       A successful invocation results in a 'push-update' of all
+       datastore nodes that the subscriber is permitted to access.
+       This RPC can only be invoked on the same session on which the
+       subscription is currently active.  In the case of an error, a
+       'resync-subscription-error' is sent as part of an error
+       response.";
+
+    input {
+      leaf id {
+        type sn:subscription-id;
+        mandatory true;
+        description
+          "Identifier of the subscription that is to be resynced.";
+      }
+    }
+  }
+
+  notification push-update {
+    description
+      "This notification contains a push update that in turn contains
+       data subscribed to via a subscription.  In the case of a
+       periodic subscription, this notification is sent for periodic
+       updates.  It can also be used for synchronization updates of
+       an on-change subscription.  This notification shall only be
+       sent to receivers of a subscription.  It does not constitute
+       a general-purpose notification that would be subscribable as
+       part of the NETCONF event stream by any receiver.";
+    leaf id {
+      type sn:subscription-id;
+      description
+        "This references the subscription that drove the
+         notification to be sent.";
+    }
+    anydata datastore-contents {
+      description
+        "This contains the updated data.  It constitutes a snapshot
+         at the time of update of the set of data that has been
+         subscribed to.  The snapshot corresponds to the same
+         snapshot that would be returned in a corresponding 'get'
+         operation with the same selection filter parameters
+         applied.";
+    }
+    leaf incomplete-update {
+      type empty;
+      description
+        "This is a flag that indicates that not all datastore
+         nodes subscribed to are included with this update.  In
+         other words, the publisher has failed to fulfill its full
+         subscription obligations and, despite its best efforts, is
+         providing an incomplete set of objects.";
+    }
+  }
+  notification push-change-update {
+    if-feature "on-change";
+    description
+      "This notification contains an on-change push update.  This
+       notification shall only be sent to the receivers of a
+       subscription.  It does not constitute a general-purpose
+       notification that would be subscribable as part of the
+       NETCONF event stream by any receiver.";
+    leaf id {
+      type sn:subscription-id;
+      description
+        "This references the subscription that drove the
+         notification to be sent.";
+    }
+    container datastore-changes {
+      description
+        "This contains the set of datastore changes of the target
+         datastore, starting at the time of the previous update, per
+         the terms of the subscription.";
+      uses ypatch:yang-patch;
+    }
+    leaf incomplete-update {
+      type empty;
+      description
+        "The presence of this object indicates that not all changes
+         that have occurred since the last update are included with
+         this update.  In other words, the publisher has failed to
+         fulfill its full subscription obligations -- for example,
+         in cases where it was not able to keep up with a burst of
+         changes.";
+    }
+  }
+}
+"""
+
+ietf_subscribed_notifications = r"""module ietf-subscribed-notifications {
+  yang-version 1.1;
+  namespace "urn:ietf:params:xml:ns:yang:ietf-subscribed-notifications";
+  prefix sn;
+
+  import ietf-inet-types {
+    prefix inet;
+    reference
+      "RFC 6991: Common YANG Data Types";
+  }
+  import ietf-interfaces {
+    prefix if;
+    reference
+      "RFC 8343: A YANG Data Model for Interface Management";
+  }
+  import ietf-netconf-acm {
+    prefix nacm;
+    reference
+      "RFC 8341: Network Configuration Access Control Model";
+  }
+  import ietf-network-instance {
+    prefix ni;
+    reference
+      "RFC 8529: YANG Data Model for Network Instances";
+  }
+  import ietf-restconf {
+    prefix rc;
+    reference
+      "RFC 8040: RESTCONF Protocol";
+  }
+  import ietf-yang-types {
+    prefix yang;
+    reference
+      "RFC 6991: Common YANG Data Types";
+  }
+
+  organization
+    "IETF NETCONF (Network Configuration) Working Group";
+  contact
+    "WG Web:  <https:/datatracker.ietf.org/wg/netconf/>
+     WG List: <mailto:netconf@ietf.org>
+
+     Author:  Alexander Clemm
+              <mailto:ludwig@clemm.org>
+
+     Author:  Eric Voit
+              <mailto:evoit@cisco.com>
+
+     Author:  Alberto Gonzalez Prieto
+              <mailto:alberto.gonzalez@microsoft.com>
+
+     Author:  Einar Nilsen-Nygaard
+              <mailto:einarnn@cisco.com>
+
+     Author:  Ambika Prasad Tripathy
+              <mailto:ambtripa@cisco.com>";
+  description
+    "This module defines a YANG data model for subscribing to event
+     records and receiving matching content in notification messages.
+
+     The key words 'MUST', 'MUST NOT', 'REQUIRED', 'SHALL', 'SHALL
+     NOT', 'SHOULD', 'SHOULD NOT', 'RECOMMENDED', 'NOT RECOMMENDED',
+     'MAY', and 'OPTIONAL' in this document are to be interpreted as
+     described in BCP 14 (RFC 2119) (RFC 8174) when, and only when,
+     they appear in all capitals, as shown here.
+
+     Copyright (c) 2019 IETF Trust and the persons identified as
+     authors of the code.  All rights reserved.
+
+     Redistribution and use in source and binary forms, with or
+     without modification, is permitted pursuant to, and subject to
+     the license terms contained in, the Simplified BSD License set
+     forth in Section 4.c of the IETF Trust's Legal Provisions
+     Relating to IETF Documents
+     (https://trustee.ietf.org/license-info).
+
+     This version of this YANG module is part of RFC 8639; see the
+     RFC itself for full legal notices.";
+
+  revision 2019-09-09 {
+    description
+      "Initial version.";
+    reference
+      "RFC 8639: A YANG Data Model for Subscriptions to
+                 Event Notifications";
+  }
+
+  extension subscription-state-notification {
+    description
+      "This statement applies only to notifications.  It indicates
+       that the notification is a subscription state change
+       notification.  Therefore, it does not participate in a regular
+       event stream and does not need to be specifically subscribed
+       to in order to be received.  This statement can only occur as
+       a substatement of the YANG 'notification' statement.  This
+       statement is not for use outside of this YANG module.";
+  }
+
+  rc:yang-data "establish-subscription-stream-error-info" {
+    container establish-subscription-stream-error-info {
+      description
+        "If any 'establish-subscription' RPC parameters are
+         unsupportable against the event stream, a subscription
+         is not created and the RPC error response MUST indicate the
+         reason why the subscription failed to be created.  This
+         yang-data MAY be inserted as structured data in a
+         subscription's RPC error response to indicate the reason for
+         the failure.  This yang-data MUST be inserted if hints are
+         to be provided back to the subscriber.";
+      leaf reason {
+        type identityref {
+          base establish-subscription-error;
+        }
+        description
+          "Indicates the reason why the subscription has failed to
+           be created to a targeted event stream.";
+      }
+      leaf filter-failure-hint {
+        type string;
+        description
+          "Information describing where and/or why a provided
+           filter was unsupportable for a subscription.  The
+           syntax and semantics of this hint are
+           implementation specific.";
+      }
+    }
+  }
+  rc:yang-data "modify-subscription-stream-error-info" {
+    container modify-subscription-stream-error-info {
+      description
+        "This yang-data MAY be provided as part of a subscription's
+         RPC error response when there is a failure of a
+         'modify-subscription' RPC that has been made against an
+         event stream.  This yang-data MUST be used if hints are to
+         be provided back to the subscriber.";
+      leaf reason {
+        type identityref {
+          base modify-subscription-error;
+        }
+        description
+          "Information in a 'modify-subscription' RPC error response
+           that indicates the reason why the subscription to an event
+           stream has failed to be modified.";
+      }
+      leaf filter-failure-hint {
+        type string;
+        description
+          "Information describing where and/or why a provided
+           filter was unsupportable for a subscription.  The syntax
+           and semantics of this hint are
+           implementation specific.";
+      }
+    }
+  }
+  rc:yang-data "delete-subscription-error-info" {
+    container delete-subscription-error-info {
+      description
+        "If a 'delete-subscription' RPC or a 'kill-subscription' RPC
+         fails, the subscription is not deleted and the RPC error
+         response MUST indicate the reason for this failure.  This
+         yang-data MAY be inserted as structured data in a
+         subscription's RPC error response to indicate the reason
+         for the failure.";
+      leaf reason {
+        type identityref {
+          base delete-subscription-error;
+        }
+        mandatory true;
+        description
+          "Indicates the reason why the subscription has failed to be
+           deleted.";
+      }
+    }
+  }
+
+  feature configured {
+    description
+      "This feature indicates that configuration of subscriptions is
+       supported.";
+  }
+
+  feature dscp {
+    description
+      "This feature indicates that a publisher supports the ability
+       to set the Differentiated Services Code Point (DSCP) value in
+       outgoing packets.";
+  }
+
+  feature encode-json {
+    description
+      "This feature indicates that JSON encoding of notification
+       messages is supported.";
+  }
+
+  feature encode-xml {
+    description
+      "This feature indicates that XML encoding of notification
+       messages is supported.";
+  }
+
+  feature interface-designation {
+    description
+      "This feature indicates that a publisher supports sourcing all
+       receiver interactions for a configured subscription from a
+       single designated egress interface.";
+  }
+
+  feature qos {
+    description
+      "This feature indicates that a publisher supports absolute
+       dependencies of one subscription's traffic over another
+       as well as weighted bandwidth sharing between subscriptions.
+       Both of these are Quality of Service (QoS) features that allow
+       differentiated treatment of notification messages between a
+       publisher and a specific receiver.";
+  }
+
+  feature replay {
+    description
+      "This feature indicates that historical event record replay is
+       supported.  With replay, it is possible for past event records
+       to be streamed in chronological order.";
+  }
+
+  feature subtree {
+    description
+      "This feature indicates support for YANG subtree filtering.";
+    reference
+      "RFC 6241: Network Configuration Protocol (NETCONF),
+                 Section 6";
+  }
+
+  feature supports-vrf {
+    description
+      "This feature indicates that a publisher supports VRF
+       configuration for configured subscriptions.  VRF support for
+       dynamic subscriptions does not require this feature.";
+    reference
+      "RFC 8529: YANG Data Model for Network Instances,
+                 Section 6";
+  }
+
+  feature xpath {
+    description
+      "This feature indicates support for XPath filtering.";
+    reference
+      "XML Path Language (XPath) Version 1.0
+       (https://www.w3.org/TR/1999/REC-xpath-19991116)";
+  }
+
+  identity delete-subscription-error {
+    description
+      "Base identity for the problem found while attempting to
+       fulfill either a 'delete-subscription' RPC request or a
+       'kill-subscription' RPC request.";
+  }
+
+  identity establish-subscription-error {
+    description
+      "Base identity for the problem found while attempting to
+       fulfill an 'establish-subscription' RPC request.";
+  }
+
+  identity modify-subscription-error {
+    description
+      "Base identity for the problem found while attempting to
+       fulfill a 'modify-subscription' RPC request.";
+  }
+
+  identity subscription-suspended-reason {
+    description
+      "Base identity for the problem condition communicated to a
+       receiver as part of a 'subscription-suspended'
+       notification.";
+  }
+
+  identity subscription-terminated-reason {
+    description
+      "Base identity for the problem condition communicated to a
+       receiver as part of a 'subscription-terminated'
+       notification.";
+  }
+
+  identity dscp-unavailable {
+    if-feature "dscp";
+    base establish-subscription-error;
+    description
+      "The publisher is unable to mark notification messages with
+       prioritization information in a way that will be respected
+       during network transit.";
+  }
+
+  identity encoding-unsupported {
+    base establish-subscription-error;
+    description
+      "Unable to encode notification messages in the desired
+       format.";
+  }
+
+  identity filter-unavailable {
+    base subscription-terminated-reason;
+    description
+      "Referenced filter does not exist.  This means a receiver is
+       referencing a filter that doesn't exist or to which it
+       does not have access permissions.";
+  }
+
+  identity filter-unsupported {
+    base establish-subscription-error;
+    base modify-subscription-error;
+    description
+      "Cannot parse syntax in the filter.  This failure can be from
+       a syntax error or a syntax too complex to be processed by the
+       publisher.";
+  }
+
+  identity insufficient-resources {
+    base establish-subscription-error;
+    base modify-subscription-error;
+    base subscription-suspended-reason;
+    description
+      "The publisher does not have sufficient resources to support
+       the requested subscription.  An example might be that
+       allocated CPU is too limited to generate the desired set of
+       notification messages.";
+  }
+
+  identity no-such-subscription {
+    base modify-subscription-error;
+    base delete-subscription-error;
+    base subscription-terminated-reason;
+    description
+      "Referenced subscription doesn't exist.  This may be as a
+       result of a nonexistent subscription ID, an ID that belongs to
+       another subscriber, or an ID for a configured subscription.";
+  }
+
+  identity replay-unsupported {
+    if-feature "replay";
+    base establish-subscription-error;
+    description
+      "Replay cannot be performed for this subscription.  This means
+       the publisher will not provide the requested historic
+       information from the event stream via replay to this
+       receiver.";
+  }
+
+  identity stream-unavailable {
+    base subscription-terminated-reason;
+    description
+      "Not a subscribable event stream.  This means the referenced
+       event stream is not available for subscription by the
+       receiver.";
+  }
+
+  identity suspension-timeout {
+    base subscription-terminated-reason;
+    description
+      "Termination of a previously suspended subscription.  The
+       publisher has eliminated the subscription, as it exceeded a
+       time limit for suspension.";
+  }
+
+  identity unsupportable-volume {
+    base subscription-suspended-reason;
+    description
+      "The publisher does not have the network bandwidth needed to
+       get the volume of generated information intended for a
+       receiver.";
+  }
+
+  identity configurable-encoding {
+    description
+      "If a transport identity derives from this identity, it means
+       that it supports configurable encodings.  An example of a
+       configurable encoding might be a new identity such as
+       'encode-cbor'.  Such an identity could use
+       'configurable-encoding' as its base.  This would allow a
+       dynamic subscription encoded in JSON (RFC 8259) to request
+       that notification messages be encoded via the Concise Binary
+       Object Representation (CBOR) (RFC 7049).  Further details for
+       any specific configurable encoding would be explored in a
+       transport document based on this specification.";
+    reference
+      "RFC 8259: The JavaScript Object Notation (JSON) Data
+                 Interchange Format
+       RFC 7049: Concise Binary Object Representation (CBOR)";
+  }
+
+  identity encoding {
+    description
+      "Base identity to represent data encodings.";
+  }
+
+  identity encode-xml {
+    if-feature "encode-xml";
+    base encoding;
+    description
+      "Encode data using XML as described in RFC 7950.";
+    reference
+      "RFC 7950: The YANG 1.1 Data Modeling Language";
+  }
+
+  identity encode-json {
+    if-feature "encode-json";
+    base encoding;
+    description
+      "Encode data using JSON as described in RFC 7951.";
+    reference
+      "RFC 7951: JSON Encoding of Data Modeled with YANG";
+  }
+
+  identity transport {
+    description
+      "An identity that represents the underlying mechanism for
+       passing notification messages.";
+  }
+
+  typedef encoding {
+    type identityref {
+      base encoding;
+    }
+    description
+      "Specifies a data encoding, e.g., for a data subscription.";
+  }
+
+  typedef stream-filter-ref {
+    type leafref {
+      path "/sn:filters/sn:stream-filter/sn:name";
+    }
+    description
+      "This type is used to reference an event stream filter.";
+  }
+
+  typedef stream-ref {
+    type leafref {
+      path "/sn:streams/sn:stream/sn:name";
+    }
+    description
+      "This type is used to reference a system-provided
+       event stream.";
+  }
+
+  typedef subscription-id {
+    type uint32;
+    description
+      "A type for subscription identifiers.";
+  }
+
+  typedef transport {
+    type identityref {
+      base transport;
+    }
+    description
+      "Specifies the transport used to send notification messages
+       to a receiver.";
+  }
+
+  grouping stream-filter-elements {
+    description
+      "This grouping defines the base for filters applied to event
+       streams.";
+    choice filter-spec {
+      description
+        "The content filter specification for this request.";
+      anydata stream-subtree-filter {
+        if-feature "subtree";
+        description
+          "Event stream evaluation criteria encoded in the syntax of
+           a subtree filter as defined in RFC 6241, Section 6.
+
+           The subtree filter is applied to the representation of
+           individual, delineated event records as contained in the
+           event stream.
+
+           If the subtree filter returns a non-empty node set, the
+           filter matches the event record, and the event record is
+           included in the notification message sent to the
+           receivers.";
+        reference
+          "RFC 6241: Network Configuration Protocol (NETCONF),
+                     Section 6";
+      }
+      leaf stream-xpath-filter {
+        if-feature "xpath";
+        type yang:xpath1.0;
+        description
+          "Event stream evaluation criteria encoded in the syntax of
+           an XPath 1.0 expression.
+
+           The XPath expression is evaluated on the representation of
+           individual, delineated event records as contained in
+           the event stream.
+
+           The result of the XPath expression is converted to a
+           boolean value using the standard XPath 1.0 rules.  If the
+           boolean value is 'true', the filter matches the event
+           record, and the event record is included in the
+           notification message sent to the receivers.
+
+           The expression is evaluated in the following XPath
+           context:
+
+              o  The set of namespace declarations is the set of
+                 prefix and namespace pairs for all YANG modules
+                 implemented by the server, where the prefix is the
+                 YANG module name and the namespace is as defined by
+                 the 'namespace' statement in the YANG module.
+
+                 If the leaf is encoded in XML, all namespace
+                 declarations in scope on the 'stream-xpath-filter'
+                 leaf element are added to the set of namespace
+                 declarations.  If a prefix found in the XML is
+                 already present in the set of namespace
+                 declarations, the namespace in the XML is used.
+
+              o  The set of variable bindings is empty.
+
+              o  The function library is comprised of the core
+                 function library and the XPath functions defined in
+                 Section 10 in RFC 7950.
+
+              o  The context node is the root node.";
+        reference
+          "XML Path Language (XPath) Version 1.0
+           (https://www.w3.org/TR/1999/REC-xpath-19991116)
+           RFC 7950: The YANG 1.1 Data Modeling Language,
+                     Section 10";
+      }
+    }
+  }
+
+  grouping update-qos {
+    description
+      "This grouping describes QoS information concerning a
+       subscription.  This information is passed to lower layers
+       for transport prioritization and treatment.";
+    leaf dscp {
+      if-feature "dscp";
+      type inet:dscp;
+      default "0";
+      description
+        "The desired network transport priority level.  This is the
+         priority set on notification messages encapsulating the
+         results of the subscription.  This transport priority is
+         shared for all receivers of a given subscription.";
+    }
+    leaf weighting {
+      if-feature "qos";
+      type uint8 {
+        range "0 .. 255";
+      }
+      description
+        "Relative weighting for a subscription.  Larger weights get
+         more resources.  Allows an underlying transport layer to
+         perform informed load-balance allocations between various
+         subscriptions.";
+      reference
+        "RFC 7540: Hypertext Transfer Protocol Version 2 (HTTP/2),
+                   Section 5.3.2";
+    }
+    leaf dependency {
+      if-feature "qos";
+      type subscription-id;
+      description
+        "Provides the 'subscription-id' of a parent subscription.
+         The parent subscription has absolute precedence should
+         that parent have push updates ready to egress the publisher.
+         In other words, there should be no streaming of objects from
+         the current subscription if the parent has something ready
+         to push.
+
+         If a dependency is asserted via configuration or via an RPC
+         but the referenced 'subscription-id' does not exist, the
+         dependency is silently discarded.  If a referenced
+         subscription is deleted, this dependency is removed.";
+      reference
+        "RFC 7540: Hypertext Transfer Protocol Version 2 (HTTP/2),
+                   Section 5.3.1";
+    }
+  }
+
+  grouping subscription-policy-modifiable {
+    description
+      "This grouping describes all objects that may be changed
+       in a subscription.";
+    choice target {
+      mandatory true;
+      description
+        "Identifies the source of information against which a
+         subscription is being applied as well as specifics on the
+         subset of information desired from that source.";
+      case stream {
+        choice stream-filter {
+          description
+            "An event stream filter can be applied to a subscription.
+             That filter will either come referenced from a global
+             list or be provided in the subscription itself.";
+          case by-reference {
+            description
+              "Apply a filter that has been configured separately.";
+            leaf stream-filter-name {
+              type stream-filter-ref;
+              mandatory true;
+              description
+                "References an existing event stream filter that is
+                 to be applied to an event stream for the
+                 subscription.";
+            }
+          }
+          case within-subscription {
+            description
+              "A local definition allows a filter to have the same
+               lifecycle as the subscription.";
+            uses stream-filter-elements;
+          }
+        }
+      }
+    }
+    leaf stop-time {
+      type yang:date-and-time;
+      description
+        "Identifies a time after which notification messages for a
+         subscription should not be sent.  If 'stop-time' is not
+         present, the notification messages will continue until the
+         subscription is terminated.  If 'replay-start-time' exists,
+         'stop-time' must be for a subsequent time.  If
+         'replay-start-time' doesn't exist, 'stop-time', when
+         established, must be for a future time.";
+    }
+  }
+
+  grouping subscription-policy-dynamic {
+    description
+      "This grouping describes the only information concerning a
+       subscription that can be passed over the RPCs defined in this
+       data model.";
+    uses subscription-policy-modifiable {
+      augment "target/stream" {
+        description
+          "Adds additional objects that can be modified by an RPC.";
+        leaf stream {
+          type stream-ref {
+            require-instance false;
+          }
+          mandatory true;
+          description
+            "Indicates the event stream to be considered for
+             this subscription.";
+        }
+        leaf replay-start-time {
+          if-feature "replay";
+          type yang:date-and-time;
+          config false;
+          description
+            "Used to trigger the 'replay' feature for a dynamic
+             subscription, where event records that are selected
+             need to be at or after the specified starting time.  If
+             'replay-start-time' is not present, this is not a replay
+             subscription and event record push should start
+             immediately.  It is never valid to specify start times
+             that are later than or equal to the current time.";
+        }
+      }
+    }
+    uses update-qos;
+  }
+
+  grouping subscription-policy {
+    description
+      "This grouping describes the full set of policy information
+       concerning both dynamic and configured subscriptions, with the
+       exclusion of both receivers and networking information
+       specific to the publisher, such as what interface should be
+       used to transmit notification messages.";
+    uses subscription-policy-dynamic;
+    leaf transport {
+      if-feature "configured";
+      type transport;
+      description
+        "For a configured subscription, this leaf specifies the
+         transport used to deliver messages destined for all
+         receivers of that subscription.";
+    }
+    leaf encoding {
+      when "not(../transport) or derived-from(../transport,
+        \"sn:configurable-encoding\")";
+      type encoding;
+      description
+        "The type of encoding for notification messages.  For a
+         dynamic subscription, if not included as part of an
+         'establish-subscription' RPC, the encoding will be populated
+         with the encoding used by that RPC.  For a configured
+         subscription, if not explicitly configured, the encoding
+         will be the default encoding for an underlying transport.";
+    }
+    leaf purpose {
+      if-feature "configured";
+      type string;
+      description
+        "Open text allowing a configuring entity to embed the
+         originator or other specifics of this subscription.";
+    }
+  }
+
+  container streams {
+    config false;
+    description
+      "Contains information on the built-in event streams provided by
+       the publisher.";
+    list stream {
+      key "name";
+      description
+        "Identifies the built-in event streams that are supported by
+         the publisher.";
+      leaf name {
+        type string;
+        description
+          "A handle for a system-provided event stream made up of a
+           sequential set of event records, each of which is
+           characterized by its own domain and semantics.";
+      }
+      leaf description {
+        type string;
+        description
+          "A description of the event stream, including such
+           information as the type of event records that are
+           available in this event stream.";
+      }
+      leaf replay-support {
+        if-feature "replay";
+        type empty;
+        description
+          "Indicates that event record replay is available on this
+           event stream.";
+      }
+      leaf replay-log-creation-time {
+        when "../replay-support";
+        if-feature "replay";
+        type yang:date-and-time;
+        mandatory true;
+        description
+          "The timestamp of the creation of the log used to support
+           the replay function on this event stream.  This time
+           might be earlier than the earliest available information
+           contained in the log.  This object is updated if the log
+           resets for some reason.";
+      }
+      leaf replay-log-aged-time {
+        when "../replay-support";
+        if-feature "replay";
+        type yang:date-and-time;
+        description
+          "The timestamp associated with the last event record that
+           has been aged out of the log.  This timestamp identifies
+           how far back in history this replay log extends, if it
+           doesn't extend back to the 'replay-log-creation-time'.
+           This object MUST be present if replay is supported and any
+           event records have been aged out of the log.";
+      }
+    }
+  }
+  container filters {
+    description
+      "Contains a list of configurable filters that can be applied to
+       subscriptions.  This facilitates the reuse of complex filters
+       once defined.";
+    list stream-filter {
+      key "name";
+      description
+        "A list of preconfigured filters that can be applied to
+         subscriptions.";
+      leaf name {
+        type string;
+        description
+          "A name to differentiate between filters.";
+      }
+      uses stream-filter-elements;
+    }
+  }
+  container subscriptions {
+    description
+      "Contains the list of currently active subscriptions, i.e.,
+       subscriptions that are currently in effect, used for
+       subscription management and monitoring purposes.  This
+       includes subscriptions that have been set up via
+       RPC primitives as well as subscriptions that have been
+       established via configuration.";
+    list subscription {
+      key "id";
+      description
+        "The identity and specific parameters of a subscription.
+         Subscriptions in this list can be created using a control
+         channel or RPC or can be established through configuration.
+
+         If the 'kill-subscription' RPC or configuration operations
+         are used to delete a subscription, a
+         'subscription-terminated' message is sent to any active or
+         suspended receivers.";
+      leaf id {
+        type subscription-id;
+        description
+          "Identifier of a subscription; unique in a given
+           publisher.";
+      }
+      uses subscription-policy {
+        refine "target/stream/stream" {
+          description
+            "Indicates the event stream to be considered for this
+             subscription.  If an event stream has been removed
+             and can no longer be referenced by an active
+             subscription, send a 'subscription-terminated'
+             notification with 'stream-unavailable' as the reason.
+             If a configured subscription refers to a nonexistent
+             event stream, move that subscription to the
+             'invalid' state.";
+        }
+        refine "transport" {
+          description
+            "For a configured subscription, this leaf specifies the
+             transport used to deliver messages destined for all
+             receivers of that subscription.  This object is
+             mandatory for subscriptions in the configuration
+             datastore.  This object (1) is not mandatory for dynamic
+             subscriptions in the operational state datastore and
+             (2) should not be present for other types of dynamic
+             subscriptions.";
+        }
+        augment "target/stream" {
+          description
+            "Enables objects to be added to a configured stream
+             subscription.";
+          leaf configured-replay {
+            if-feature "configured";
+            if-feature "replay";
+            type empty;
+            description
+              "The presence of this leaf indicates that replay for
+               the configured subscription should start at the
+               earliest time in the event log or at the publisher
+               boot time, whichever is later.";
+          }
+        }
+      }
+      choice notification-message-origin {
+        if-feature "configured";
+        description
+          "Identifies the egress interface on the publisher
+           from which notification messages are to be sent.";
+        case interface-originated {
+          description
+            "When notification messages are to egress a specific,
+             designated interface on the publisher.";
+          leaf source-interface {
+            if-feature "interface-designation";
+            type if:interface-ref;
+            description
+              "References the interface for notification messages.";
+          }
+        }
+        case address-originated {
+          description
+            "When notification messages are to depart from a
+             publisher using a specific originating address and/or
+             routing context information.";
+          leaf source-vrf {
+            if-feature "supports-vrf";
+            type leafref {
+              path "/ni:network-instances/ni:network-instance/ni:name";
+            }
+            description
+              "VRF from which notification messages should egress a
+               publisher.";
+          }
+          leaf source-address {
+            type inet:ip-address-no-zone;
+            description
+              "The source address for the notification messages.
+               If a source VRF exists but this object doesn't, a
+               publisher's default address for that VRF must
+               be used.";
+          }
+        }
+      }
+      leaf configured-subscription-state {
+        if-feature "configured";
+        type enumeration {
+          enum "valid" {
+            value 1;
+            description
+              "The subscription is supportable with its current
+               parameters.";
+          }
+          enum "invalid" {
+            value 2;
+            description
+              "The subscription as a whole is unsupportable with its
+               current parameters.";
+          }
+          enum "concluded" {
+            value 3;
+            description
+              "A subscription is inactive, as it has hit a
+               stop time.  It no longer has receivers in the
+               'active' or 'suspended' state, but the subscription
+               has not yet been removed from configuration.";
+          }
+        }
+        config false;
+        description
+          "The presence of this leaf indicates that the subscription
+           originated from configuration, not through a control
+           channel or RPC.  The value indicates the state of the
+           subscription as established by the publisher.";
+      }
+      container receivers {
+        description
+          "Set of receivers in a subscription.";
+        list receiver {
+          key "name";
+          min-elements 1;
+          description
+            "A host intended as a recipient for the notification
+             messages of a subscription.  For configured
+             subscriptions, transport-specific network parameters
+             (or a leafref to those parameters) may be augmented to a
+             specific receiver in this list.";
+          leaf name {
+            type string;
+            description
+              "Identifies a unique receiver for a subscription.";
+          }
+          leaf sent-event-records {
+            type yang:zero-based-counter64;
+            config false;
+            description
+              "The number of event records sent to the receiver.  The
+               count is initialized when a dynamic subscription is
+               established or when a configured receiver
+               transitions to the 'valid' state.";
+          }
+          leaf excluded-event-records {
+            type yang:zero-based-counter64;
+            config false;
+            description
+              "The number of event records explicitly removed via
+               either an event stream filter or an access control
+               filter so that they are not passed to a receiver.
+               This count is set to zero each time
+               'sent-event-records' is initialized.";
+          }
+          leaf state {
+            type enumeration {
+              enum "active" {
+                value 1;
+                description
+                  "The receiver is currently being sent any
+                   applicable notification messages for the
+                   subscription.";
+              }
+              enum "suspended" {
+                value 2;
+                description
+                  "The receiver state is 'suspended', so the
+                   publisher is currently unable to provide
+                   notification messages for the subscription.";
+              }
+              enum "connecting" {
+                if-feature "configured";
+                value 3;
+                description
+                  "A subscription has been configured, but a
+                   'subscription-started' subscription state change
+                   notification needs to be successfully received
+                   before notification messages are sent.
+
+                   If the 'reset' action is invoked for a receiver of
+                   an active configured subscription, the state
+                   must be moved to 'connecting'.";
+              }
+              enum "disconnected" {
+                if-feature "configured";
+                value 4;
+                description
+                  "A subscription has failed to send a
+                   'subscription-started' state change to the
+                   receiver.  Additional connection attempts are not
+                   currently being made.";
+              }
+            }
+            config false;
+            mandatory true;
+            description
+              "Specifies the state of a subscription from the
+               perspective of a particular receiver.  With this
+               information, it is possible to determine whether a
+               publisher is currently generating notification
+               messages intended for that receiver.";
+          }
+          action reset {
+            if-feature "configured";
+            description
+              "Allows the reset of this configured subscription's
+               receiver to the 'connecting' state.  This enables the
+               connection process to be reinitiated.";
+
+            output {
+              leaf time {
+                type yang:date-and-time;
+                mandatory true;
+                description
+                  "Time at which a publisher returned the receiver to
+                   the 'connecting' state.";
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+
+  rpc establish-subscription {
+    description
+      "This RPC allows a subscriber to create (and possibly
+       negotiate) a subscription on its own behalf.  If successful,
+       the subscription remains in effect for the duration of the
+       subscriber's association with the publisher or until the
+       subscription is terminated.  If an error occurs or the
+       publisher cannot meet the terms of a subscription, an RPC
+       error is returned, and the subscription is not created.
+       In that case, the RPC reply's 'error-info' MAY include
+       suggested parameter settings that would have a higher
+       likelihood of succeeding in a subsequent
+       'establish-subscription' request.";
+
+    input {
+      uses subscription-policy-dynamic;
+      leaf encoding {
+        type encoding;
+        description
+          "The type of encoding for the subscribed data.  If not
+           included as part of the RPC, the encoding MUST be set by
+           the publisher to be the encoding used by this RPC.";
+      }
+    }
+    output {
+      leaf id {
+        type subscription-id;
+        mandatory true;
+        description
+          "Identifier used for this subscription.";
+      }
+      leaf replay-start-time-revision {
+        if-feature "replay";
+        type yang:date-and-time;
+        description
+          "If a replay has been requested, this object represents
+           the earliest time covered by the event buffer for the
+           requested event stream.  The value of this object is the
+           'replay-log-aged-time' if it exists.  Otherwise, it is
+           the 'replay-log-creation-time'.  All buffered event
+           records after this time will be replayed to a receiver.
+           This object will only be sent if the starting time has
+           been revised to be later than the time requested by the
+           subscriber.";
+      }
+    }
+  }
+  rpc modify-subscription {
+    description
+      "This RPC allows a subscriber to modify a dynamic
+       subscription's parameters.  If successful, the changed
+       subscription parameters remain in effect for the duration of
+       the subscription, until the subscription is again modified, or
+       until the subscription is terminated.  In the case of an error
+       or an inability to meet the modified parameters, the
+       subscription is not modified and the original subscription
+       parameters remain in effect.  In that case, the RPC error MAY
+       include 'error-info' suggested parameter hints that would have
+       a high likelihood of succeeding in a subsequent
+       'modify-subscription' request.  A successful
+       'modify-subscription' will return a suspended subscription to
+       the 'active' state.";
+
+    input {
+      leaf id {
+        type subscription-id;
+        mandatory true;
+        description
+          "Identifier to use for this subscription.";
+      }
+      uses subscription-policy-modifiable;
+    }
+  }
+  rpc delete-subscription {
+    description
+      "This RPC allows a subscriber to delete a subscription that
+       was previously created by that same subscriber using the
+       'establish-subscription' RPC.
+
+       If an error occurs, the server replies with an 'rpc-error'
+       where the 'error-info' field MAY contain a
+       'delete-subscription-error-info' structure.";
+
+    input {
+      leaf id {
+        type subscription-id;
+        mandatory true;
+        description
+          "Identifier of the subscription that is to be deleted.
+           Only subscriptions that were created using
+           'establish-subscription' from the same origin as this RPC
+           can be deleted via this RPC.";
+      }
+    }
+  }
+  rpc kill-subscription {
+    nacm:default-deny-all;
+    description
+      "This RPC allows an operator to delete a dynamic subscription
+       without restrictions on the originating subscriber or
+       underlying transport session.
+
+       If an error occurs, the server replies with an 'rpc-error'
+       where the 'error-info' field MAY contain a
+       'delete-subscription-error-info' structure.";
+
+    input {
+      leaf id {
+        type subscription-id;
+        mandatory true;
+        description
+          "Identifier of the subscription that is to be deleted.
+           Only subscriptions that were created using
+           'establish-subscription' can be deleted via this RPC.";
+      }
+    }
+  }
+
+  notification replay-completed {
+    sn:subscription-state-notification;
+    if-feature "replay";
+    description
+      "This notification is sent to indicate that all of the replay
+       notifications have been sent.";
+    leaf id {
+      type subscription-id;
+      mandatory true;
+      description
+        "This references the affected subscription.";
+    }
+  }
+  notification subscription-completed {
+    sn:subscription-state-notification;
+    if-feature "configured";
+    description
+      "This notification is sent to indicate that a subscription has
+       finished passing event records, as the 'stop-time' has been
+       reached.";
+    leaf id {
+      type subscription-id;
+      mandatory true;
+      description
+        "This references the gracefully completed subscription.";
+    }
+  }
+  notification subscription-modified {
+    sn:subscription-state-notification;
+    description
+      "This notification indicates that a subscription has been
+       modified.  Notification messages sent from this point on will
+       conform to the modified terms of the subscription.  For
+       completeness, this subscription state change notification
+       includes both modified and unmodified aspects of a
+       subscription.";
+    leaf id {
+      type subscription-id;
+      mandatory true;
+      description
+        "This references the affected subscription.";
+    }
+    uses subscription-policy {
+      refine "target/stream/stream-filter/within-subscription" {
+        description
+          "Filter applied to the subscription.  If the
+           'stream-filter-name' is populated, the filter in the
+           subscription came from the 'filters' container.
+           Otherwise, it is populated in-line as part of the
+           subscription.";
+      }
+    }
+  }
+  notification subscription-resumed {
+    sn:subscription-state-notification;
+    description
+      "This notification indicates that a subscription that had
+       previously been suspended has resumed.  Notifications will
+       once again be sent.  In addition, a 'subscription-resumed'
+       indicates that no modification of parameters has occurred
+       since the last time event records have been sent.";
+    leaf id {
+      type subscription-id;
+      mandatory true;
+      description
+        "This references the affected subscription.";
+    }
+  }
+  notification subscription-started {
+    sn:subscription-state-notification;
+    if-feature "configured";
+    description
+      "This notification indicates that a subscription has started
+       and notifications will now be sent.";
+    leaf id {
+      type subscription-id;
+      mandatory true;
+      description
+        "This references the affected subscription.";
+    }
+    uses subscription-policy {
+      refine "target/stream/replay-start-time" {
+        description
+          "Indicates the time that a replay is using for the
+           streaming of buffered event records.  This will be
+           populated with the most recent of the following:
+           the event time of the previous event record sent to a
+           receiver, the 'replay-log-creation-time', the
+           'replay-log-aged-time', or the most recent publisher
+           boot time.";
+      }
+      refine "target/stream/stream-filter/within-subscription" {
+        description
+          "Filter applied to the subscription.  If the
+           'stream-filter-name' is populated, the filter in the
+           subscription came from the 'filters' container.
+           Otherwise, it is populated in-line as part of the
+           subscription.";
+      }
+      augment "target/stream" {
+        description
+          "This augmentation adds additional parameters specific to a
+           'subscription-started' notification.";
+        leaf replay-previous-event-time {
+          when "../replay-start-time";
+          if-feature "replay";
+          type yang:date-and-time;
+          description
+            "If there is at least one event in the replay buffer
+             prior to 'replay-start-time', this gives the time of
+             the event generated immediately prior to the
+             'replay-start-time'.
+
+             If a receiver previously received event records for
+             this configured subscription, it can compare this time
+             to the last event record previously received.  If the
+             two are not the same (perhaps due to a reboot), then a
+             dynamic replay can be initiated to acquire any missing
+             event records.";
+        }
+      }
+    }
+  }
+  notification subscription-suspended {
+    sn:subscription-state-notification;
+    description
+      "This notification indicates that a suspension of the
+       subscription by the publisher has occurred.  No further
+       notifications will be sent until the subscription resumes.
+       This notification shall only be sent to receivers of a
+       subscription; it does not constitute a general-purpose
+       notification.";
+    leaf id {
+      type subscription-id;
+      mandatory true;
+      description
+        "This references the affected subscription.";
+    }
+    leaf reason {
+      type identityref {
+        base subscription-suspended-reason;
+      }
+      mandatory true;
+      description
+        "Identifies the condition that resulted in the suspension.";
+    }
+  }
+  notification subscription-terminated {
+    sn:subscription-state-notification;
+    description
+      "This notification indicates that a subscription has been
+       terminated.";
+    leaf id {
+      type subscription-id;
+      mandatory true;
+      description
+        "This references the affected subscription.";
+    }
+    leaf reason {
+      type identityref {
+        base subscription-terminated-reason;
+      }
+      mandatory true;
+      description
+        "Identifies the condition that resulted in the termination.";
+    }
+  }
+}
+"""
+
+ietf_restconf = r"""module ietf-restconf {
+  yang-version 1.1;
+  namespace "urn:ietf:params:xml:ns:yang:ietf-restconf";
+  prefix rc;
+
+  organization
+    "IETF NETCONF (Network Configuration) Working Group";
+  contact
+    "WG Web:   <https://datatracker.ietf.org/wg/netconf/>
+     WG List:  <mailto:netconf@ietf.org>
+
+     Author:   Andy Bierman
+               <mailto:andy@yumaworks.com>
+
+     Author:   Martin Bjorklund
+               <mailto:mbj@tail-f.com>
+
+     Author:   Kent Watsen
+               <mailto:kwatsen@juniper.net>";
+  description
+    "This module contains conceptual YANG specifications
+     for basic RESTCONF media type definitions used in
+     RESTCONF protocol messages.
+
+     Note that the YANG definitions within this module do not
+     represent configuration data of any kind.
+     The 'restconf-media-type' YANG extension statement
+     provides a normative syntax for XML and JSON
+     message-encoding purposes.
+
+     Copyright (c) 2017 IETF Trust and the persons identified as
+     authors of the code.  All rights reserved.
+
+     Redistribution and use in source and binary forms, with or
+     without modification, is permitted pursuant to, and subject
+     to the license terms contained in, the Simplified BSD License
+     set forth in Section 4.c of the IETF Trust's Legal Provisions
+     Relating to IETF Documents
+     (http://trustee.ietf.org/license-info).
+
+     This version of this YANG module is part of RFC 8040; see
+     the RFC itself for full legal notices.";
+
+  revision 2017-01-26 {
+    description
+      "Initial revision.";
+    reference
+      "RFC 8040: RESTCONF Protocol.";
+  }
+
+  extension yang-data {
+    argument name {
+      yin-element true;
+    }
+    description
+      "This extension is used to specify a YANG data template that
+       represents conceptual data defined in YANG.  It is
+       intended to describe hierarchical data independent of
+       protocol context or specific message-encoding format.
+       Data definition statements within a yang-data extension
+       specify the generic syntax for the specific YANG data
+       template, whose name is the argument of the 'yang-data'
+       extension statement.
+
+       Note that this extension does not define a media type.
+       A specification using this extension MUST specify the
+       message-encoding rules, including the content media type.
+
+       The mandatory 'name' parameter value identifies the YANG
+       data template that is being defined.  It contains the
+       template name.
+
+       This extension is ignored unless it appears as a top-level
+       statement.  It MUST contain data definition statements
+       that result in exactly one container data node definition.
+       An instance of a YANG data template can thus be translated
+       into an XML instance document, whose top-level element
+       corresponds to the top-level container.
+       The module name and namespace values for the YANG module using
+       the extension statement are assigned to instance document data
+       conforming to the data definition statements within
+       this extension.
+
+       The substatements of this extension MUST follow the
+       'data-def-stmt' rule in the YANG ABNF.
+
+       The XPath document root is the extension statement itself,
+       such that the child nodes of the document root are
+       represented by the data-def-stmt substatements within
+       this extension.  This conceptual document is the context
+       for the following YANG statements:
+
+         - must-stmt
+         - when-stmt
+         - path-stmt
+         - min-elements-stmt
+         - max-elements-stmt
+         - mandatory-stmt
+         - unique-stmt
+         - ordered-by
+         - instance-identifier data type
+
+       The following data-def-stmt substatements are constrained
+       when used within a 'yang-data' extension statement.
+
+         - The list-stmt is not required to have a key-stmt defined.
+         - The if-feature-stmt is ignored if present.
+         - The config-stmt is ignored if present.
+         - The available identity values for any 'identityref'
+           leaf or leaf-list nodes are limited to the module
+           containing this extension statement and the modules
+           imported into that module.
+       ";
+  }
+
+  rc:yang-data "yang-errors" {
+    uses errors;
+  }
+  rc:yang-data "yang-api" {
+    uses restconf;
+  }
+
+  grouping errors {
+    description
+      "A grouping that contains a YANG container
+       representing the syntax and semantics of a
+       YANG Patch error report within a response message.";
+    container errors {
+      description
+        "Represents an error report returned by the server if
+         a request results in an error.";
+      list error {
+        description
+          "An entry containing information about one
+           specific error that occurred while processing
+           a RESTCONF request.";
+        reference
+          "RFC 6241, Section 4.3.";
+        leaf error-type {
+          type enumeration {
+            enum "transport" {
+              description
+                "The transport layer.";
+            }
+            enum "rpc" {
+              description
+                "The rpc or notification layer.";
+            }
+            enum "protocol" {
+              description
+                "The protocol operation layer.";
+            }
+            enum "application" {
+              description
+                "The server application layer.";
+            }
+          }
+          mandatory true;
+          description
+            "The protocol layer where the error occurred.";
+        }
+        leaf error-tag {
+          type string;
+          mandatory true;
+          description
+            "The enumerated error-tag.";
+        }
+        leaf error-app-tag {
+          type string;
+          description
+            "The application-specific error-tag.";
+        }
+        leaf error-path {
+          type instance-identifier;
+          description
+            "The YANG instance identifier associated
+             with the error node.";
+        }
+        leaf error-message {
+          type string;
+          description
+            "A message describing the error.";
+        }
+        anydata error-info {
+          description
+            "This anydata value MUST represent a container with
+             zero or more data nodes representing additional
+             error information.";
+        }
+      }
+    }
+  }
+
+  grouping restconf {
+    description
+      "Conceptual grouping representing the RESTCONF
+       root resource.";
+    container restconf {
+      description
+        "Conceptual container representing the RESTCONF
+         root resource.";
+      container data {
+        description
+          "Container representing the datastore resource.
+           Represents the conceptual root of all state data
+           and configuration data supported by the server.
+           The child nodes of this container can be any data
+           resources that are defined as top-level data nodes
+           from the YANG modules advertised by the server in
+           the 'ietf-yang-library' module.";
+      }
+      container operations {
+        description
+          "Container for all operation resources.
+
+           Each resource is represented as an empty leaf with the
+           name of the RPC operation from the YANG 'rpc' statement.
+
+           For example, the 'system-restart' RPC operation defined
+           in the 'ietf-system' module would be represented as
+           an empty leaf in the 'ietf-system' namespace.  This is
+           a conceptual leaf and will not actually be found in
+           the module:
+
+              module ietf-system {
+                leaf system-reset {
+                  type empty;
+                }
+              }
+
+           To invoke the 'system-restart' RPC operation:
+
+              POST /restconf/operations/ietf-system:system-restart
+
+           To discover the RPC operations supported by the server:
+
+              GET /restconf/operations
+
+           In XML, the YANG module namespace identifies the module:
+
+             <system-restart
+                xmlns='urn:ietf:params:xml:ns:yang:ietf-system'/>
+
+           In JSON, the YANG module name identifies the module:
+
+             { 'ietf-system:system-restart' : [null] }
+           ";
+      }
+      leaf yang-library-version {
+        type string {
+          pattern '\d{4}-\d{2}-\d{2}';
+        }
+        config false;
+        mandatory true;
+        description
+          "Identifies the revision date of the 'ietf-yang-library'
+           module that is implemented by this RESTCONF server.
+           Indicates the year, month, and day in YYYY-MM-DD
+           numeric format.";
+      }
+    }
+  }
+}
+"""
+
+ietf_yang_patch = r"""module ietf-yang-patch {
+  yang-version 1.1;
+  namespace "urn:ietf:params:xml:ns:yang:ietf-yang-patch";
+  prefix ypatch;
+
+  import ietf-restconf {
+    prefix rc;
+  }
+
+  organization
+    "IETF NETCONF (Network Configuration) Working Group";
+  contact
+    "WG Web:   <https://datatracker.ietf.org/wg/netconf/>
+     WG List:  <mailto:netconf@ietf.org>
+
+     Author:   Andy Bierman
+               <mailto:andy@yumaworks.com>
+
+     Author:   Martin Bjorklund
+               <mailto:mbj@tail-f.com>
+
+     Author:   Kent Watsen
+               <mailto:kwatsen@juniper.net>";
+  description
+    "This module contains conceptual YANG specifications
+     for the YANG Patch and YANG Patch Status data structures.
+
+     Note that the YANG definitions within this module do not
+     represent configuration data of any kind.
+     The YANG grouping statements provide a normative syntax
+     for XML and JSON message-encoding purposes.
+
+     Copyright (c) 2017 IETF Trust and the persons identified as
+     authors of the code.  All rights reserved.
+
+     Redistribution and use in source and binary forms, with or
+     without modification, is permitted pursuant to, and subject
+     to the license terms contained in, the Simplified BSD License
+     set forth in Section 4.c of the IETF Trust's Legal Provisions
+     Relating to IETF Documents
+     (http://trustee.ietf.org/license-info).
+
+     This version of this YANG module is part of RFC 8072; see
+     the RFC itself for full legal notices.";
+
+  revision 2017-02-22 {
+    description
+      "Initial revision.";
+    reference
+      "RFC 8072: YANG Patch Media Type.";
+  }
+
+  rc:yang-data "yang-patch" {
+    uses yang-patch;
+  }
+  rc:yang-data "yang-patch-status" {
+    uses yang-patch-status;
+  }
+
+  typedef target-resource-offset {
+    type string;
+    description
+      "Contains a data resource identifier string representing
+       a sub-resource within the target resource.
+       The document root for this expression is the
+       target resource that is specified in the
+       protocol operation (e.g., the URI for the PATCH request).
+
+       This string is encoded according to the same rules as those
+       for a data resource identifier in a RESTCONF request URI.";
+    reference
+      "RFC 8040, Section 3.5.3.";
+  }
+
+  grouping yang-patch {
+    description
+      "A grouping that contains a YANG container representing the
+       syntax and semantics of a YANG Patch edit request message.";
+    container yang-patch {
+      description
+        "Represents a conceptual sequence of datastore edits,
+         called a patch.  Each patch is given a client-assigned
+         patch identifier.  Each edit MUST be applied
+         in ascending order, and all edits MUST be applied.
+         If any errors occur, then the target datastore MUST NOT
+         be changed by the YANG Patch operation.
+
+         It is possible for a datastore constraint violation to occur
+         due to any node in the datastore, including nodes not
+         included in the 'edit' list.  Any validation errors MUST
+         be reported in the reply message.";
+      reference
+        "RFC 7950, Section 8.3.";
+      leaf patch-id {
+        type string;
+        mandatory true;
+        description
+          "An arbitrary string provided by the client to identify
+           the entire patch.  Error messages returned by the server
+           that pertain to this patch will be identified by this
+           'patch-id' value.  A client SHOULD attempt to generate
+           unique 'patch-id' values to distinguish between
+           transactions from multiple clients in any audit logs
+           maintained by the server.";
+      }
+      leaf comment {
+        type string;
+        description
+          "An arbitrary string provided by the client to describe
+           the entire patch.  This value SHOULD be present in any
+           audit logging records generated by the server for the
+           patch.";
+      }
+      list edit {
+        key "edit-id";
+        ordered-by user;
+        description
+          "Represents one edit within the YANG Patch request message.
+           The 'edit' list is applied in the following manner:
+
+             - The first edit is conceptually applied to a copy
+               of the existing target datastore, e.g., the
+               running configuration datastore.
+             - Each ascending edit is conceptually applied to
+               the result of the previous edit(s).
+             - After all edits have been successfully processed,
+               the result is validated according to YANG constraints.
+             - If successful, the server will attempt to apply
+               the result to the target datastore.";
+        leaf edit-id {
+          type string;
+          description
+            "Arbitrary string index for the edit.
+             Error messages returned by the server that pertain
+             to a specific edit will be identified by this value.";
+        }
+        leaf operation {
+          type enumeration {
+            enum "create" {
+              description
+                "The target data node is created using the supplied
+                 value, only if it does not already exist.  The
+                 'target' leaf identifies the data node to be
+                 created, not the parent data node.";
+            }
+            enum "delete" {
+              description
+                "Delete the target node, only if the data resource
+                 currently exists; otherwise, return an error.";
+            }
+            enum "insert" {
+              description
+                "Insert the supplied value into a user-ordered
+                 list or leaf-list entry.  The target node must
+                 represent a new data resource.  If the 'where'
+                 parameter is set to 'before' or 'after', then
+                 the 'point' parameter identifies the insertion
+                 point for the target node.";
+            }
+            enum "merge" {
+              description
+                "The supplied value is merged with the target data
+                 node.";
+            }
+            enum "move" {
+              description
+                "Move the target node.  Reorder a user-ordered
+                 list or leaf-list.  The target node must represent
+                 an existing data resource.  If the 'where' parameter
+                 is set to 'before' or 'after', then the 'point'
+                 parameter identifies the insertion point to move
+                 the target node.";
+            }
+            enum "replace" {
+              description
+                "The supplied value is used to replace the target
+                 data node.";
+            }
+            enum "remove" {
+              description
+                "Delete the target node if it currently exists.";
+            }
+          }
+          mandatory true;
+          description
+            "The datastore operation requested for the associated
+             'edit' entry.";
+        }
+        leaf target {
+          type target-resource-offset;
+          mandatory true;
+          description
+            "Identifies the target data node for the edit
+             operation.  If the target has the value '/', then
+             the target data node is the target resource.
+             The target node MUST identify a data resource,
+             not the datastore resource.";
+        }
+        leaf point {
+          when "(../operation = 'insert' or ../operation = 'move')and (../where = 'before' or ../where = 'after')" {
+            description
+              "This leaf only applies for 'insert' or 'move'
+               operations, before or after an existing entry.";
+          }
+          type target-resource-offset;
+          description
+            "The absolute URL path for the data node that is being
+             used as the insertion point or move point for the
+             target of this 'edit' entry.";
+        }
+        leaf where {
+          when "../operation = 'insert' or ../operation = 'move'" {
+            description
+              "This leaf only applies for 'insert' or 'move'
+               operations.";
+          }
+          type enumeration {
+            enum "before" {
+              description
+                "Insert or move a data node before the data resource
+                 identified by the 'point' parameter.";
+            }
+            enum "after" {
+              description
+                "Insert or move a data node after the data resource
+                 identified by the 'point' parameter.";
+            }
+            enum "first" {
+              description
+                "Insert or move a data node so it becomes ordered
+                 as the first entry.";
+            }
+            enum "last" {
+              description
+                "Insert or move a data node so it becomes ordered
+                 as the last entry.";
+            }
+          }
+          default "last";
+          description
+            "Identifies where a data resource will be inserted
+             or moved.  YANG only allows these operations for
+             list and leaf-list data nodes that are
+             'ordered-by user'.";
+        }
+        anydata value {
+          when "../operation = 'create' or ../operation = 'merge' or ../operation = 'replace' or ../operation = 'insert'" {
+            description
+              "The anydata 'value' is only used for 'create',
+               'merge', 'replace', and 'insert' operations.";
+          }
+          description
+            "Value used for this edit operation.  The anydata 'value'
+             contains the target resource associated with the
+             'target' leaf.
+
+             For example, suppose the target node is a YANG container
+             named foo:
+
+                 container foo {
+                   leaf a { type string; }
+                   leaf b { type int32; }
+                 }
+
+             The 'value' node contains one instance of foo:
+
+                 <value>
+                    <foo xmlns='example-foo-namespace'>
+                       <a>some value</a>
+                       <b>42</b>
+                    </foo>
+                 </value>
+              ";
+        }
+      }
+    }
+  }
+
+  grouping yang-patch-status {
+    description
+      "A grouping that contains a YANG container representing the
+       syntax and semantics of a YANG Patch Status response
+       message.";
+    container yang-patch-status {
+      description
+        "A container representing the response message sent by the
+         server after a YANG Patch edit request message has been
+         processed.";
+      leaf patch-id {
+        type string;
+        mandatory true;
+        description
+          "The 'patch-id' value used in the request.";
+      }
+      choice global-status {
+        description
+          "Report global errors or complete success.
+           If there is no case selected, then errors
+           are reported in the 'edit-status' container.";
+        case global-errors {
+          description
+            "This container will be present if global errors that
+             are unrelated to a specific edit occurred.";
+          uses rc:errors;
+        }
+        leaf ok {
+          type empty;
+          description
+            "This leaf will be present if the request succeeded
+             and there are no errors reported in the 'edit-status'
+             container.";
+        }
+      }
+      container edit-status {
+        description
+          "This container will be present if there are
+           edit-specific status responses to report.
+           If all edits succeeded and the 'global-status'
+           returned is 'ok', then a server MAY omit this
+           container.";
+        list edit {
+          key "edit-id";
+          description
+            "Represents a list of status responses,
+             corresponding to edits in the YANG Patch
+             request message.  If an 'edit' entry was
+             skipped or not reached by the server,
+             then this list will not contain a corresponding
+             entry for that edit.";
+          leaf edit-id {
+            type string;
+            description
+              "Response status is for the 'edit' list entry
+               with this 'edit-id' value.";
+          }
+          choice edit-status-choice {
+            description
+              "A choice between different types of status
+               responses for each 'edit' entry.";
+            leaf ok {
+              type empty;
+              description
+                "This 'edit' entry was invoked without any
+                 errors detected by the server associated
+                 with this edit.";
+            }
+            case errors {
+              description
+                "The server detected errors associated with the
+                 edit identified by the same 'edit-id' value.";
+              uses rc:errors;
+            }
+          }
+        }
+      }
+    }
+  }
+}
+"""
+
+ietf_interfaces = r"""module ietf-interfaces {
+  yang-version 1.1;
+  namespace "urn:ietf:params:xml:ns:yang:ietf-interfaces";
+  prefix if;
+
+  import ietf-yang-types {
+    prefix yang;
+  }
+
+  organization
+    "IETF NETMOD (Network Modeling) Working Group";
+  contact
+    "WG Web:   <https://datatracker.ietf.org/wg/netmod/>
+     WG List:  <mailto:netmod@ietf.org>
+
+     Editor:   Martin Bjorklund
+               <mailto:mbj@tail-f.com>";
+  description
+    "This module contains a collection of YANG definitions for
+     managing network interfaces.
+
+     Copyright (c) 2018 IETF Trust and the persons identified as
+     authors of the code.  All rights reserved.
+
+     Redistribution and use in source and binary forms, with or
+     without modification, is permitted pursuant to, and subject
+     to the license terms contained in, the Simplified BSD License
+     set forth in Section 4.c of the IETF Trust's Legal Provisions
+     Relating to IETF Documents
+     (https://trustee.ietf.org/license-info).
+
+     This version of this YANG module is part of RFC 8343; see
+     the RFC itself for full legal notices.";
+
+  revision 2018-02-20 {
+    description
+      "Updated to support NMDA.";
+    reference
+      "RFC 8343: A YANG Data Model for Interface Management";
+  }
+  revision 2014-05-08 {
+    description
+      "Initial revision.";
+    reference
+      "RFC 7223: A YANG Data Model for Interface Management";
+  }
+
+  feature arbitrary-names {
+    description
+      "This feature indicates that the device allows user-controlled
+       interfaces to be named arbitrarily.";
+  }
+
+  feature pre-provisioning {
+    description
+      "This feature indicates that the device supports
+       pre-provisioning of interface configuration, i.e., it is
+       possible to configure an interface whose physical interface
+       hardware is not present on the device.";
+  }
+
+  feature if-mib {
+    description
+      "This feature indicates that the device implements
+       the IF-MIB.";
+    reference
+      "RFC 2863: The Interfaces Group MIB";
+  }
+
+  identity interface-type {
+    description
+      "Base identity from which specific interface types are
+       derived.";
+  }
+
+  typedef interface-ref {
+    type leafref {
+      path "/if:interfaces/if:interface/if:name";
+    }
+    description
+      "This type is used by data models that need to reference
+       interfaces.";
+  }
+
+  typedef interface-state-ref {
+    type leafref {
+      path "/if:interfaces-state/if:interface/if:name";
+    }
+    status deprecated;
+    description
+      "This type is used by data models that need to reference
+       the operationally present interfaces.";
+  }
+
+  container interfaces {
+    description
+      "Interface parameters.";
+    list interface {
+      key "name";
+      description
+        "The list of interfaces on the device.
+
+         The status of an interface is available in this list in the
+         operational state.  If the configuration of a
+         system-controlled interface cannot be used by the system
+         (e.g., the interface hardware present does not match the
+         interface type), then the configuration is not applied to
+         the system-controlled interface shown in the operational
+         state.  If the configuration of a user-controlled interface
+         cannot be used by the system, the configured interface is
+         not instantiated in the operational state.
+
+         System-controlled interfaces created by the system are
+         always present in this list in the operational state,
+         whether or not they are configured.";
+      leaf name {
+        type string;
+        description
+          "The name of the interface.
+
+           A device MAY restrict the allowed values for this leaf,
+           possibly depending on the type of the interface.
+           For system-controlled interfaces, this leaf is the
+           device-specific name of the interface.
+
+           If a client tries to create configuration for a
+           system-controlled interface that is not present in the
+           operational state, the server MAY reject the request if
+           the implementation does not support pre-provisioning of
+           interfaces or if the name refers to an interface that can
+           never exist in the system.  A Network Configuration
+           Protocol (NETCONF) server MUST reply with an rpc-error
+           with the error-tag 'invalid-value' in this case.
+
+           If the device supports pre-provisioning of interface
+           configuration, the 'pre-provisioning' feature is
+           advertised.
+
+           If the device allows arbitrarily named user-controlled
+           interfaces, the 'arbitrary-names' feature is advertised.
+
+           When a configured user-controlled interface is created by
+           the system, it is instantiated with the same name in the
+           operational state.
+
+           A server implementation MAY map this leaf to the ifName
+           MIB object.  Such an implementation needs to use some
+           mechanism to handle the differences in size and characters
+           allowed between this leaf and ifName.  The definition of
+           such a mechanism is outside the scope of this document.";
+        reference
+          "RFC 2863: The Interfaces Group MIB - ifName";
+      }
+      leaf description {
+        type string;
+        description
+          "A textual description of the interface.
+
+           A server implementation MAY map this leaf to the ifAlias
+           MIB object.  Such an implementation needs to use some
+           mechanism to handle the differences in size and characters
+           allowed between this leaf and ifAlias.  The definition of
+           such a mechanism is outside the scope of this document.
+
+           Since ifAlias is defined to be stored in non-volatile
+           storage, the MIB implementation MUST map ifAlias to the
+           value of 'description' in the persistently stored
+           configuration.";
+        reference
+          "RFC 2863: The Interfaces Group MIB - ifAlias";
+      }
+      leaf type {
+        type identityref {
+          base interface-type;
+        }
+        mandatory true;
+        description
+          "The type of the interface.
+
+           When an interface entry is created, a server MAY
+           initialize the type leaf with a valid value, e.g., if it
+           is possible to derive the type from the name of the
+           interface.
+
+           If a client tries to set the type of an interface to a
+           value that can never be used by the system, e.g., if the
+           type is not supported or if the type does not match the
+           name of the interface, the server MUST reject the request.
+           A NETCONF server MUST reply with an rpc-error with the
+           error-tag 'invalid-value' in this case.";
+        reference
+          "RFC 2863: The Interfaces Group MIB - ifType";
+      }
+      leaf enabled {
+        type boolean;
+        default "true";
+        description
+          "This leaf contains the configured, desired state of the
+           interface.
+
+           Systems that implement the IF-MIB use the value of this
+           leaf in the intended configuration to set
+           IF-MIB.ifAdminStatus to 'up' or 'down' after an ifEntry
+           has been initialized, as described in RFC 2863.
+
+           Changes in this leaf in the intended configuration are
+           reflected in ifAdminStatus.";
+        reference
+          "RFC 2863: The Interfaces Group MIB - ifAdminStatus";
+      }
+      leaf link-up-down-trap-enable {
+        if-feature "if-mib";
+        type enumeration {
+          enum "enabled" {
+            value 1;
+            description
+              "The device will generate linkUp/linkDown SNMP
+               notifications for this interface.";
+          }
+          enum "disabled" {
+            value 2;
+            description
+              "The device will not generate linkUp/linkDown SNMP
+               notifications for this interface.";
+          }
+        }
+        description
+          "Controls whether linkUp/linkDown SNMP notifications
+           should be generated for this interface.
+
+           If this node is not configured, the value 'enabled' is
+           operationally used by the server for interfaces that do
+           not operate on top of any other interface (i.e., there are
+           no 'lower-layer-if' entries), and 'disabled' otherwise.";
+        reference
+          "RFC 2863: The Interfaces Group MIB -
+                     ifLinkUpDownTrapEnable";
+      }
+      leaf admin-status {
+        if-feature "if-mib";
+        type enumeration {
+          enum "up" {
+            value 1;
+            description
+              "Ready to pass packets.";
+          }
+          enum "down" {
+            value 2;
+            description
+              "Not ready to pass packets and not in some test mode.";
+          }
+          enum "testing" {
+            value 3;
+            description
+              "In some test mode.";
+          }
+        }
+        config false;
+        mandatory true;
+        description
+          "The desired state of the interface.
+
+           This leaf has the same read semantics as ifAdminStatus.";
+        reference
+          "RFC 2863: The Interfaces Group MIB - ifAdminStatus";
+      }
+      leaf oper-status {
+        type enumeration {
+          enum "up" {
+            value 1;
+            description
+              "Ready to pass packets.";
+          }
+          enum "down" {
+            value 2;
+            description
+              "The interface does not pass any packets.";
+          }
+          enum "testing" {
+            value 3;
+            description
+              "In some test mode.  No operational packets can
+               be passed.";
+          }
+          enum "unknown" {
+            value 4;
+            description
+              "Status cannot be determined for some reason.";
+          }
+          enum "dormant" {
+            value 5;
+            description
+              "Waiting for some external event.";
+          }
+          enum "not-present" {
+            value 6;
+            description
+              "Some component (typically hardware) is missing.";
+          }
+          enum "lower-layer-down" {
+            value 7;
+            description
+              "Down due to state of lower-layer interface(s).";
+          }
+        }
+        config false;
+        mandatory true;
+        description
+          "The current operational state of the interface.
+
+           This leaf has the same semantics as ifOperStatus.";
+        reference
+          "RFC 2863: The Interfaces Group MIB - ifOperStatus";
+      }
+      leaf last-change {
+        type yang:date-and-time;
+        config false;
+        description
+          "The time the interface entered its current operational
+           state.  If the current state was entered prior to the
+           last re-initialization of the local network management
+           subsystem, then this node is not present.";
+        reference
+          "RFC 2863: The Interfaces Group MIB - ifLastChange";
+      }
+      leaf if-index {
+        if-feature "if-mib";
+        type int32 {
+          range "1..2147483647";
+        }
+        config false;
+        mandatory true;
+        description
+          "The ifIndex value for the ifEntry represented by this
+           interface.";
+        reference
+          "RFC 2863: The Interfaces Group MIB - ifIndex";
+      }
+      leaf phys-address {
+        type yang:phys-address;
+        config false;
+        description
+          "The interface's address at its protocol sub-layer.  For
+           example, for an 802.x interface, this object normally
+           contains a Media Access Control (MAC) address.  The
+           interface's media-specific modules must define the bit
+           and byte ordering and the format of the value of this
+           object.  For interfaces that do not have such an address
+           (e.g., a serial line), this node is not present.";
+        reference
+          "RFC 2863: The Interfaces Group MIB - ifPhysAddress";
+      }
+      leaf-list higher-layer-if {
+        type interface-ref;
+        config false;
+        description
+          "A list of references to interfaces layered on top of this
+           interface.";
+        reference
+          "RFC 2863: The Interfaces Group MIB - ifStackTable";
+      }
+      leaf-list lower-layer-if {
+        type interface-ref;
+        config false;
+        description
+          "A list of references to interfaces layered underneath this
+           interface.";
+        reference
+          "RFC 2863: The Interfaces Group MIB - ifStackTable";
+      }
+      leaf speed {
+        type yang:gauge64;
+        units "bits/second";
+        config false;
+        description
+          "An estimate of the interface's current bandwidth in bits
+           per second.  For interfaces that do not vary in
+           bandwidth or for those where no accurate estimation can
+           be made, this node should contain the nominal bandwidth.
+           For interfaces that have no concept of bandwidth, this
+           node is not present.";
+        reference
+          "RFC 2863: The Interfaces Group MIB -
+                     ifSpeed, ifHighSpeed";
+      }
+      container statistics {
+        config false;
+        description
+          "A collection of interface-related statistics objects.";
+        leaf discontinuity-time {
+          type yang:date-and-time;
+          mandatory true;
+          description
+            "The time on the most recent occasion at which any one or
+             more of this interface's counters suffered a
+             discontinuity.  If no such discontinuities have occurred
+             since the last re-initialization of the local management
+             subsystem, then this node contains the time the local
+             management subsystem re-initialized itself.";
+        }
+        leaf in-octets {
+          type yang:counter64;
+          description
+            "The total number of octets received on the interface,
+             including framing characters.
+
+             Discontinuities in the value of this counter can occur
+             at re-initialization of the management system and at
+             other times as indicated by the value of
+             'discontinuity-time'.";
+          reference
+            "RFC 2863: The Interfaces Group MIB - ifHCInOctets";
+        }
+        leaf in-unicast-pkts {
+          type yang:counter64;
+          description
+            "The number of packets, delivered by this sub-layer to a
+             higher (sub-)layer, that were not addressed to a
+             multicast or broadcast address at this sub-layer.
+
+             Discontinuities in the value of this counter can occur
+             at re-initialization of the management system and at
+             other times as indicated by the value of
+             'discontinuity-time'.";
+          reference
+            "RFC 2863: The Interfaces Group MIB - ifHCInUcastPkts";
+        }
+        leaf in-broadcast-pkts {
+          type yang:counter64;
+          description
+            "The number of packets, delivered by this sub-layer to a
+             higher (sub-)layer, that were addressed to a broadcast
+             address at this sub-layer.
+
+             Discontinuities in the value of this counter can occur
+             at re-initialization of the management system and at
+             other times as indicated by the value of
+             'discontinuity-time'.";
+          reference
+            "RFC 2863: The Interfaces Group MIB -
+                       ifHCInBroadcastPkts";
+        }
+        leaf in-multicast-pkts {
+          type yang:counter64;
+          description
+            "The number of packets, delivered by this sub-layer to a
+             higher (sub-)layer, that were addressed to a multicast
+             address at this sub-layer.  For a MAC-layer protocol,
+             this includes both Group and Functional addresses.
+
+             Discontinuities in the value of this counter can occur
+             at re-initialization of the management system and at
+             other times as indicated by the value of
+             'discontinuity-time'.";
+          reference
+            "RFC 2863: The Interfaces Group MIB -
+                       ifHCInMulticastPkts";
+        }
+        leaf in-discards {
+          type yang:counter32;
+          description
+            "The number of inbound packets that were chosen to be
+             discarded even though no errors had been detected to
+             prevent their being deliverable to a higher-layer
+             protocol.  One possible reason for discarding such a
+             packet could be to free up buffer space.
+
+             Discontinuities in the value of this counter can occur
+             at re-initialization of the management system and at
+             other times as indicated by the value of
+             'discontinuity-time'.";
+          reference
+            "RFC 2863: The Interfaces Group MIB - ifInDiscards";
+        }
+        leaf in-errors {
+          type yang:counter32;
+          description
+            "For packet-oriented interfaces, the number of inbound
+             packets that contained errors preventing them from being
+             deliverable to a higher-layer protocol.  For character-
+             oriented or fixed-length interfaces, the number of
+             inbound transmission units that contained errors
+             preventing them from being deliverable to a higher-layer
+             protocol.
+
+             Discontinuities in the value of this counter can occur
+             at re-initialization of the management system and at
+             other times as indicated by the value of
+             'discontinuity-time'.";
+          reference
+            "RFC 2863: The Interfaces Group MIB - ifInErrors";
+        }
+        leaf in-unknown-protos {
+          type yang:counter32;
+          description
+            "For packet-oriented interfaces, the number of packets
+             received via the interface that were discarded because
+             of an unknown or unsupported protocol.  For
+             character-oriented or fixed-length interfaces that
+             support protocol multiplexing, the number of
+             transmission units received via the interface that were
+             discarded because of an unknown or unsupported protocol.
+             For any interface that does not support protocol
+             multiplexing, this counter is not present.
+
+             Discontinuities in the value of this counter can occur
+             at re-initialization of the management system and at
+             other times as indicated by the value of
+             'discontinuity-time'.";
+          reference
+            "RFC 2863: The Interfaces Group MIB - ifInUnknownProtos";
+        }
+        leaf out-octets {
+          type yang:counter64;
+          description
+            "The total number of octets transmitted out of the
+             interface, including framing characters.
+
+             Discontinuities in the value of this counter can occur
+             at re-initialization of the management system and at
+             other times as indicated by the value of
+             'discontinuity-time'.";
+          reference
+            "RFC 2863: The Interfaces Group MIB - ifHCOutOctets";
+        }
+        leaf out-unicast-pkts {
+          type yang:counter64;
+          description
+            "The total number of packets that higher-level protocols
+             requested be transmitted and that were not addressed
+             to a multicast or broadcast address at this sub-layer,
+             including those that were discarded or not sent.
+
+             Discontinuities in the value of this counter can occur
+             at re-initialization of the management system and at
+             other times as indicated by the value of
+             'discontinuity-time'.";
+          reference
+            "RFC 2863: The Interfaces Group MIB - ifHCOutUcastPkts";
+        }
+        leaf out-broadcast-pkts {
+          type yang:counter64;
+          description
+            "The total number of packets that higher-level protocols
+             requested be transmitted and that were addressed to a
+             broadcast address at this sub-layer, including those
+             that were discarded or not sent.
+
+             Discontinuities in the value of this counter can occur
+             at re-initialization of the management system and at
+             other times as indicated by the value of
+             'discontinuity-time'.";
+          reference
+            "RFC 2863: The Interfaces Group MIB -
+                       ifHCOutBroadcastPkts";
+        }
+        leaf out-multicast-pkts {
+          type yang:counter64;
+          description
+            "The total number of packets that higher-level protocols
+             requested be transmitted and that were addressed to a
+             multicast address at this sub-layer, including those
+             that were discarded or not sent.  For a MAC-layer
+             protocol, this includes both Group and Functional
+             addresses.
+
+             Discontinuities in the value of this counter can occur
+             at re-initialization of the management system and at
+             other times as indicated by the value of
+             'discontinuity-time'.";
+          reference
+            "RFC 2863: The Interfaces Group MIB -
+                       ifHCOutMulticastPkts";
+        }
+        leaf out-discards {
+          type yang:counter32;
+          description
+            "The number of outbound packets that were chosen to be
+             discarded even though no errors had been detected to
+             prevent their being transmitted.  One possible reason
+             for discarding such a packet could be to free up buffer
+             space.
+
+             Discontinuities in the value of this counter can occur
+             at re-initialization of the management system and at
+             other times as indicated by the value of
+             'discontinuity-time'.";
+          reference
+            "RFC 2863: The Interfaces Group MIB - ifOutDiscards";
+        }
+        leaf out-errors {
+          type yang:counter32;
+          description
+            "For packet-oriented interfaces, the number of outbound
+             packets that could not be transmitted because of errors.
+             For character-oriented or fixed-length interfaces, the
+             number of outbound transmission units that could not be
+             transmitted because of errors.
+
+             Discontinuities in the value of this counter can occur
+             at re-initialization of the management system and at
+             other times as indicated by the value of
+             'discontinuity-time'.";
+          reference
+            "RFC 2863: The Interfaces Group MIB - ifOutErrors";
+        }
+      }
+    }
+  }
+  container interfaces-state {
+    config false;
+    status deprecated;
+    description
+      "Data nodes for the operational state of interfaces.";
+    list interface {
+      key "name";
+      status deprecated;
+      description
+        "The list of interfaces on the device.
+
+         System-controlled interfaces created by the system are
+         always present in this list, whether or not they are
+         configured.";
+      leaf name {
+        type string;
+        status deprecated;
+        description
+          "The name of the interface.
+
+           A server implementation MAY map this leaf to the ifName
+           MIB object.  Such an implementation needs to use some
+           mechanism to handle the differences in size and characters
+           allowed between this leaf and ifName.  The definition of
+           such a mechanism is outside the scope of this document.";
+        reference
+          "RFC 2863: The Interfaces Group MIB - ifName";
+      }
+      leaf type {
+        type identityref {
+          base interface-type;
+        }
+        mandatory true;
+        status deprecated;
+        description
+          "The type of the interface.";
+        reference
+          "RFC 2863: The Interfaces Group MIB - ifType";
+      }
+      leaf admin-status {
+        if-feature "if-mib";
+        type enumeration {
+          enum "up" {
+            value 1;
+            description
+              "Ready to pass packets.";
+          }
+          enum "down" {
+            value 2;
+            description
+              "Not ready to pass packets and not in some test mode.";
+          }
+          enum "testing" {
+            value 3;
+            description
+              "In some test mode.";
+          }
+        }
+        mandatory true;
+        status deprecated;
+        description
+          "The desired state of the interface.
+
+           This leaf has the same read semantics as ifAdminStatus.";
+        reference
+          "RFC 2863: The Interfaces Group MIB - ifAdminStatus";
+      }
+      leaf oper-status {
+        type enumeration {
+          enum "up" {
+            value 1;
+            description
+              "Ready to pass packets.";
+          }
+          enum "down" {
+            value 2;
+            description
+              "The interface does not pass any packets.";
+          }
+          enum "testing" {
+            value 3;
+            description
+              "In some test mode.  No operational packets can
+               be passed.";
+          }
+          enum "unknown" {
+            value 4;
+            description
+              "Status cannot be determined for some reason.";
+          }
+          enum "dormant" {
+            value 5;
+            description
+              "Waiting for some external event.";
+          }
+          enum "not-present" {
+            value 6;
+            description
+              "Some component (typically hardware) is missing.";
+          }
+          enum "lower-layer-down" {
+            value 7;
+            description
+              "Down due to state of lower-layer interface(s).";
+          }
+        }
+        mandatory true;
+        status deprecated;
+        description
+          "The current operational state of the interface.
+
+           This leaf has the same semantics as ifOperStatus.";
+        reference
+          "RFC 2863: The Interfaces Group MIB - ifOperStatus";
+      }
+      leaf last-change {
+        type yang:date-and-time;
+        status deprecated;
+        description
+          "The time the interface entered its current operational
+           state.  If the current state was entered prior to the
+           last re-initialization of the local network management
+           subsystem, then this node is not present.";
+        reference
+          "RFC 2863: The Interfaces Group MIB - ifLastChange";
+      }
+      leaf if-index {
+        if-feature "if-mib";
+        type int32 {
+          range "1..2147483647";
+        }
+        mandatory true;
+        status deprecated;
+        description
+          "The ifIndex value for the ifEntry represented by this
+           interface.";
+        reference
+          "RFC 2863: The Interfaces Group MIB - ifIndex";
+      }
+      leaf phys-address {
+        type yang:phys-address;
+        status deprecated;
+        description
+          "The interface's address at its protocol sub-layer.  For
+           example, for an 802.x interface, this object normally
+           contains a Media Access Control (MAC) address.  The
+           interface's media-specific modules must define the bit
+           and byte ordering and the format of the value of this
+           object.  For interfaces that do not have such an address
+           (e.g., a serial line), this node is not present.";
+        reference
+          "RFC 2863: The Interfaces Group MIB - ifPhysAddress";
+      }
+      leaf-list higher-layer-if {
+        type interface-state-ref;
+        status deprecated;
+        description
+          "A list of references to interfaces layered on top of this
+           interface.";
+        reference
+          "RFC 2863: The Interfaces Group MIB - ifStackTable";
+      }
+      leaf-list lower-layer-if {
+        type interface-state-ref;
+        status deprecated;
+        description
+          "A list of references to interfaces layered underneath this
+           interface.";
+        reference
+          "RFC 2863: The Interfaces Group MIB - ifStackTable";
+      }
+      leaf speed {
+        type yang:gauge64;
+        units "bits/second";
+        status deprecated;
+        description
+          "An estimate of the interface's current bandwidth in bits
+           per second.  For interfaces that do not vary in
+           bandwidth or for those where no accurate estimation can
+
+           be made, this node should contain the nominal bandwidth.
+           For interfaces that have no concept of bandwidth, this
+           node is not present.";
+        reference
+          "RFC 2863: The Interfaces Group MIB -
+                     ifSpeed, ifHighSpeed";
+      }
+      container statistics {
+        status deprecated;
+        description
+          "A collection of interface-related statistics objects.";
+        leaf discontinuity-time {
+          type yang:date-and-time;
+          mandatory true;
+          status deprecated;
+          description
+            "The time on the most recent occasion at which any one or
+             more of this interface's counters suffered a
+             discontinuity.  If no such discontinuities have occurred
+             since the last re-initialization of the local management
+             subsystem, then this node contains the time the local
+             management subsystem re-initialized itself.";
+        }
+        leaf in-octets {
+          type yang:counter64;
+          status deprecated;
+          description
+            "The total number of octets received on the interface,
+             including framing characters.
+
+             Discontinuities in the value of this counter can occur
+             at re-initialization of the management system and at
+             other times as indicated by the value of
+             'discontinuity-time'.";
+          reference
+            "RFC 2863: The Interfaces Group MIB - ifHCInOctets";
+        }
+        leaf in-unicast-pkts {
+          type yang:counter64;
+          status deprecated;
+          description
+            "The number of packets, delivered by this sub-layer to a
+             higher (sub-)layer, that were not addressed to a
+             multicast or broadcast address at this sub-layer.
+             Discontinuities in the value of this counter can occur
+             at re-initialization of the management system and at
+             other times as indicated by the value of
+             'discontinuity-time'.";
+          reference
+            "RFC 2863: The Interfaces Group MIB - ifHCInUcastPkts";
+        }
+        leaf in-broadcast-pkts {
+          type yang:counter64;
+          status deprecated;
+          description
+            "The number of packets, delivered by this sub-layer to a
+             higher (sub-)layer, that were addressed to a broadcast
+             address at this sub-layer.
+
+             Discontinuities in the value of this counter can occur
+             at re-initialization of the management system and at
+             other times as indicated by the value of
+             'discontinuity-time'.";
+          reference
+            "RFC 2863: The Interfaces Group MIB -
+                       ifHCInBroadcastPkts";
+        }
+        leaf in-multicast-pkts {
+          type yang:counter64;
+          status deprecated;
+          description
+            "The number of packets, delivered by this sub-layer to a
+             higher (sub-)layer, that were addressed to a multicast
+             address at this sub-layer.  For a MAC-layer protocol,
+             this includes both Group and Functional addresses.
+
+             Discontinuities in the value of this counter can occur
+             at re-initialization of the management system and at
+             other times as indicated by the value of
+             'discontinuity-time'.";
+          reference
+            "RFC 2863: The Interfaces Group MIB -
+                       ifHCInMulticastPkts";
+        }
+        leaf in-discards {
+          type yang:counter32;
+          status deprecated;
+          description
+            "The number of inbound packets that were chosen to be
+             discarded even though no errors had been detected to
+             prevent their being deliverable to a higher-layer
+             protocol.  One possible reason for discarding such a
+             packet could be to free up buffer space.
+
+             Discontinuities in the value of this counter can occur
+             at re-initialization of the management system and at
+             other times as indicated by the value of
+             'discontinuity-time'.";
+          reference
+            "RFC 2863: The Interfaces Group MIB - ifInDiscards";
+        }
+        leaf in-errors {
+          type yang:counter32;
+          status deprecated;
+          description
+            "For packet-oriented interfaces, the number of inbound
+             packets that contained errors preventing them from being
+             deliverable to a higher-layer protocol.  For character-
+             oriented or fixed-length interfaces, the number of
+             inbound transmission units that contained errors
+             preventing them from being deliverable to a higher-layer
+             protocol.
+
+             Discontinuities in the value of this counter can occur
+             at re-initialization of the management system and at
+             other times as indicated by the value of
+             'discontinuity-time'.";
+          reference
+            "RFC 2863: The Interfaces Group MIB - ifInErrors";
+        }
+        leaf in-unknown-protos {
+          type yang:counter32;
+          status deprecated;
+          description
+            "For packet-oriented interfaces, the number of packets
+             received via the interface that were discarded because
+             of an unknown or unsupported protocol.  For
+             character-oriented or fixed-length interfaces that
+             support protocol multiplexing, the number of
+             transmission units received via the interface that were
+             discarded because of an unknown or unsupported protocol.
+             For any interface that does not support protocol
+             multiplexing, this counter is not present.
+             Discontinuities in the value of this counter can occur
+             at re-initialization of the management system and at
+             other times as indicated by the value of
+             'discontinuity-time'.";
+          reference
+            "RFC 2863: The Interfaces Group MIB - ifInUnknownProtos";
+        }
+        leaf out-octets {
+          type yang:counter64;
+          status deprecated;
+          description
+            "The total number of octets transmitted out of the
+             interface, including framing characters.
+
+             Discontinuities in the value of this counter can occur
+             at re-initialization of the management system and at
+             other times as indicated by the value of
+             'discontinuity-time'.";
+          reference
+            "RFC 2863: The Interfaces Group MIB - ifHCOutOctets";
+        }
+        leaf out-unicast-pkts {
+          type yang:counter64;
+          status deprecated;
+          description
+            "The total number of packets that higher-level protocols
+             requested be transmitted and that were not addressed
+             to a multicast or broadcast address at this sub-layer,
+             including those that were discarded or not sent.
+
+             Discontinuities in the value of this counter can occur
+             at re-initialization of the management system and at
+             other times as indicated by the value of
+             'discontinuity-time'.";
+          reference
+            "RFC 2863: The Interfaces Group MIB - ifHCOutUcastPkts";
+        }
+        leaf out-broadcast-pkts {
+          type yang:counter64;
+          status deprecated;
+          description
+            "The total number of packets that higher-level protocols
+             requested be transmitted and that were addressed to a
+             broadcast address at this sub-layer, including those
+             that were discarded or not sent.
+
+             Discontinuities in the value of this counter can occur
+             at re-initialization of the management system and at
+             other times as indicated by the value of
+             'discontinuity-time'.";
+          reference
+            "RFC 2863: The Interfaces Group MIB -
+                       ifHCOutBroadcastPkts";
+        }
+        leaf out-multicast-pkts {
+          type yang:counter64;
+          status deprecated;
+          description
+            "The total number of packets that higher-level protocols
+             requested be transmitted and that were addressed to a
+             multicast address at this sub-layer, including those
+             that were discarded or not sent.  For a MAC-layer
+             protocol, this includes both Group and Functional
+             addresses.
+
+             Discontinuities in the value of this counter can occur
+             at re-initialization of the management system and at
+             other times as indicated by the value of
+             'discontinuity-time'.";
+          reference
+            "RFC 2863: The Interfaces Group MIB -
+                       ifHCOutMulticastPkts";
+        }
+        leaf out-discards {
+          type yang:counter32;
+          status deprecated;
+          description
+            "The number of outbound packets that were chosen to be
+             discarded even though no errors had been detected to
+             prevent their being transmitted.  One possible reason
+             for discarding such a packet could be to free up buffer
+             space.
+
+             Discontinuities in the value of this counter can occur
+             at re-initialization of the management system and at
+             other times as indicated by the value of
+             'discontinuity-time'.";
+          reference
+            "RFC 2863: The Interfaces Group MIB - ifOutDiscards";
+        }
+        leaf out-errors {
+          type yang:counter32;
+          status deprecated;
+          description
+            "For packet-oriented interfaces, the number of outbound
+             packets that could not be transmitted because of errors.
+             For character-oriented or fixed-length interfaces, the
+             number of outbound transmission units that could not be
+             transmitted because of errors.
+
+             Discontinuities in the value of this counter can occur
+             at re-initialization of the management system and at
+             other times as indicated by the value of
+             'discontinuity-time'.";
+          reference
+            "RFC 2863: The Interfaces Group MIB - ifOutErrors";
+        }
+      }
+    }
+  }
+}
+"""
+
+ietf_netconf_acm = r"""module ietf-netconf-acm {
+  namespace "urn:ietf:params:xml:ns:yang:ietf-netconf-acm";
+  prefix nacm;
+
+  import ietf-yang-types {
+    prefix yang;
+  }
+
+  organization
+    "IETF NETCONF (Network Configuration) Working Group";
+  contact
+    "WG Web:   <https://datatracker.ietf.org/wg/netconf/>
+     WG List:  <mailto:netconf@ietf.org>
+
+     Author:   Andy Bierman
+               <mailto:andy@yumaworks.com>
+
+     Author:   Martin Bjorklund
+               <mailto:mbj@tail-f.com>";
+  description
+    "Network Configuration Access Control Model.
+
+     Copyright (c) 2012 - 2018 IETF Trust and the persons
+     identified as authors of the code.  All rights reserved.
+
+     Redistribution and use in source and binary forms, with or
+     without modification, is permitted pursuant to, and subject
+     to the license terms contained in, the Simplified BSD
+     License set forth in Section 4.c of the IETF Trust's
+     Legal Provisions Relating to IETF Documents
+     (https://trustee.ietf.org/license-info).
+
+     This version of this YANG module is part of RFC 8341; see
+     the RFC itself for full legal notices.";
+
+  revision 2018-02-14 {
+    description
+      "Added support for YANG 1.1 actions and notifications tied to
+       data nodes.  Clarified how NACM extensions can be used by
+       other data models.";
+    reference
+      "RFC 8341: Network Configuration Access Control Model";
+  }
+  revision 2012-02-22 {
+    description
+      "Initial version.";
+    reference
+      "RFC 6536: Network Configuration Protocol (NETCONF)
+                 Access Control Model";
+  }
+
+  extension default-deny-write {
+    description
+      "Used to indicate that the data model node
+       represents a sensitive security system parameter.
+
+       If present, the NETCONF server will only allow the designated
+       'recovery session' to have write access to the node.  An
+       explicit access control rule is required for all other users.
+
+       If the NACM module is used, then it must be enabled (i.e.,
+       /nacm/enable-nacm object equals 'true'), or this extension
+       is ignored.
+
+       The 'default-deny-write' extension MAY appear within a data
+       definition statement.  It is ignored otherwise.";
+  }
+  extension default-deny-all {
+    description
+      "Used to indicate that the data model node
+       controls a very sensitive security system parameter.
+
+       If present, the NETCONF server will only allow the designated
+       'recovery session' to have read, write, or execute access to
+       the node.  An explicit access control rule is required for all
+       other users.
+
+       If the NACM module is used, then it must be enabled (i.e.,
+       /nacm/enable-nacm object equals 'true'), or this extension
+       is ignored.
+
+       The 'default-deny-all' extension MAY appear within a data
+       definition statement, 'rpc' statement, or 'notification'
+       statement.  It is ignored otherwise.";
+  }
+
+  typedef user-name-type {
+    type string {
+      length "1..max";
+    }
+    description
+      "General-purpose username string.";
+  }
+
+  typedef matchall-string-type {
+    type string {
+      pattern '\*';
+    }
+    description
+      "The string containing a single asterisk '*' is used
+       to conceptually represent all possible values
+       for the particular leaf using this data type.";
+  }
+
+  typedef access-operations-type {
+    type bits {
+      bit create {
+        description
+          "Any protocol operation that creates a
+           new data node.";
+      }
+      bit read {
+        description
+          "Any protocol operation or notification that
+           returns the value of a data node.";
+      }
+      bit update {
+        description
+          "Any protocol operation that alters an existing
+           data node.";
+      }
+      bit delete {
+        description
+          "Any protocol operation that removes a data node.";
+      }
+      bit exec {
+        description
+          "Execution access to the specified protocol operation.";
+      }
+    }
+    description
+      "Access operation.";
+  }
+
+  typedef group-name-type {
+    type string {
+      length "1..max";
+      pattern '[^\*].*';
+    }
+    description
+      "Name of administrative group to which
+       users can be assigned.";
+  }
+
+  typedef action-type {
+    type enumeration {
+      enum "permit" {
+        description
+          "Requested action is permitted.";
+      }
+      enum "deny" {
+        description
+          "Requested action is denied.";
+      }
+    }
+    description
+      "Action taken by the server when a particular
+       rule matches.";
+  }
+
+  typedef node-instance-identifier {
+    type yang:xpath1.0;
+    description
+      "Path expression used to represent a special
+       data node, action, or notification instance-identifier
+       string.
+
+       A node-instance-identifier value is an
+       unrestricted YANG instance-identifier expression.
+       All the same rules as an instance-identifier apply,
+       except that predicates for keys are optional.  If a key
+       predicate is missing, then the node-instance-identifier
+       represents all possible server instances for that key.
+
+       This XML Path Language (XPath) expression is evaluated in the
+       following context:
+
+          o  The set of namespace declarations are those in scope on
+             the leaf element where this type is used.
+
+          o  The set of variable bindings contains one variable,
+             'USER', which contains the name of the user of the
+             current session.
+
+          o  The function library is the core function library, but
+             note that due to the syntax restrictions of an
+             instance-identifier, no functions are allowed.
+
+          o  The context node is the root node in the data tree.
+
+       The accessible tree includes actions and notifications tied
+       to data nodes.";
+  }
+
+  container nacm {
+    nacm:default-deny-all;
+    description
+      "Parameters for NETCONF access control model.";
+    leaf enable-nacm {
+      type boolean;
+      default "true";
+      description
+        "Enables or disables all NETCONF access control
+         enforcement.  If 'true', then enforcement
+         is enabled.  If 'false', then enforcement
+         is disabled.";
+    }
+    leaf read-default {
+      type action-type;
+      default "permit";
+      description
+        "Controls whether read access is granted if
+         no appropriate rule is found for a
+         particular read request.";
+    }
+    leaf write-default {
+      type action-type;
+      default "deny";
+      description
+        "Controls whether create, update, or delete access
+         is granted if no appropriate rule is found for a
+         particular write request.";
+    }
+    leaf exec-default {
+      type action-type;
+      default "permit";
+      description
+        "Controls whether exec access is granted if no appropriate
+         rule is found for a particular protocol operation request.";
+    }
+    leaf enable-external-groups {
+      type boolean;
+      default "true";
+      description
+        "Controls whether the server uses the groups reported by the
+         NETCONF transport layer when it assigns the user to a set of
+         NACM groups.  If this leaf has the value 'false', any group
+         names reported by the transport layer are ignored by the
+         server.";
+    }
+    leaf denied-operations {
+      type yang:zero-based-counter32;
+      config false;
+      mandatory true;
+      description
+        "Number of times since the server last restarted that a
+         protocol operation request was denied.";
+    }
+    leaf denied-data-writes {
+      type yang:zero-based-counter32;
+      config false;
+      mandatory true;
+      description
+        "Number of times since the server last restarted that a
+         protocol operation request to alter
+         a configuration datastore was denied.";
+    }
+    leaf denied-notifications {
+      type yang:zero-based-counter32;
+      config false;
+      mandatory true;
+      description
+        "Number of times since the server last restarted that
+         a notification was dropped for a subscription because
+         access to the event type was denied.";
+    }
+    container groups {
+      description
+        "NETCONF access control groups.";
+      list group {
+        key "name";
+        description
+          "One NACM group entry.  This list will only contain
+           configured entries, not any entries learned from
+           any transport protocols.";
+        leaf name {
+          type group-name-type;
+          description
+            "Group name associated with this entry.";
+        }
+        leaf-list user-name {
+          type user-name-type;
+          description
+            "Each entry identifies the username of
+             a member of the group associated with
+             this entry.";
+        }
+      }
+    }
+    list rule-list {
+      key "name";
+      ordered-by user;
+      description
+        "An ordered collection of access control rules.";
+      leaf name {
+        type string {
+          length "1..max";
+        }
+        description
+          "Arbitrary name assigned to the rule-list.";
+      }
+      leaf-list group {
+        type union {
+          type matchall-string-type;
+          type group-name-type;
+        }
+        description
+          "List of administrative groups that will be
+           assigned the associated access rights
+           defined by the 'rule' list.
+
+           The string '*' indicates that all groups apply to the
+           entry.";
+      }
+      list rule {
+        key "name";
+        ordered-by user;
+        description
+          "One access control rule.
+
+           Rules are processed in user-defined order until a match is
+           found.  A rule matches if 'module-name', 'rule-type', and
+           'access-operations' match the request.  If a rule
+           matches, the 'action' leaf determines whether or not
+           access is granted.";
+        leaf name {
+          type string {
+            length "1..max";
+          }
+          description
+            "Arbitrary name assigned to the rule.";
+        }
+        leaf module-name {
+          type union {
+            type matchall-string-type;
+            type string;
+          }
+          default "*";
+          description
+            "Name of the module associated with this rule.
+
+             This leaf matches if it has the value '*' or if the
+             object being accessed is defined in the module with the
+             specified module name.";
+        }
+        choice rule-type {
+          description
+            "This choice matches if all leafs present in the rule
+             match the request.  If no leafs are present, the
+             choice matches all requests.";
+          case protocol-operation {
+            leaf rpc-name {
+              type union {
+                type matchall-string-type;
+                type string;
+              }
+              description
+                "This leaf matches if it has the value '*' or if
+                 its value equals the requested protocol operation
+                 name.";
+            }
+          }
+          case notification {
+            leaf notification-name {
+              type union {
+                type matchall-string-type;
+                type string;
+              }
+              description
+                "This leaf matches if it has the value '*' or if its
+                 value equals the requested notification name.";
+            }
+          }
+          case data-node {
+            leaf path {
+              type node-instance-identifier;
+              mandatory true;
+              description
+                "Data node instance-identifier associated with the
+                 data node, action, or notification controlled by
+                 this rule.
+
+                 Configuration data or state data
+                 instance-identifiers start with a top-level
+                 data node.  A complete instance-identifier is
+                 required for this type of path value.
+
+                 The special value '/' refers to all possible
+                 datastore contents.";
+            }
+          }
+        }
+        leaf access-operations {
+          type union {
+            type matchall-string-type;
+            type access-operations-type;
+          }
+          default "*";
+          description
+            "Access operations associated with this rule.
+
+             This leaf matches if it has the value '*' or if the
+             bit corresponding to the requested operation is set.";
+        }
+        leaf action {
+          type action-type;
+          mandatory true;
+          description
+            "The access control action associated with the
+             rule.  If a rule has been determined to match a
+             particular request, then this object is used
+             to determine whether to permit or deny the
+             request.";
+        }
+        leaf comment {
+          type string;
+          description
+            "A textual description of the access rule.";
+        }
+      }
+    }
+  }
+}
+"""
+
+ietf_network_instance = r"""module ietf-network-instance {
+  yang-version 1.1;
+  namespace "urn:ietf:params:xml:ns:yang:ietf-network-instance";
+  prefix ni;
+
+  import ietf-interfaces {
+    prefix if;
+    reference
+      "RFC 8343: A YANG Data Model for Interface Management";
+  }
+  import ietf-ip {
+    prefix ip;
+    reference
+      "RFC 8344: A YANG Data Model for IP Management";
+  }
+  import ietf-yang-schema-mount {
+    prefix yangmnt;
+    reference
+      "RFC 8528: YANG Schema Mount";
+  }
+
+  organization
+    "IETF Routing Area (rtgwg) Working Group";
+  contact
+    "WG Web:   <https://datatracker.ietf.org/wg/rtgwg>
+     WG List:  <mailto:rtgwg@ietf.org>
+
+     Author:   Lou Berger
+               <mailto:lberger@labn.net>
+     Author:   Christian Hopps
+               <mailto:chopps@chopps.org>
+     Author:   Acee Lindem
+               <mailto:acee@cisco.com>
+     Author:   Dean Bogdanovic
+               <mailto:ivandean@gmail.com>";
+  description
+    "This module is used to support multiple network instances
+     within a single physical or virtual device.  Network
+     instances are commonly known as VRFs (VPN Routing and
+     Forwarding) and VSIs (Virtual Switching Instances).
+     The key words 'MUST', 'MUST NOT', 'REQUIRED', 'SHALL',
+     'SHALL NOT', 'SHOULD', 'SHOULD NOT', 'RECOMMENDED',
+     'NOT RECOMMENDED', 'MAY', and 'OPTIONAL' in this document
+     are to be interpreted as described in BCP 14 (RFC 2119)
+     (RFC 8174) when, and only when, they appear in all capitals,
+      as shown here.
+
+     Copyright (c) 2019 IETF Trust and the persons identified as
+     authors of the code.  All rights reserved.
+
+     Redistribution and use in source and binary forms, with or
+     without modification, is permitted pursuant to, and subject
+     to the license terms contained in, the Simplified BSD
+     License set forth in Section 4.c of the IETF Trust's Legal
+     Provisions Relating to IETF Documents
+     (https://trustee.ietf.org/license-info).
+
+     This version of this YANG module is part of RFC 8529; see
+     the RFC itself for full legal notices.";
+
+  revision 2019-01-21 {
+    description
+      "Initial revision.";
+    reference
+      "RFC 8529";
+  }
+
+  container network-instances {
+    description
+      "Network instances, each of which consists of
+       VRFs and/or VSIs.";
+    reference
+      "RFC 8349: A YANG Data Model for Routing Management";
+    list network-instance {
+      key "name";
+      description
+        "List of network instances.";
+      leaf name {
+        type string;
+        mandatory true;
+        description
+          "device-scoped identifier for the network
+           instance.";
+      }
+      leaf enabled {
+        type boolean;
+        default "true";
+        description
+          "Flag indicating whether or not the network
+           instance is enabled.";
+      }
+      leaf description {
+        type string;
+        description
+          "Description of the network instance
+           and its intended purpose.";
+      }
+      choice ni-type {
+        description
+          "This node serves as an anchor point for different types
+           of network instances.  Each 'case' is expected to
+           differ in terms of the information needed in the
+           parent/core to support the NI and may differ in their
+           mounted-schema definition.  When the mounted schema is
+           not expected to be the same for a specific type of NI,
+           a mount point should be defined.";
+      }
+      choice root-type {
+        mandatory true;
+        description
+          "Well-known mount points.";
+        container vrf-root {
+          yangmnt:mount-point "vrf-root" {
+            description
+              "Root for L3VPN-type models.  This will typically
+               not be an inline-type mount point.";
+          }
+          description
+            "Container for mount point.";
+        }
+        container vsi-root {
+          yangmnt:mount-point "vsi-root" {
+            description
+              "Root for L2VPN-type models.  This will typically
+               not be an inline-type mount point.";
+          }
+          description
+            "Container for mount point.";
+        }
+        container vv-root {
+          yangmnt:mount-point "vv-root" {
+            description
+              "Root models that support both L2VPN-type bridging
+               and L3VPN-type routing.  This will typically
+               not be an inline-type mount point.";
+          }
+          description
+            "Container for mount point.";
+        }
+      }
+    }
+  }
+
+  augment "/if:interfaces/if:interface" {
+    description
+      "Add a node for the identification of the network
+       instance associated with the information configured
+       on a interface.
+
+       Note that a standard error will be returned if the
+       identified leafref isn't present.  If an interface cannot
+       be assigned for any other reason, the operation SHALL fail
+       with an error-tag of 'operation-failed' and an
+       error-app-tag of 'ni-assignment-failed'.  A meaningful
+       error-info that indicates the source of the assignment
+       failure SHOULD also be provided.";
+    leaf bind-ni-name {
+      type leafref {
+        path "/network-instances/network-instance/name";
+      }
+      description
+        "Network instance to which an interface is bound.";
+    }
+  }
+  augment "/if:interfaces/if:interface/ip:ipv4" {
+    description
+      "Add a node for the identification of the network
+       instance associated with the information configured
+       on an IPv4 interface.
+
+       Note that a standard error will be returned if the
+       identified leafref isn't present.  If an interface cannot
+       be assigned for any other reason, the operation SHALL fail
+       with an error-tag of 'operation-failed' and an
+       error-app-tag of 'ni-assignment-failed'.  A meaningful
+       error-info that indicates the source of the assignment
+       failure SHOULD also be provided.";
+    leaf bind-ni-name {
+      type leafref {
+        path "/network-instances/network-instance/name";
+      }
+      description
+        "Network instance to which IPv4 interface is bound.";
+    }
+  }
+  augment "/if:interfaces/if:interface/ip:ipv6" {
+    description
+      "Add a node for the identification of the network
+       instance associated with the information configured
+       on an IPv6 interface.
+
+       Note that a standard error will be returned if the
+       identified leafref isn't present.  If an interface cannot
+       be assigned for any other reason, the operation SHALL fail
+       with an error-tag of 'operation-failed' and an
+       error-app-tag of 'ni-assignment-failed'.  A meaningful
+       error-info that indicates the source of the assignment
+       failure SHOULD also be provided.";
+    leaf bind-ni-name {
+      type leafref {
+        path "/network-instances/network-instance/name";
+      }
+      description
+        "Network instance to which IPv6 interface is bound.";
+    }
+  }
+
+  notification bind-ni-name-failed {
+    description
+      "Indicates an error in the association of an interface to an
+       NI.  Only generated after success is initially returned when
+       bind-ni-name is set.
+
+       Note: Some errors may need to be reported for multiple
+       associations, e.g., a single error may need to be reported
+       for an IPv4 and an IPv6 bind-ni-name.
+
+       At least one container with a bind-ni-name leaf MUST be
+       included in this notification.";
+    leaf name {
+      type leafref {
+        path "/if:interfaces/if:interface/if:name";
+      }
+      mandatory true;
+      description
+        "Contains the interface name associated with the
+         failure.";
+    }
+    container interface {
+      description
+        "Generic interface type.";
+      leaf bind-ni-name {
+        type leafref {
+          path "/if:interfaces/if:interface/ni:bind-ni-name";
+        }
+        description
+          "Contains the bind-ni-name associated with the
+           failure.";
+      }
+    }
+    container ipv4 {
+      description
+        "IPv4 interface type.";
+      leaf bind-ni-name {
+        type leafref {
+          path "/if:interfaces/if:interface/ip:ipv4/ni:bind-ni-name";
+        }
+        description
+          "Contains the bind-ni-name associated with the
+           failure.";
+      }
+    }
+    container ipv6 {
+      description
+        "IPv6 interface type.";
+      leaf bind-ni-name {
+        type leafref {
+          path "/if:interfaces/if:interface/ip:ipv6/ni:bind-ni-name";
+        }
+        description
+          "Contains the bind-ni-name associated with the
+           failure.";
+      }
+    }
+    leaf error-info {
+      type string;
+      description
+        "Optionally, indicates the source of the assignment
+         failure.";
+    }
+  }
+}
+"""
+
+ietf_ip = r"""module ietf-ip {
+  yang-version 1.1;
+  namespace "urn:ietf:params:xml:ns:yang:ietf-ip";
+  prefix ip;
+
+  import ietf-interfaces {
+    prefix if;
+  }
+  import ietf-inet-types {
+    prefix inet;
+  }
+  import ietf-yang-types {
+    prefix yang;
+  }
+
+  organization
+    "IETF NETMOD (Network Modeling) Working Group";
+  contact
+    "WG Web:   <https://datatracker.ietf.org/wg/netmod/>
+     WG List:  <mailto:netmod@ietf.org>
+
+     Editor:   Martin Bjorklund
+               <mailto:mbj@tail-f.com>";
+  description
+    "This module contains a collection of YANG definitions for
+     managing IP implementations.
+
+     Copyright (c) 2018 IETF Trust and the persons identified as
+     authors of the code.  All rights reserved.
+
+     Redistribution and use in source and binary forms, with or
+     without modification, is permitted pursuant to, and subject
+     to the license terms contained in, the Simplified BSD License
+     set forth in Section 4.c of the IETF Trust's Legal Provisions
+     Relating to IETF Documents
+     (https://trustee.ietf.org/license-info).
+
+     This version of this YANG module is part of RFC 8344; see
+     the RFC itself for full legal notices.";
+
+  revision 2018-02-22 {
+    description
+      "Updated to support NMDA.";
+    reference
+      "RFC 8344: A YANG Data Model for IP Management";
+  }
+  revision 2014-06-16 {
+    description
+      "Initial revision.";
+    reference
+      "RFC 7277: A YANG Data Model for IP Management";
+  }
+
+  feature ipv4-non-contiguous-netmasks {
+    description
+      "Indicates support for configuring non-contiguous
+       subnet masks.";
+  }
+
+  feature ipv6-privacy-autoconf {
+    description
+      "Indicates support for privacy extensions for stateless address
+       autoconfiguration in IPv6.";
+    reference
+      "RFC 4941: Privacy Extensions for Stateless Address
+                 Autoconfiguration in IPv6";
+  }
+
+  typedef ip-address-origin {
+    type enumeration {
+      enum "other" {
+        description
+          "None of the following.";
+      }
+      enum "static" {
+        description
+          "Indicates that the address has been statically
+           configured -- for example, using the Network Configuration
+           Protocol (NETCONF) or a command line interface.";
+      }
+      enum "dhcp" {
+        description
+          "Indicates an address that has been assigned to this
+           system by a DHCP server.";
+      }
+      enum "link-layer" {
+        description
+          "Indicates an address created by IPv6 stateless
+           autoconfiguration that embeds a link-layer address in its
+           interface identifier.";
+      }
+      enum "random" {
+        description
+          "Indicates an address chosen by the system at
+           random, e.g., an IPv4 address within 169.254/16, a
+           temporary address as described in RFC 4941, or a
+           semantically opaque address as described in RFC 7217.";
+        reference
+          "RFC 4941: Privacy Extensions for Stateless Address
+                     Autoconfiguration in IPv6
+           RFC 7217: A Method for Generating Semantically Opaque
+                     Interface Identifiers with IPv6 Stateless
+                     Address Autoconfiguration (SLAAC)";
+      }
+    }
+    description
+      "The origin of an address.";
+  }
+
+  typedef neighbor-origin {
+    type enumeration {
+      enum "other" {
+        description
+          "None of the following.";
+      }
+      enum "static" {
+        description
+          "Indicates that the mapping has been statically
+           configured -- for example, using NETCONF or a command line
+           interface.";
+      }
+      enum "dynamic" {
+        description
+          "Indicates that the mapping has been dynamically resolved
+           using, for example, IPv4 ARP or the IPv6 Neighbor
+           Discovery protocol.";
+      }
+    }
+    description
+      "The origin of a neighbor entry.";
+  }
+
+  augment "/if:interfaces/if:interface" {
+    description
+      "IP parameters on interfaces.
+
+       If an interface is not capable of running IP, the server
+       must not allow the client to configure these parameters.";
+    container ipv4 {
+      presence "Enables IPv4 unless the 'enabled' leaf
+       (which defaults to 'true') is set to 'false'";
+      description
+        "Parameters for the IPv4 address family.";
+      leaf enabled {
+        type boolean;
+        default "true";
+        description
+          "Controls whether IPv4 is enabled or disabled on this
+           interface.  When IPv4 is enabled, this interface is
+           connected to an IPv4 stack, and the interface can send
+           and receive IPv4 packets.";
+      }
+      leaf forwarding {
+        type boolean;
+        default "false";
+        description
+          "Controls IPv4 packet forwarding of datagrams received by,
+           but not addressed to, this interface.  IPv4 routers
+           forward datagrams.  IPv4 hosts do not (except those
+           source-routed via the host).";
+      }
+      leaf mtu {
+        type uint16 {
+          range "68..max";
+        }
+        units "octets";
+        description
+          "The size, in octets, of the largest IPv4 packet that the
+           interface will send and receive.
+
+           The server may restrict the allowed values for this leaf,
+           depending on the interface's type.
+
+           If this leaf is not configured, the operationally used MTU
+           depends on the interface's type.";
+        reference
+          "RFC 791: Internet Protocol";
+      }
+      list address {
+        key "ip";
+        description
+          "The list of IPv4 addresses on the interface.";
+        leaf ip {
+          type inet:ipv4-address-no-zone;
+          description
+            "The IPv4 address on the interface.";
+        }
+        choice subnet {
+          mandatory true;
+          description
+            "The subnet can be specified as a prefix length or,
+             if the server supports non-contiguous netmasks, as
+             a netmask.";
+          leaf prefix-length {
+            type uint8 {
+              range "0..32";
+            }
+            description
+              "The length of the subnet prefix.";
+          }
+          leaf netmask {
+            if-feature "ipv4-non-contiguous-netmasks";
+            type yang:dotted-quad;
+            description
+              "The subnet specified as a netmask.";
+          }
+        }
+        leaf origin {
+          type ip-address-origin;
+          config false;
+          description
+            "The origin of this address.";
+        }
+      }
+      list neighbor {
+        key "ip";
+        description
+          "A list of mappings from IPv4 addresses to
+           link-layer addresses.
+
+           Entries in this list in the intended configuration are
+           used as static entries in the ARP Cache.
+
+           In the operational state, this list represents the ARP
+           Cache.";
+        reference
+          "RFC 826: An Ethernet Address Resolution Protocol";
+        leaf ip {
+          type inet:ipv4-address-no-zone;
+          description
+            "The IPv4 address of the neighbor node.";
+        }
+        leaf link-layer-address {
+          type yang:phys-address;
+          mandatory true;
+          description
+            "The link-layer address of the neighbor node.";
+        }
+        leaf origin {
+          type neighbor-origin;
+          config false;
+          description
+            "The origin of this neighbor entry.";
+        }
+      }
+    }
+    container ipv6 {
+      presence "Enables IPv6 unless the 'enabled' leaf
+       (which defaults to 'true') is set to 'false'";
+      description
+        "Parameters for the IPv6 address family.";
+      leaf enabled {
+        type boolean;
+        default "true";
+        description
+          "Controls whether IPv6 is enabled or disabled on this
+           interface.  When IPv6 is enabled, this interface is
+           connected to an IPv6 stack, and the interface can send
+           and receive IPv6 packets.";
+      }
+      leaf forwarding {
+        type boolean;
+        default "false";
+        description
+          "Controls IPv6 packet forwarding of datagrams received by,
+           but not addressed to, this interface.  IPv6 routers
+           forward datagrams.  IPv6 hosts do not (except those
+           source-routed via the host).";
+        reference
+          "RFC 4861: Neighbor Discovery for IP version 6 (IPv6)
+                     Section 6.2.1, IsRouter";
+      }
+      leaf mtu {
+        type uint32 {
+          range "1280..max";
+        }
+        units "octets";
+        description
+          "The size, in octets, of the largest IPv6 packet that the
+           interface will send and receive.
+
+           The server may restrict the allowed values for this leaf,
+           depending on the interface's type.
+
+           If this leaf is not configured, the operationally used MTU
+           depends on the interface's type.";
+        reference
+          "RFC 8200: Internet Protocol, Version 6 (IPv6)
+                     Specification
+                     Section 5";
+      }
+      list address {
+        key "ip";
+        description
+          "The list of IPv6 addresses on the interface.";
+        leaf ip {
+          type inet:ipv6-address-no-zone;
+          description
+            "The IPv6 address on the interface.";
+        }
+        leaf prefix-length {
+          type uint8 {
+            range "0..128";
+          }
+          mandatory true;
+          description
+            "The length of the subnet prefix.";
+        }
+        leaf origin {
+          type ip-address-origin;
+          config false;
+          description
+            "The origin of this address.";
+        }
+        leaf status {
+          type enumeration {
+            enum "preferred" {
+              description
+                "This is a valid address that can appear as the
+                 destination or source address of a packet.";
+            }
+            enum "deprecated" {
+              description
+                "This is a valid but deprecated address that should
+                 no longer be used as a source address in new
+                 communications, but packets addressed to such an
+                 address are processed as expected.";
+            }
+            enum "invalid" {
+              description
+                "This isn't a valid address, and it shouldn't appear
+                 as the destination or source address of a packet.";
+            }
+            enum "inaccessible" {
+              description
+                "The address is not accessible because the interface
+                 to which this address is assigned is not
+                 operational.";
+            }
+            enum "unknown" {
+              description
+                "The status cannot be determined for some reason.";
+            }
+            enum "tentative" {
+              description
+                "The uniqueness of the address on the link is being
+                 verified.  Addresses in this state should not be
+                 used for general communication and should only be
+                 used to determine the uniqueness of the address.";
+            }
+            enum "duplicate" {
+              description
+                "The address has been determined to be non-unique on
+                 the link and so must not be used.";
+            }
+            enum "optimistic" {
+              description
+                "The address is available for use, subject to
+                 restrictions, while its uniqueness on a link is
+                 being verified.";
+            }
+          }
+          config false;
+          description
+            "The status of an address.  Most of the states correspond
+             to states from the IPv6 Stateless Address
+             Autoconfiguration protocol.";
+          reference
+            "RFC 4293: Management Information Base for the
+                       Internet Protocol (IP)
+                       - IpAddressStatusTC
+             RFC 4862: IPv6 Stateless Address Autoconfiguration";
+        }
+      }
+      list neighbor {
+        key "ip";
+        description
+          "A list of mappings from IPv6 addresses to
+           link-layer addresses.
+
+           Entries in this list in the intended configuration are
+           used as static entries in the Neighbor Cache.
+
+           In the operational state, this list represents the
+           Neighbor Cache.";
+        reference
+          "RFC 4861: Neighbor Discovery for IP version 6 (IPv6)";
+        leaf ip {
+          type inet:ipv6-address-no-zone;
+          description
+            "The IPv6 address of the neighbor node.";
+        }
+        leaf link-layer-address {
+          type yang:phys-address;
+          mandatory true;
+          description
+            "The link-layer address of the neighbor node.
+
+             In the operational state, if the neighbor's 'state' leaf
+             is 'incomplete', this leaf is not instantiated.";
+        }
+        leaf origin {
+          type neighbor-origin;
+          config false;
+          description
+            "The origin of this neighbor entry.";
+        }
+        leaf is-router {
+          type empty;
+          config false;
+          description
+            "Indicates that the neighbor node acts as a router.";
+        }
+        leaf state {
+          type enumeration {
+            enum "incomplete" {
+              description
+                "Address resolution is in progress, and the
+                 link-layer address of the neighbor has not yet been
+                 determined.";
+            }
+            enum "reachable" {
+              description
+                "Roughly speaking, the neighbor is known to have been
+                 reachable recently (within tens of seconds ago).";
+            }
+            enum "stale" {
+              description
+                "The neighbor is no longer known to be reachable, but
+                 until traffic is sent to the neighbor no attempt
+                 should be made to verify its reachability.";
+            }
+            enum "delay" {
+              description
+                "The neighbor is no longer known to be reachable, and
+                 traffic has recently been sent to the neighbor.
+                 Rather than probe the neighbor immediately, however,
+                 delay sending probes for a short while in order to
+                 give upper-layer protocols a chance to provide
+                 reachability confirmation.";
+            }
+            enum "probe" {
+              description
+                "The neighbor is no longer known to be reachable, and
+                 unicast Neighbor Solicitation probes are being sent
+                 to verify reachability.";
+            }
+          }
+          config false;
+          description
+            "The Neighbor Unreachability Detection state of this
+             entry.";
+          reference
+            "RFC 4861: Neighbor Discovery for IP version 6 (IPv6)
+                       Section 7.3.2";
+        }
+      }
+      leaf dup-addr-detect-transmits {
+        type uint32;
+        default "1";
+        description
+          "The number of consecutive Neighbor Solicitation messages
+           sent while performing Duplicate Address Detection on a
+           tentative address.  A value of zero indicates that
+           Duplicate Address Detection is not performed on
+           tentative addresses.  A value of one indicates a single
+           transmission with no follow-up retransmissions.";
+        reference
+          "RFC 4862: IPv6 Stateless Address Autoconfiguration";
+      }
+      container autoconf {
+        description
+          "Parameters to control the autoconfiguration of IPv6
+           addresses, as described in RFC 4862.";
+        reference
+          "RFC 4862: IPv6 Stateless Address Autoconfiguration";
+        leaf create-global-addresses {
+          type boolean;
+          default "true";
+          description
+            "If enabled, the host creates global addresses as
+             described in RFC 4862.";
+          reference
+            "RFC 4862: IPv6 Stateless Address Autoconfiguration
+                       Section 5.5";
+        }
+        leaf create-temporary-addresses {
+          if-feature "ipv6-privacy-autoconf";
+          type boolean;
+          default "false";
+          description
+            "If enabled, the host creates temporary addresses as
+             described in RFC 4941.";
+          reference
+            "RFC 4941: Privacy Extensions for Stateless Address
+                       Autoconfiguration in IPv6";
+        }
+        leaf temporary-valid-lifetime {
+          if-feature "ipv6-privacy-autoconf";
+          type uint32;
+          units "seconds";
+          default "604800";
+          description
+            "The time period during which the temporary address
+             is valid.";
+          reference
+            "RFC 4941: Privacy Extensions for Stateless Address
+                       Autoconfiguration in IPv6
+                       - TEMP_VALID_LIFETIME";
+        }
+        leaf temporary-preferred-lifetime {
+          if-feature "ipv6-privacy-autoconf";
+          type uint32;
+          units "seconds";
+          default "86400";
+          description
+            "The time period during which the temporary address is
+             preferred.";
+          reference
+            "RFC 4941: Privacy Extensions for Stateless Address
+                       Autoconfiguration in IPv6
+                       - TEMP_PREFERRED_LIFETIME";
+        }
+      }
+    }
+  }
+  augment "/if:interfaces-state/if:interface" {
+    status deprecated;
+    description
+      "Data nodes for the operational state of IP on interfaces.";
+    container ipv4 {
+      presence "Present if IPv4 is enabled on this interface";
+      config false;
+      status deprecated;
+      description
+        "Interface-specific parameters for the IPv4 address family.";
+      leaf forwarding {
+        type boolean;
+        status deprecated;
+        description
+          "Indicates whether IPv4 packet forwarding is enabled or
+           disabled on this interface.";
+      }
+      leaf mtu {
+        type uint16 {
+          range "68..max";
+        }
+        units "octets";
+        status deprecated;
+        description
+          "The size, in octets, of the largest IPv4 packet that the
+           interface will send and receive.";
+        reference
+          "RFC 791: Internet Protocol";
+      }
+      list address {
+        key "ip";
+        status deprecated;
+        description
+          "The list of IPv4 addresses on the interface.";
+        leaf ip {
+          type inet:ipv4-address-no-zone;
+          status deprecated;
+          description
+            "The IPv4 address on the interface.";
+        }
+        choice subnet {
+          status deprecated;
+          description
+            "The subnet can be specified as a prefix length or,
+             if the server supports non-contiguous netmasks, as
+             a netmask.";
+          leaf prefix-length {
+            type uint8 {
+              range "0..32";
+            }
+            status deprecated;
+            description
+              "The length of the subnet prefix.";
+          }
+          leaf netmask {
+            if-feature "ipv4-non-contiguous-netmasks";
+            type yang:dotted-quad;
+            status deprecated;
+            description
+              "The subnet specified as a netmask.";
+          }
+        }
+        leaf origin {
+          type ip-address-origin;
+          status deprecated;
+          description
+            "The origin of this address.";
+        }
+      }
+      list neighbor {
+        key "ip";
+        status deprecated;
+        description
+          "A list of mappings from IPv4 addresses to
+           link-layer addresses.
+
+           This list represents the ARP Cache.";
+        reference
+          "RFC 826: An Ethernet Address Resolution Protocol";
+        leaf ip {
+          type inet:ipv4-address-no-zone;
+          status deprecated;
+          description
+            "The IPv4 address of the neighbor node.";
+        }
+        leaf link-layer-address {
+          type yang:phys-address;
+          status deprecated;
+          description
+            "The link-layer address of the neighbor node.";
+        }
+        leaf origin {
+          type neighbor-origin;
+          status deprecated;
+          description
+            "The origin of this neighbor entry.";
+        }
+      }
+    }
+    container ipv6 {
+      presence "Present if IPv6 is enabled on this interface";
+      config false;
+      status deprecated;
+      description
+        "Parameters for the IPv6 address family.";
+      leaf forwarding {
+        type boolean;
+        default "false";
+        status deprecated;
+        description
+          "Indicates whether IPv6 packet forwarding is enabled or
+           disabled on this interface.";
+        reference
+          "RFC 4861: Neighbor Discovery for IP version 6 (IPv6)
+                     Section 6.2.1, IsRouter";
+      }
+      leaf mtu {
+        type uint32 {
+          range "1280..max";
+        }
+        units "octets";
+        status deprecated;
+        description
+          "The size, in octets, of the largest IPv6 packet that the
+           interface will send and receive.";
+        reference
+          "RFC 8200: Internet Protocol, Version 6 (IPv6)
+                     Specification
+                     Section 5";
+      }
+      list address {
+        key "ip";
+        status deprecated;
+        description
+          "The list of IPv6 addresses on the interface.";
+        leaf ip {
+          type inet:ipv6-address-no-zone;
+          status deprecated;
+          description
+            "The IPv6 address on the interface.";
+        }
+        leaf prefix-length {
+          type uint8 {
+            range "0..128";
+          }
+          mandatory true;
+          status deprecated;
+          description
+            "The length of the subnet prefix.";
+        }
+        leaf origin {
+          type ip-address-origin;
+          status deprecated;
+          description
+            "The origin of this address.";
+        }
+        leaf status {
+          type enumeration {
+            enum "preferred" {
+              description
+                "This is a valid address that can appear as the
+                 destination or source address of a packet.";
+            }
+            enum "deprecated" {
+              description
+                "This is a valid but deprecated address that should
+                 no longer be used as a source address in new
+                 communications, but packets addressed to such an
+                 address are processed as expected.";
+            }
+            enum "invalid" {
+              description
+                "This isn't a valid address, and it shouldn't appear
+                 as the destination or source address of a packet.";
+            }
+            enum "inaccessible" {
+              description
+                "The address is not accessible because the interface
+                 to which this address is assigned is not
+                 operational.";
+            }
+            enum "unknown" {
+              description
+                "The status cannot be determined for some reason.";
+            }
+            enum "tentative" {
+              description
+                "The uniqueness of the address on the link is being
+                 verified.  Addresses in this state should not be
+                 used for general communication and should only be
+                 used to determine the uniqueness of the address.";
+            }
+            enum "duplicate" {
+              description
+                "The address has been determined to be non-unique on
+                 the link and so must not be used.";
+            }
+            enum "optimistic" {
+              description
+                "The address is available for use, subject to
+                 restrictions, while its uniqueness on a link is
+                 being verified.";
+            }
+          }
+          status deprecated;
+          description
+            "The status of an address.  Most of the states correspond
+             to states from the IPv6 Stateless Address
+             Autoconfiguration protocol.";
+          reference
+            "RFC 4293: Management Information Base for the
+                       Internet Protocol (IP)
+                       - IpAddressStatusTC
+             RFC 4862: IPv6 Stateless Address Autoconfiguration";
+        }
+      }
+      list neighbor {
+        key "ip";
+        status deprecated;
+        description
+          "A list of mappings from IPv6 addresses to
+           link-layer addresses.
+
+           This list represents the Neighbor Cache.";
+        reference
+          "RFC 4861: Neighbor Discovery for IP version 6 (IPv6)";
+        leaf ip {
+          type inet:ipv6-address-no-zone;
+          status deprecated;
+          description
+            "The IPv6 address of the neighbor node.";
+        }
+        leaf link-layer-address {
+          type yang:phys-address;
+          status deprecated;
+          description
+            "The link-layer address of the neighbor node.";
+        }
+        leaf origin {
+          type neighbor-origin;
+          status deprecated;
+          description
+            "The origin of this neighbor entry.";
+        }
+        leaf is-router {
+          type empty;
+          status deprecated;
+          description
+            "Indicates that the neighbor node acts as a router.";
+        }
+        leaf state {
+          type enumeration {
+            enum "incomplete" {
+              description
+                "Address resolution is in progress, and the
+                 link-layer address of the neighbor has not yet been
+                 determined.";
+            }
+            enum "reachable" {
+              description
+                "Roughly speaking, the neighbor is known to have been
+                 reachable recently (within tens of seconds ago).";
+            }
+            enum "stale" {
+              description
+                "The neighbor is no longer known to be reachable, but
+                 until traffic is sent to the neighbor no attempt
+                 should be made to verify its reachability.";
+            }
+            enum "delay" {
+              description
+                "The neighbor is no longer known to be reachable, and
+                 traffic has recently been sent to the neighbor.
+                 Rather than probe the neighbor immediately, however,
+                 delay sending probes for a short while in order to
+                 give upper-layer protocols a chance to provide
+                 reachability confirmation.";
+            }
+            enum "probe" {
+              description
+                "The neighbor is no longer known to be reachable, and
+                 unicast Neighbor Solicitation probes are being sent
+                 to verify reachability.";
+            }
+          }
+          status deprecated;
+          description
+            "The Neighbor Unreachability Detection state of this
+             entry.";
+          reference
+            "RFC 4861: Neighbor Discovery for IP version 6 (IPv6)
+                       Section 7.3.2";
+        }
+      }
+    }
+  }
+}
+"""
+
+ietf_yang_schema_mount = r"""module ietf-yang-schema-mount {
+  yang-version 1.1;
+  namespace "urn:ietf:params:xml:ns:yang:ietf-yang-schema-mount";
+  prefix yangmnt;
+
+  import ietf-inet-types {
+    prefix inet;
+    reference
+      "RFC 6991: Common YANG Data Types";
+  }
+  import ietf-yang-types {
+    prefix yang;
+    reference
+      "RFC 6991: Common YANG Data Types";
+  }
+
+  organization
+    "IETF NETMOD (NETCONF Data Modeling Language) Working Group";
+  contact
+    "WG Web:   <https://datatracker.ietf.org/wg/netmod/>
+     WG List:  <mailto:netmod@ietf.org>
+
+     Editor:   Martin Bjorklund
+               <mailto:mbj@tail-f.com>
+
+     Editor:   Ladislav Lhotka
+               <mailto:lhotka@nic.cz>";
+  description
+    "This module defines a YANG extension statement that can be used
+     to incorporate data models defined in other YANG modules in a
+     module.  It also defines operational state data that specify the
+     overall structure of the data model.
+
+     The key words 'MUST', 'MUST NOT', 'REQUIRED', 'SHALL', 'SHALL
+     NOT', 'SHOULD', 'SHOULD NOT', 'RECOMMENDED', 'NOT RECOMMENDED',
+     'MAY', and 'OPTIONAL' in this document are to be interpreted as
+     described in BCP 14 (RFC 2119) (RFC 8174) when, and only when,
+     they appear in all capitals, as shown here.
+
+     Copyright (c) 2019 IETF Trust and the persons identified as
+     authors of the code.  All rights reserved.
+
+     Redistribution and use in source and binary forms, with or
+     without modification, is permitted pursuant to, and subject to
+     the license terms contained in, the Simplified BSD License set
+     forth in Section 4.c of the IETF Trust's Legal Provisions
+     Relating to IETF Documents
+     (https://trustee.ietf.org/license-info).
+
+     This version of this YANG module is part of RFC 8528;
+     see the RFC itself for full legal notices.";
+
+  revision 2019-01-14 {
+    description
+      "Initial revision.";
+    reference
+      "RFC 8528: YANG Schema Mount";
+  }
+
+  extension mount-point {
+    argument label;
+    description
+      "The argument 'label' is a YANG identifier, i.e., it is of the
+       type 'yang:yang-identifier'.
+
+       The 'mount-point' statement MUST NOT be used in a YANG
+       version 1 module, neither explicitly nor via a 'uses'
+       statement.
+       The 'mount-point' statement MAY be present as a substatement
+       of 'container' and 'list' and MUST NOT be present elsewhere.
+       There MUST NOT be more than one 'mount-point' statement in a
+       given 'container' or 'list' statement.
+
+       If a mount point is defined within a grouping, its label is
+       bound to the module where the grouping is used.
+
+       A mount point defines a place in the node hierarchy where
+       other data models may be attached.  A server that implements a
+       module with a mount point populates the
+       '/schema-mounts/mount-point' list with detailed information on
+       which data models are mounted at each mount point.
+
+       Note that the 'mount-point' statement does not define a new
+       data node.";
+  }
+
+  container schema-mounts {
+    config false;
+    description
+      "Contains information about the structure of the overall
+       mounted data model implemented in the server.";
+    list namespace {
+      key "prefix";
+      description
+        "This list provides a mapping of namespace prefixes that are
+         used in XPath expressions of 'parent-reference' leafs to the
+         corresponding namespace URI references.";
+      leaf prefix {
+        type yang:yang-identifier;
+        description
+          "Namespace prefix.";
+      }
+      leaf uri {
+        type inet:uri;
+        description
+          "Namespace URI reference.";
+      }
+    }
+    list mount-point {
+      key "module label";
+      description
+        "Each entry of this list specifies a schema for a particular
+         mount point.
+
+         Each mount point MUST be defined using the 'mount-point'
+         extension in one of the modules listed in the server's
+         YANG library instance with conformance type 'implement'.";
+      leaf module {
+        type yang:yang-identifier;
+        description
+          "Name of a module containing the mount point.";
+      }
+      leaf label {
+        type yang:yang-identifier;
+        description
+          "Label of the mount point defined using the 'mount-point'
+           extension.";
+      }
+      leaf config {
+        type boolean;
+        default "true";
+        description
+          "If this leaf is set to 'false', then all data nodes in the
+           mounted schema are read-only ('config false'), regardless
+           of their 'config' property.";
+      }
+      choice schema-ref {
+        mandatory true;
+        description
+          "Alternatives for specifying the schema.";
+        container inline {
+          presence "A complete self-contained schema is mounted at the
+           mount point.";
+          description
+            "This node indicates that the server has mounted at least
+             the module 'ietf-yang-library' at the mount point, and
+             its instantiation provides the information about the
+             mounted schema.
+
+             Different instances of the mount point may have
+             different schemas mounted.";
+        }
+        container shared-schema {
+          presence "The mounted schema together with the 'parent-reference'
+           make up the schema for this mount point.";
+          description
+            "This node indicates that the server has mounted at least
+             the module 'ietf-yang-library' at the mount point, and
+             its instantiation provides the information about the
+             mounted schema.  When XPath expressions in the mounted
+             schema are evaluated, the 'parent-reference' leaf-list
+             is taken into account.
+
+             Different instances of the mount point MUST have the
+             same schema mounted.";
+          leaf-list parent-reference {
+            type yang:xpath1.0;
+            description
+              "Entries of this leaf-list are XPath 1.0 expressions
+               that are evaluated in the following context:
+
+               - The context node is the node in the parent data tree
+                 where the mount-point is defined.
+
+               - The accessible tree is the parent data tree
+                 *without* any nodes defined in modules that are
+                 mounted inside the parent schema.
+
+               - The context position and context size are both equal
+                 to 1.
+
+               - The set of variable bindings is empty.
+
+               - The function library is the core function library
+                 defined in the W3C XPath 1.0 document
+                 (http://www.w3.org/TR/1999/REC-xpath-19991116) and
+                 the functions defined in Section 10 of RFC 7950.
+
+               - The set of namespace declarations is defined by the
+                 'namespace' list under 'schema-mounts'.
+
+               Each XPath expression MUST evaluate to a node-set
+               (possibly empty).  For the purposes of evaluating
+               XPath expressions whose context nodes are defined in
+               the mounted schema, the union of all these node-sets
+               together with ancestor nodes are added to the
+               accessible data tree.
+
+               Note that in the case 'ietf-yang-schema-mount' is
+               itself mounted, a 'parent-reference' in the mounted
+               module may refer to nodes that were brought into the
+               accessible tree through a 'parent-reference' in the
+               parent schema.";
+          }
+        }
+      }
+    }
+  }
+}
+"""

--- a/src/test_devicemgr_netconf.act
+++ b/src/test_devicemgr_netconf.act
@@ -10,6 +10,7 @@ import yang.schema as yschema
 
 import device as swdev
 import adapters.netconf as swna
+import monitoring
 import swyang
 
 from device_meta_config import \
@@ -247,7 +248,7 @@ actor _test_get_yang_library(t: testing.EnvT):
         if isinstance(adapter, swna.NetconfAdapter):
             rpc = xml.Node("get", children=[
                 xml.Node("filter", attributes=[("type", "subtree")], children=[
-                    xml.Node("yang-library", [(None, swna.NS_YANG_LIBRARY)], children=[
+                    xml.Node("yang-library", [(None, monitoring.NS_YANG_LIBRARY)], children=[
                         xml.Node("module-set"),
                         xml.Node("schema"),
                         xml.Node("datastore")

--- a/src/test_monitoring.act
+++ b/src/test_monitoring.act
@@ -1,0 +1,72 @@
+"""Unit tests for the reusable ietf-yang-library + get-schema serving helpers."""
+
+import testing
+import std.xml as xml
+
+import yang
+import yang.schema as yschema
+
+import monitoring
+import swyang
+
+
+DEMO_YANG = r"""module demo {
+  yang-version 1.1;
+  namespace "urn:demo";
+  prefix d;
+  container system {
+    leaf hostname { type string; }
+  }
+}"""
+
+
+def _schema_with_library() -> yschema.DRoot:
+    return yang.compile([DEMO_YANG, swyang.ietf_yang_library, swyang.ietf_datastores,
+                         swyang.ietf_yang_types, swyang.ietf_inet_types])
+
+
+def _test_yl_view_present():
+    """When the inventory implements ietf-yang-library, build_yl_view returns a view
+    with a non-empty content-id, and module_capabilities advertises yang-library:1.1
+    carrying that content-id."""
+    schema = _schema_with_library()
+    yl_view = monitoring.build_yl_view([schema])
+    if yl_view is not None:
+        testing.assertTrue(len(yl_view.content_id) > 0, "content-id must be non-empty")
+        caps = monitoring.module_capabilities([schema], yl_view)
+        found = False
+        for c in caps:
+            if "yang-library:1.1" in c and "content-id=" + yl_view.content_id in c:
+                found = True
+        testing.assertTrue(found, "a yang-library:1.1 capability with the content-id must be advertised")
+    else:
+        testing.error("expected a yang-library view when the closure is compiled in")
+
+
+def _test_yl_view_absent():
+    """Without ietf-yang-library in the inventory, build_yl_view is None and the
+    capabilities fall back to one ?module= per module."""
+    schema = yang.compile([DEMO_YANG])
+    yl_view = monitoring.build_yl_view([schema])
+    testing.assertTrue(yl_view is None, "no yang-library view without the module")
+    caps = monitoring.module_capabilities([schema], yl_view)
+    found = False
+    for c in caps:
+        if "urn:demo?module=demo" in c:
+            found = True
+    testing.assertTrue(found, "demo module advertised as a ?module= capability")
+
+
+def _test_get_schema_reply():
+    """get_schema_reply returns a <data> node carrying the module source for a known
+    module, and None for an unknown one."""
+    sources = {"demo": DEMO_YANG}
+    op = xml.decode('<get-schema xmlns="urn:ietf:params:xml:ns:yang:ietf-netconf-monitoring"><identifier>demo</identifier></get-schema>')
+    reply = monitoring.get_schema_reply(op, sources)
+    if reply is not None:
+        testing.assertEqual(reply.tag, "data", "reply is a <data> node")
+        testing.assertEqual(reply.text, DEMO_YANG, "reply carries the module source")
+    else:
+        testing.error("expected a data reply for a known module")
+    unknown = xml.decode('<get-schema xmlns="urn:ietf:params:xml:ns:yang:ietf-netconf-monitoring"><identifier>nope</identifier></get-schema>')
+    testing.assertTrue(monitoring.get_schema_reply(unknown, sources) is None, "unknown module yields None")

--- a/src/yp/mock_backend.act
+++ b/src/yp/mock_backend.act
@@ -1,37 +1,53 @@
 """Self-contained mock data backend for YANG-push demos and tests.
 
-This deliberately has no dependency on any datastore engine: it is a tiny periodic
-data generator modelling a handful of interface counters, ietf-interfaces style.
-It exists so the same backend can drive both the in-process push demo over an
-actor pipe and the standalone mock server that ncurl connects to.
+This deliberately has no dependency on any datastore engine: it is a tiny data
+generator modelling a handful of interface counters, ietf-interfaces style. It
+exists so the same backend can drive both the in-process push demo over an actor
+pipe and the standalone mock server that ncurl connects to.
 
-InterfaceCountersBackend is the YangPushBackend the publisher pulls from: snapshot
-returns the current counters and sample advances them once and returns the new
-contents. The mutable counter state lives in an actor, with a small class in front
-of it so the publisher gets its values back from a plain call.
+InterfaceCountersBackend is the YangPushBackend the publisher pulls from. It holds
+its state as a gdata tree: snapshot returns the current counters as XML and oper_data
+the same as a gdata tree (for <get>); sample advances them once and returns the new
+XML (periodic). The mutable state lives in an actor, with a small class in front so
+the publisher gets its values back from a plain call.
 """
 
 import std.xml as xml
+
+import yang.gdata as gdata
+
 from yp.engine import YangPushBackend
 
-NS_IF: str = "urn:ietf:params:xml:ns:yang:ietf-interfaces"
+NS_IF: str = "urn:mock:interfaces"
 
 
-def _interface_node(name: str, in_octets: int, out_octets: int) -> xml.Node:
-    return xml.Node("interface", children=[
-        xml.Node("name", text=name),
-        xml.Node("statistics", children=[
-            xml.Node("in-octets", text=str(in_octets)),
-            xml.Node("out-octets", text=str(out_octets))
-        ])
-    ])
+class MockBackend(YangPushBackend):
+    """A YangPushBackend that also exposes its current operational state as a gdata
+    tree, for serving <get> and for overlaying further operational state (e.g. the
+    ietf-yang-library tree) on top of it.
+
+    oper_data is declared via proc here because a concrete class method that awaits
+    an actor call (return self._c.oper_data()) only compiles when the method is
+    declared in a proc-typed parent - otherwise the CPS pass crashes."""
+    oper_data: proc() -> gdata.Node
 
 
-def _interfaces_node(names: list[str], in_octets: dict[str, int], out_octets: dict[str, int]) -> xml.Node:
-    ifaces: list[xml.Node] = []
-    for n in names:
-        ifaces.append(_interface_node(n, in_octets[n], out_octets[n]))
-    return xml.Node("interfaces", nsdefs=[(None, NS_IF)], children=ifaces)
+def _tree(if_names: list[str], in_octets: dict[str, int], out_octets: dict[str, int]) -> gdata.Container:
+    """Build the interface-counters gdata tree for the current counter values.
+
+    ns on the top container gives the periodic push-update its xmlns; the leaf
+    namespaces come from each Id, so the tree filters and renders against the
+    mock-interfaces schema."""
+    entries: list[gdata.Node] = []
+    for n in if_names:
+        entries.append(gdata.Container({
+            gdata.Id(NS_IF, "name"): gdata.Leaf(n),
+            gdata.Id(NS_IF, "in-octets"): gdata.Leaf(in_octets[n]),
+            gdata.Id(NS_IF, "out-octets"): gdata.Leaf(out_octets[n]),
+        }))
+    iflist = gdata.List([gdata.Id(NS_IF, "name")], entries)
+    return gdata.Container({gdata.Id(NS_IF, "interfaces"):
+        gdata.Container({gdata.Id(NS_IF, "interface"): iflist}, ns=NS_IF)})
 
 
 actor _Counters(if_names: list[str], in_step: int, out_step: int):
@@ -43,24 +59,33 @@ actor _Counters(if_names: list[str], in_step: int, out_step: int):
         in_octets[_n] = 0
         out_octets[_n] = 0
 
-    def snapshot() -> list[xml.Node]:
-        return [_interfaces_node(if_names, in_octets, out_octets)]
-
-    def sample() -> list[xml.Node]:
+    def _advance() -> None:
         for n in if_names:
             in_octets[n] = in_octets[n] + in_step
             out_octets[n] = out_octets[n] + out_step
-        return [_interfaces_node(if_names, in_octets, out_octets)]
+
+    def snapshot() -> list[xml.Node]:
+        return _tree(if_names, in_octets, out_octets).to_xml(deterministic=True)
+
+    def oper_data() -> gdata.Container:
+        return _tree(if_names, in_octets, out_octets)
+
+    def sample() -> list[xml.Node]:
+        _advance()
+        return _tree(if_names, in_octets, out_octets).to_xml(deterministic=True)
 
 
-class InterfaceCountersBackend(YangPushBackend):
-    """A mock backend whose per-interface octet counters increase on each sample."""
+class InterfaceCountersBackend(MockBackend):
+    """A mock backend whose per-interface octet counters increase on each pull."""
 
     def __init__(self, if_names: list[str], in_step: int=100, out_step: int=200):
         self._c = _Counters(if_names, in_step, out_step)
 
     def snapshot(self) -> list[xml.Node]:
         return self._c.snapshot()
+
+    def oper_data(self) -> gdata.Node:
+        return self._c.oper_data()
 
     def sample(self) -> list[xml.Node]:
         return self._c.sample()

--- a/src/yp_mockserver.act
+++ b/src/yp_mockserver.act
@@ -3,15 +3,22 @@
 A self-contained NETCONF server (over SSH) that serves YANG-push subscriptions
 backed by the InterfaceCountersBackend mock data generator — no datastore engine
 (no TTT) involved. It exists so a client such as ncurl monitor can connect to a
-real NETCONF/SSH server and stream periodic pushes of generated data.
+real NETCONF/SSH server and stream pushes of generated data.
 
 Each accepted SSH session gets its own netconf.Server + a NetconfSubscriptionService
-wired to its own InterfaceCountersBackend, so subscribers are independent. Besides
-the subscription RPCs (establish/delete-subscription), a plain <get> returns the
-backend's current interface-counters snapshot.
+wired to its own InterfaceCountersBackend, so subscribers are independent.
+
+The mock has a real schema (a small mock-interfaces module compiled with the
+ietf-yang-library and ietf-yang-push closures), so it is a proper discoverable
+NETCONF server: it advertises and serves ietf-yang-library and answers <get-schema>
+with module source, so a client like ncurl can discover the schema, fetch it, and
+render the data. Because ietf-yang-push is in the advertised module set, the client
+establishes a real yang-push subscription rather than falling back to periodic <get>
+polling. A plain <get> returns the interface-counters operational data merged with
+the ietf-yang-library tree, subtree-filtered.
 
 Run:  yp_mockserver [--address ::] [--port 12830] [--username admin]
-                     [--password admin] [--interfaces eth0,eth1] [--verbose]
+                    [--password admin] [--interfaces eth0,eth1] [--verbose]
 """
 
 import argparse
@@ -21,10 +28,118 @@ import std.xml as xml
 
 import ssh.pipe as sshpipe
 
+import yang
+import yang.gdata as ygdata
+import yang.schema as yschema
+import yang.xml as yxml
+
 import netconf
 import netconf.yp as nyp
+import monitoring
 import yp
 import yp.mock_backend as mb
+import swyang
+
+
+INTERFACES_YANG: str = r"""module mock-interfaces {
+  yang-version 1.1;
+  namespace "urn:mock:interfaces";
+  prefix mif;
+  container interfaces {
+    config false;
+    list interface {
+      key name;
+      leaf name { type string; }
+      leaf in-octets { type uint64; }
+      leaf out-octets { type uint64; }
+    }
+  }
+}"""
+
+
+class MockSchema(object):
+    """The compiled mock data model plus everything the server needs to advertise and
+    serve it: the schema (for subtree filtering), the ietf-yang-library view and the
+    matching capabilities, and the module-name -> YANG source map for get-schema."""
+    schema: yschema.DRoot
+    yl_view: ?(root: ygdata.Node, content_id: str)
+    capabilities: list[str]
+    sources: dict[str, str]
+
+    def __init__(self, schema: yschema.DRoot,
+                 yl_view: ?(root: ygdata.Node, content_id: str),
+                 capabilities: list[str], sources: dict[str, str]):
+        self.schema = schema
+        self.yl_view = yl_view
+        self.capabilities = capabilities
+        self.sources = sources
+
+
+def build_mock_schema() -> MockSchema:
+    """Compile the mock interfaces module with the ietf-yang-library and ietf-yang-push
+    closures, so the server advertises + serves ietf-yang-library, lists ietf-yang-push
+    (which makes a client establish a real yang-push subscription rather than polling),
+    and answers get-schema for every module."""
+    modules: list[(name: str, src: str)] = [
+        (name="mock-interfaces", src=INTERFACES_YANG),
+        (name="ietf-yang-library", src=swyang.ietf_yang_library),
+        (name="ietf-datastores", src=swyang.ietf_datastores),
+        (name="ietf-yang-types", src=swyang.ietf_yang_types),
+        (name="ietf-inet-types", src=swyang.ietf_inet_types),
+        (name="ietf-yang-push", src=swyang.ietf_yang_push),
+        (name="ietf-subscribed-notifications", src=swyang.ietf_subscribed_notifications),
+        (name="ietf-restconf", src=swyang.ietf_restconf),
+        (name="ietf-yang-patch", src=swyang.ietf_yang_patch),
+        (name="ietf-interfaces", src=swyang.ietf_interfaces),
+        (name="ietf-netconf-acm", src=swyang.ietf_netconf_acm),
+        (name="ietf-network-instance", src=swyang.ietf_network_instance),
+        (name="ietf-ip", src=swyang.ietf_ip),
+        (name="ietf-yang-schema-mount", src=swyang.ietf_yang_schema_mount),
+    ]
+    sources: dict[str, str] = {}
+    srcs: list[str] = []
+    for m in modules:
+        sources[m.name] = m.src
+        srcs.append(m.src)
+    schema = yang.compile(srcs)
+    yl_view = monitoring.build_yl_view([schema])
+    capabilities = [netconf.CAP_NC_1_0, netconf.CAP_NC_1_1] + monitoring.module_capabilities([schema], yl_view)
+    return MockSchema(schema, yl_view, capabilities, sources)
+
+
+class OperBackend(mb.MockBackend):
+    """The mock's operational datastore: the per-session interface counters overlaid
+    with the static ietf-yang-library tree.
+
+    This single source feeds both <get> and the yang-push subscription, so a periodic
+    push carries the same operational content a <get> returns. A real server reads one
+    datastore for both paths so they cannot diverge; the mock has to overlay its
+    synthesised library tree onto both explicitly, which is what this does."""
+    _counters: mb.InterfaceCountersBackend
+    _yl: ?ygdata.Node
+    _yl_xml: list[xml.Node]
+
+    def __init__(self, if_names: list[str], yl_view: ?(root: ygdata.Node, content_id: str)):
+        self._counters = mb.InterfaceCountersBackend(if_names)
+        if yl_view is not None:
+            self._yl = yl_view.root
+            self._yl_xml = yl_view.root.to_xml(deterministic=True)
+        else:
+            self._yl = None
+            self._yl_xml = []
+
+    def snapshot(self) -> list[xml.Node]:
+        return self._counters.snapshot() + self._yl_xml
+
+    def sample(self) -> list[xml.Node]:
+        return self._counters.sample() + self._yl_xml
+
+    def oper_data(self) -> ygdata.Node:
+        base: ygdata.Node = self._counters.oper_data()
+        yl = self._yl
+        if yl is not None:
+            return ygdata.merge(base, yl)
+        return base
 
 
 actor StaticAuthChecker(expected_user: str, expected_password: str):
@@ -36,11 +151,29 @@ actor StaticAuthChecker(expected_user: str, expected_password: str):
 actor YpMockSession(pipe,
                     log_handler: logging.Handler,
                     if_names: list[str],
+                    ms: MockSchema,
                     on_close: ?action(YpMockSession) -> None=None):
     """One NETCONF session: a Server + a YANG-push service over a mock backend."""
     _log = logging.Logger(log_handler)
-    backend = mb.InterfaceCountersBackend(if_names)
+    backend = OperBackend(if_names, ms.yl_view)
     var service: ?nyp.NetconfSubscriptionService = None
+
+    def _get_data() -> ygdata.Node:
+        # <get> and the yang-push subscription read the same operational datastore
+        # (counters overlaid with the ietf-yang-library tree) from one backend, so
+        # they always return the same content.
+        return backend.oper_data()
+
+    def _get_reply_children(op: xml.Node) -> list[xml.Node]:
+        data = _get_data()
+        for child in op.children:
+            if child.tag == "filter":
+                filt = yxml.from_filter_xml(ms.schema, child)
+                filtered = ygdata.filter(data, filt)
+                if filtered is not None:
+                    return filtered.to_xml(deterministic=True)
+                return []
+        return data.to_xml(deterministic=True)
 
     def on_rpc(s: netconf.Server, message_id: str, op: xml.Node):
         if yp.is_subscription_rpc(op.tag):
@@ -50,7 +183,13 @@ actor YpMockSession(pipe,
             else:
                 s.send_error(message_id, "operation-failed", "subscription service not ready")
         elif op.tag == "get":
-            s.send_reply(message_id, [xml.Node("data", [(None, netconf.NS_NC_1_0)], children=backend.snapshot())])
+            s.send_reply(message_id, [xml.Node("data", [(None, netconf.NS_NC_1_0)], children=_get_reply_children(op))])
+        elif op.tag == "get-schema":
+            data = monitoring.get_schema_reply(op, ms.sources)
+            if data is not None:
+                s.send_reply(message_id, [data])
+            else:
+                s.send_error(message_id, "operation-not-supported", "unknown schema module")
         else:
             s.send_error(message_id, "operation-not-supported", "Unsupported RPC operation: " + op.tag)
 
@@ -63,13 +202,14 @@ actor YpMockSession(pipe,
             if cb is not None:
                 cb(self)
 
-    server = netconf.Server(pipe=pipe, on_connect=_on_conn, on_rpc=on_rpc, log_handler=log_handler)
+    server = netconf.Server(pipe=pipe, on_connect=_on_conn, on_rpc=on_rpc, capabilities=ms.capabilities, log_handler=log_handler)
     service = nyp.NetconfSubscriptionService(server, backend, log_handler)
 
 
 actor YpMockServer(listen_cap: net.TCPListenCap,
                    log_handler: logging.Handler,
                    if_names: list[str],
+                   ms: MockSchema,
                    address: str="::",
                    port: int=12830,
                    username: str="admin",
@@ -90,7 +230,7 @@ actor YpMockServer(listen_cap: net.TCPListenCap,
 
     def _on_accept(l: sshpipe.SshPipeListener, p: sshpipe.SshListenPipe):
         _log.info("session accepted")
-        sessions.append(YpMockSession(p, log_handler, if_names, on_close=_session_closed))
+        sessions.append(YpMockSession(p, log_handler, if_names, ms, on_close=_session_closed))
 
     def _on_listen(l: sshpipe.SshPipeListener, err: ?Exception):
         if err is not None:
@@ -138,7 +278,7 @@ actor main(env):
             if_names = ["eth0", "eth1"]
 
         listen_cap = net.TCPListenCap(net.TCPCap(net.NetCap(env.auth)))
-        YpMockServer(listen_cap, logh, if_names, address, port, username, password)
+        YpMockServer(listen_cap, logh, if_names, build_mock_schema(), address, port, username, password)
         # No env.exit(): the SSH listener keeps the runtime alive until killed.
 
     def _parse_args():


### PR DESCRIPTION
Move the ietf-yang-libray and accompanying code to common monitoring.act and reuse it across mock server and our standalone yp_mockserver. yp_mockserver can now serve its YANGT schema over get-schema. ncurl monitor uses get-schema as well as the yang-push module in yang-library to determine that the server supports periodic yang-push, so now ncurl does yang-push and not periodic polling of yp_mockserver!