### PR TITLE
More YANG Push fixes

### DIFF
--- a/src/adapters/netconf.act
+++ b/src/adapters/netconf.act
@@ -64,24 +64,32 @@ class _MockPushBackend(YangPushBackend):
     since the last push. The two procs are the server's own methods, so the data is
     read live in the server actor (the class-in-front-of-an-actor pattern)."""
     @property
-    _snap: proc() -> list[xml.Node]
+    _prep: proc(?list[xml.Node]) -> ?ygdata.FNode
     @property
-    _chg: proc() -> ?xml.Node
+    _snap: proc(?ygdata.FNode) -> list[xml.Node]
+    @property
+    _chg: proc(?ygdata.FNode) -> ?xml.Node
 
-    def __init__(self, snap: proc() -> list[xml.Node], chg: proc() -> ?xml.Node):
+    def __init__(self, prep: proc(?list[xml.Node]) -> ?ygdata.FNode,
+                 snap: proc(?ygdata.FNode) -> list[xml.Node],
+                 chg: proc(?ygdata.FNode) -> ?xml.Node):
+        self._prep = prep
         self._snap = snap
         self._chg = chg
 
-    def snapshot(self) -> list[xml.Node]:
-        return self._snap()
+    def prepare_filter(self, subtree_filter: ?list[xml.Node]) -> ?ygdata.FNode:
+        return self._prep(subtree_filter)
 
-    def sample(self) -> list[xml.Node]:
+    def snapshot(self, filter: ?ygdata.FNode) -> list[xml.Node]:
+        return self._snap(filter)
+
+    def sample(self, filter: ?ygdata.FNode) -> list[xml.Node]:
         # The mock's oper data changes only via set_oper_ds, so a periodic sample is
         # the current snapshot (no synthetic advance).
-        return self._snap()
+        return self._snap(filter)
 
-    def change(self) -> ?xml.Node:
-        return self._chg()
+    def change(self, filter: ?ygdata.FNode) -> ?xml.Node:
+        return self._chg(filter)
 
 
 actor NetconfMockServer(pipe, log_handler: logging.Handler, capabilities: list[str], bundled_schema: DeviceSchema):
@@ -240,20 +248,35 @@ actor NetconfMockServer(pipe, log_handler: logging.Handler, capabilities: list[s
         wrapper = xml.Node("data", children=data_children)
         return yxml.from_xml(conf_schema, wrapper, loose=True)
 
-    def _yp_snapshot() -> list[xml.Node]:
+    def _yp_prepare_filter(subtree_filter: ?list[xml.Node]) -> ?ygdata.FNode:
+        if subtree_filter is not None:
+            wrapper = xml.Node("filter", attributes=[("type", "subtree")], children=subtree_filter)
+            return yxml.from_filter_xml(oper_schema, wrapper)
+        return None
+
+    def _yp_snapshot(filter: ?ygdata.FNode) -> list[xml.Node]:
         # Current operational data as a push baseline, recorded so the next on-change
         # diff is taken from what was last pushed.
         _yp_last = oper_ds
+        if filter is not None:
+            filtered = ygdata.filter(oper_ds, filter)
+            if filtered is not None:
+                return filtered.to_xml(deterministic=True)
+            return []
         return oper_ds.to_xml(deterministic=True)
 
-    def _yp_change() -> ?xml.Node:
+    def _yp_change(filter: ?ygdata.FNode) -> ?xml.Node:
         # A yang-patch of what changed since the last push, or None if unchanged.
-        prev = _yp_last
-        cur = oper_ds
+        prev: ?ygdata.Node = _yp_last
+        cur: ?ygdata.Node = oper_ds
         _yp_last = cur
-        d = ygdata.diff(prev, cur)
-        if d is not None:
-            return ypatch.diff_to_patch(d, "mock-change").to_xml()
+        if filter is not None:
+            prev = ygdata.filter(prev, filter)
+            cur = ygdata.filter(cur, filter)
+        if cur is not None:
+            d = ygdata.diff(prev, cur)
+            if d is not None:
+                return ypatch.diff_to_patch(d, "mock-change").to_xml()
         return None
 
     def on_rpc(s: netconf.Server, message_id: str, op: xml.Node):
@@ -306,7 +329,7 @@ actor NetconfMockServer(pipe, log_handler: logging.Handler, capabilities: list[s
             send_error(s, message_id, "operation-not-supported", "Unsupported RPC operation: {op.tag}")
 
     var server: netconf.Server = netconf.Server(pipe=pipe, on_rpc=on_rpc, log_handler=log_handler, capabilities=all_capabilities)
-    yp_service = nyp.NetconfSubscriptionService(server, _MockPushBackend(_yp_snapshot, _yp_change), log_handler)
+    yp_service = nyp.NetconfSubscriptionService(server, _MockPushBackend(_yp_prepare_filter, _yp_snapshot, _yp_change), log_handler)
 
     def set_oper_ds(new_oper_ds: ygdata.Node, schema: ?yschema.DRoot=None):
         """Set the operational datastore (and optionally its schema) for <get>."""

--- a/src/device.act
+++ b/src/device.act
@@ -113,7 +113,7 @@ actor SchemaRegistry():
         content_hash = _list_hash(yang_src)
         if content_hash not in store:
             try:
-                compiled_schema = yang.compile(yang_src)
+                compiled_schema = yang.compile(yang_src, strict_quoting=False)
                 store[content_hash] = compiled_schema
             except Exception as e:
                 # Schema compilation failed, return error

--- a/src/netconf.act
+++ b/src/netconf.act
@@ -445,15 +445,16 @@ actor Client(
                                period: ?int=None,
                                on_change: bool=False,
                                dampening_period: ?int=None,
-                               sync_on_start: bool=False) -> None:
+                               sync_on_start: bool=True) -> None:
         """Establish a YANG-push subscription (RFC 8639 + 8641 / 8640).
 
         Pass period (centiseconds) for a periodic subscription, or on_change=True for
-        an on-change one (optionally with dampening_period centiseconds and
-        sync_on_start). The callback receives the allocated subscription-id on
-        success; push notifications then arrive via the Client's on_notif callback —
-        push-update for periodic, push-change-update carrying a yang-patch for
-        on-change.
+        an on-change one (optionally with dampening_period centiseconds). For
+        on-change, sync_on_start defaults to the RFC 8641/YANG default of true;
+        pass false to request deltas only. The callback receives the allocated
+        subscription-id on success; push notifications then arrive via the Client's
+        on_notif callback — push-update for periodic and sync-on-start, and
+        push-change-update carrying a yang-patch for on-change deltas.
         """
         _log.info("NETCONF establish-subscription", {"datastore": datastore, "period": period, "on_change": on_change})
         op = yp.build_establish_subscription(datastore, subtree_filter, xpath_filter, period, on_change, dampening_period, sync_on_start)

--- a/src/netconf/buffer.act
+++ b/src/netconf/buffer.act
@@ -199,7 +199,10 @@ class Buffer(object):
         return IncompleteReadError()
 
     def match_bytes(self, pattern: bytes) -> value: # (is_match: bool | err: IncompleteReadError)
-        b = self.read_bytes(len(pattern))
+        try:
+            b = self.read_bytes(len(pattern))
+        except IncompleteReadError:
+            return IncompleteReadError()
         if isinstance(b, bytes):
             return b == pattern
         else:
@@ -346,6 +349,15 @@ def _test_buffer_find_bytes_empty_pattern():
     testing.assertTrue(isinstance(result, int), "Should return int for empty pattern")
     if isinstance(result, int):
         testing.assertEqual(result, 0, "Empty pattern should return 0")
+
+
+def _test_buffer_match_bytes_short_pattern_returns_incomplete():
+    """Test matching a pattern longer than the buffer returns IncompleteReadError."""
+    buf = Buffer()
+    buf.write_str("#")
+    result = buf.match_bytes("##".encode())
+    testing.assertTrue(isinstance(result, IncompleteReadError), "Short buffer should return IncompleteReadError")
+    testing.assertEqual(buf.unread_bytes, 1, "Incomplete match should not consume buffered data")
 
 
 def _test_buffer_find_bytes_pattern_too_long():

--- a/src/netconf/test_yp.act
+++ b/src/netconf/test_yp.act
@@ -35,6 +35,11 @@ actor _test_yangpush_periodic(t: testing.EnvT):
 
     backend = mb.InterfaceCountersBackend(["eth0"])
 
+    def _advance_source() -> None:
+        if not done:
+            backend.advance()
+            after 0.02: _advance_source()
+
     def _fail(e: Exception) -> None:
         if not done:
             done = True
@@ -88,6 +93,7 @@ actor _test_yangpush_periodic(t: testing.EnvT):
 
     server = netconf.Server(pipe=pipes.server, on_rpc=_on_server_rpc, log_handler=t.log_handler)
     service = yn.NetconfSubscriptionService(server, backend, log_handler=t.log_handler)
+    after 0.01: _advance_source()
     client = netconf.Client(None,
                             address="actor-pipe",
                             username="actor-pipe",
@@ -109,6 +115,15 @@ def _counter_merge_edits(p: ypatch.Patch) -> int:
         if e.operation == ypatch.OP_MERGE and (last == "in-octets" or last == "out-octets"):
             n += 1
     return n
+
+
+def _counter_edit_value(p: ypatch.Patch, leaf_name: str) -> ?str:
+    for e in p.edits:
+        if e.target.split("/")[-1] == leaf_name:
+            v = e.value
+            if v is not None:
+                return v.text
+    return None
 
 
 actor _test_yangpush_on_change(t: testing.EnvT):
@@ -177,9 +192,12 @@ actor _test_yangpush_on_change(t: testing.EnvT):
         _fail(ValueError("Unexpected notification: " + notif.encode()))
 
     def _trigger() -> None:
-        # On-change is event-driven: ask the server-side service to emit a delta.
-        if service is not None:
-            service.trigger_change()
+        # On-change is event-driven: advance the source, then ask the server-side
+        # service to emit that delta.
+        backend.advance()
+        sv = service
+        if sv is not None:
+            sv.trigger_change()
 
     def _on_sub(c: netconf.Client, sub_id: ?int, err: ?netconf.NetconfError) -> None:
         if err is not None:
@@ -247,6 +265,7 @@ actor _test_yangpush_on_change_subtree_filter(t: testing.EnvT):
             s.send_error(message_id, "operation-not-supported", "unsupported: " + op.tag)
 
     def _trigger() -> None:
+        backend.advance()
         sv = service
         if sv is not None:
             sv.trigger_change()
@@ -315,6 +334,113 @@ actor _test_yangpush_on_change_subtree_filter(t: testing.EnvT):
 
     def _on_timeout() -> None:
         _fail(ValueError("Timed out waiting for filtered on-change update"))
+
+    server = netconf.Server(pipe=pipes.server, on_rpc=_on_server_rpc, log_handler=t.log_handler)
+    service = yn.NetconfSubscriptionService(server, backend, log_handler=t.log_handler)
+    client = netconf.Client(None,
+                            address="actor-pipe",
+                            username="actor-pipe",
+                            key=None,
+                            password=None,
+                            port=0,
+                            on_connect=_on_connect,
+                            on_notif=_on_notif,
+                            log_handler=t.log_handler,
+                            pipe=pipes.client)
+    after 10.0: _on_timeout()
+
+
+actor _test_yangpush_on_change_two_subscriptions_share_source(t: testing.EnvT):
+    """One source advance is fanned out to multiple on-change subscriptions."""
+    log = logging.Logger(t.log_handler)
+    pipes = netconf.actor_pipe_pair()
+
+    var service: ?yn.NetconfSubscriptionService = None
+    var done = False
+    var patches = 0
+    var sub1: ?int = None
+    var sub2: ?int = None
+
+    backend = mb.InterfaceCountersBackend(["eth0"])
+
+    def _fail(e: Exception) -> None:
+        if not done:
+            done = True
+            t.failure(e)
+
+    def _finish(c: netconf.Client) -> None:
+        if not done:
+            done = True
+            c.close(None)
+            log.info("two on-change subscriptions shared one source update")
+            t.success()
+
+    def _on_server_rpc(s: netconf.Server, message_id: str, op: xml.Node) -> None:
+        if yp.is_subscription_rpc(op.tag):
+            sv = service
+            if sv is not None:
+                sv.handle_rpc(message_id, op)
+        else:
+            s.send_error(message_id, "operation-not-supported", "unsupported: " + op.tag)
+
+    def _trigger() -> None:
+        backend.advance()
+        sv = service
+        if sv is not None:
+            sv.trigger_change()
+
+    def _on_notif(c: netconf.Client, notif: xml.Node) -> None:
+        if yp.parse_push_update(notif) is not None:
+            _fail(ValueError("unexpected sync-on-start baseline for sync_on_start=false"))
+            return
+
+        pcu = yp.parse_push_change_update(notif)
+        if pcu is not None:
+            yp_node = pcu.yang_patch
+            if yp_node is not None:
+                patch = ypatch.Patch.from_xml(yp_node)
+                val = _counter_edit_value(patch, "in-octets")
+                if val != "100":
+                    _fail(ValueError("expected shared source value 100, got {val} in " + notif.encode()))
+                    return
+                if patch.patch_id != "patch1":
+                    _fail(ValueError("expected shared patch id patch1, got {patch.patch_id}"))
+                    return
+                patches += 1
+                if patches == 2:
+                    _finish(c)
+            else:
+                _fail(ValueError("push-change-update missing yang-patch"))
+            return
+
+        _fail(ValueError("Unexpected notification: " + notif.encode()))
+
+    def _on_sub2(c: netconf.Client, sub_id: ?int, err: ?netconf.NetconfError) -> None:
+        if err is not None:
+            _fail(err)
+        elif sub_id is None:
+            _fail(ValueError("second establish-subscription returned no id"))
+        else:
+            sub2 = sub_id
+            _trigger()
+
+    def _on_sub1(c: netconf.Client, sub_id: ?int, err: ?netconf.NetconfError) -> None:
+        if err is not None:
+            _fail(err)
+        elif sub_id is None:
+            _fail(ValueError("first establish-subscription returned no id"))
+        else:
+            sub1 = sub_id
+            c.establish_subscription(_on_sub2, on_change=True, sync_on_start=False)
+
+    def _on_connect(c: netconf.Client, e: ?Exception) -> None:
+        if e is not None:
+            _fail(ValueError("connect failed: " + str(e)))
+        else:
+            c.establish_subscription(_on_sub1, on_change=True, sync_on_start=False)
+
+    def _on_timeout() -> None:
+        _fail(ValueError("Timed out waiting for two shared-source on-change updates; patches={patches}, sub1={sub1}, sub2={sub2}"))
 
     server = netconf.Server(pipe=pipes.server, on_rpc=_on_server_rpc, log_handler=t.log_handler)
     service = yn.NetconfSubscriptionService(server, backend, log_handler=t.log_handler)

--- a/src/netconf/test_yp.act
+++ b/src/netconf/test_yp.act
@@ -119,6 +119,7 @@ actor _test_yangpush_on_change(t: testing.EnvT):
 
     var service: ?yn.NetconfSubscriptionService = None
     var changes = 0
+    var baseline_seen = False
     var done = False
     var sub_id_seen: ?int = None
 
@@ -144,8 +145,17 @@ actor _test_yangpush_on_change(t: testing.EnvT):
             s.send_error(message_id, "operation-not-supported", "unsupported: " + op.tag)
 
     def _on_notif(c: netconf.Client, notif: xml.Node) -> None:
+        pu = yp.parse_push_update(notif)
+        if pu is not None:
+            baseline_seen = True
+            log.info("on-change sync-on-start push-update id={pu.sub_id}")
+            return
+
         pcu = yp.parse_push_change_update(notif)
         if pcu is not None:
+            if not baseline_seen:
+                _fail(ValueError("push-change-update arrived before sync-on-start"))
+                return
             yp_node = pcu.yang_patch
             if yp_node is not None:
                 patch = ypatch.Patch.from_xml(yp_node)
@@ -188,6 +198,123 @@ actor _test_yangpush_on_change(t: testing.EnvT):
 
     def _on_timeout() -> None:
         _fail(ValueError("Timed out: changes={changes}"))
+
+    server = netconf.Server(pipe=pipes.server, on_rpc=_on_server_rpc, log_handler=t.log_handler)
+    service = yn.NetconfSubscriptionService(server, backend, log_handler=t.log_handler)
+    client = netconf.Client(None,
+                            address="actor-pipe",
+                            username="actor-pipe",
+                            key=None,
+                            password=None,
+                            port=0,
+                            on_connect=_on_connect,
+                            on_notif=_on_notif,
+                            log_handler=t.log_handler,
+                            pipe=pipes.client)
+    after 10.0: _on_timeout()
+
+
+actor _test_yangpush_on_change_subtree_filter(t: testing.EnvT):
+    """On-change subtree filters constrain sync-on-start and yang-patch edits."""
+    log = logging.Logger(t.log_handler)
+    pipes = netconf.actor_pipe_pair()
+
+    var service: ?yn.NetconfSubscriptionService = None
+    var done = False
+    var baseline_seen = False
+
+    backend = mb.InterfaceCountersBackend(["eth0", "eth1"], schema=mb.build_interfaces_schema())
+    filter_node = xml.decode('<interfaces xmlns="urn:mock:interfaces"><interface><name>eth0</name><in-octets/></interface></interfaces>')
+
+    def _fail(e: Exception) -> None:
+        if not done:
+            done = True
+            t.failure(e)
+
+    def _on_deleted(c: netconf.Client, err: ?netconf.NetconfError) -> None:
+        if not done:
+            done = True
+            c.close(None)
+            log.info("on-change filtered push demo ok")
+            t.success()
+
+    def _on_server_rpc(s: netconf.Server, message_id: str, op: xml.Node) -> None:
+        if yp.is_subscription_rpc(op.tag):
+            sv = service
+            if sv is not None:
+                sv.handle_rpc(message_id, op)
+        else:
+            s.send_error(message_id, "operation-not-supported", "unsupported: " + op.tag)
+
+    def _trigger() -> None:
+        sv = service
+        if sv is not None:
+            sv.trigger_change()
+
+    def _on_notif(c: netconf.Client, notif: xml.Node) -> None:
+        pu = yp.parse_push_update(notif)
+        if pu is not None:
+            payload = ""
+            for node in pu.contents:
+                payload = payload + node.encode()
+            if payload.find("eth1") != -1:
+                _fail(ValueError("filtered sync-on-start leaked eth1: " + payload))
+                return
+            if payload.find("eth0") == -1:
+                _fail(ValueError("filtered sync-on-start did not include eth0: " + payload))
+                return
+            if payload.find("out-octets") != -1:
+                _fail(ValueError("filtered sync-on-start leaked unselected out-octets: " + payload))
+                return
+            baseline_seen = True
+            _trigger()
+            return
+
+        pcu = yp.parse_push_change_update(notif)
+        if pcu is not None:
+            if not baseline_seen:
+                _fail(ValueError("push-change-update arrived before filtered sync-on-start"))
+                return
+            yp_node = pcu.yang_patch
+            if yp_node is not None:
+                patch = ypatch.Patch.from_xml(yp_node)
+                saw_eth0 = False
+                for e in patch.edits:
+                    if e.target.find("interface=eth1") != -1:
+                        _fail(ValueError("filtered yang-patch leaked eth1 edit: " + e.target))
+                        return
+                    if e.target.find("interface=eth0") != -1:
+                        saw_eth0 = True
+                    if e.target.find("out-octets") != -1:
+                        _fail(ValueError("filtered yang-patch leaked unselected out-octets edit: " + e.target))
+                        return
+                if not saw_eth0:
+                    _fail(ValueError("filtered yang-patch did not include eth0 edits"))
+                    return
+                sid = pcu.sub_id
+                if sid is not None:
+                    c.delete_subscription(_on_deleted, sid)
+                else:
+                    _fail(ValueError("push-change-update missing subscription id"))
+                return
+            _fail(ValueError("push-change-update missing yang-patch"))
+            return
+        _fail(ValueError("Unexpected notification: " + notif.encode()))
+
+    def _on_sub(c: netconf.Client, sub_id: ?int, err: ?netconf.NetconfError) -> None:
+        if err is not None:
+            _fail(err)
+        elif sub_id is None:
+            _fail(ValueError("establish-subscription returned no id"))
+
+    def _on_connect(c: netconf.Client, e: ?Exception) -> None:
+        if e is not None:
+            _fail(ValueError("connect failed: " + str(e)))
+        else:
+            c.establish_subscription(_on_sub, subtree_filter=[filter_node], on_change=True, sync_on_start=True)
+
+    def _on_timeout() -> None:
+        _fail(ValueError("Timed out waiting for filtered on-change update"))
 
     server = netconf.Server(pipe=pipes.server, on_rpc=_on_server_rpc, log_handler=t.log_handler)
     service = yn.NetconfSubscriptionService(server, backend, log_handler=t.log_handler)

--- a/src/yp.act
+++ b/src/yp.act
@@ -43,24 +43,31 @@ class EstablishParams(object):
     """Parsed parameters of an incoming <establish-subscription> (server side).
 
     A subscription is either periodic (periodic_period set) or on-change (on_change
-    True, with optional dampening_period and sync_on_start). The filter is not
-    captured here; a binding that cannot honour a filter rejects a request that
-    carries one. datastore is captured but not enforced here.
+    True, with optional dampening_period and sync_on_start). subtree_filter
+    carries the top-level data nodes from datastore-subtree-filter, if present.
+    xpath_filter is captured so bindings can reject it when they cannot honour it.
+    datastore is captured but not enforced here.
     """
     datastore: ?str
     periodic_period: ?int    # centiseconds; None if no <period> was given
     on_change: bool          # True if an <on-change> element was present
     dampening_period: ?int   # centiseconds; on-change only, None if absent
     sync_on_start: bool      # on-change: send a full baseline before deltas
+    subtree_filter: ?list[xml.Node]
+    xpath_filter: ?str
 
     def __init__(self, datastore: ?str, periodic_period: ?int,
                  on_change: bool=False, dampening_period: ?int=None,
-                 sync_on_start: bool=False):
+                 sync_on_start: bool=True,
+                 subtree_filter: ?list[xml.Node]=None,
+                 xpath_filter: ?str=None):
         self.datastore = datastore
         self.periodic_period = periodic_period
         self.on_change = on_change
         self.dampening_period = dampening_period
         self.sync_on_start = sync_on_start
+        self.subtree_filter = subtree_filter
+        self.xpath_filter = xpath_filter
 
 
 class PushUpdate(object):
@@ -103,14 +110,15 @@ def build_establish_subscription(
         period: ?int=None,
         on_change: bool=False,
         dampening_period: ?int=None,
-        sync_on_start: bool=False) -> xml.Node:
+        sync_on_start: bool=True) -> xml.Node:
     """Build an <establish-subscription> operation node (RFC 8639 + 8641).
 
     Pass period (centiseconds) for a periodic subscription, or on_change=True for an
-    on-change one (optionally with dampening_period centiseconds and sync_on_start).
-    on-change takes precedence if both are given. A filter is optional; pass either
-    subtree_filter (the filter's top-level data nodes, each carrying its own module
-    namespace) or xpath_filter.
+    on-change one (optionally with dampening_period centiseconds). sync_on_start
+    defaults to the RFC 8641/YANG default of true; pass false to request
+    push-change-update notifications only. on-change takes precedence if both are
+    given. A filter is optional; pass either subtree_filter (the filter's top-level
+    data nodes, each carrying its own module namespace) or xpath_filter.
     """
     children: list[xml.Node] = []
 
@@ -131,8 +139,7 @@ def build_establish_subscription(
         oc_children: list[xml.Node] = []
         if dampening_period is not None:
             oc_children.append(xml.Node("dampening-period", text=str(dampening_period)))
-        if sync_on_start:
-            oc_children.append(xml.Node("sync-on-start", text="true"))
+        oc_children.append(xml.Node("sync-on-start", text="true" if sync_on_start else "false"))
         children.append(xml.Node("on-change", nsdefs=[(None, NS_YP)], children=oc_children))
     elif period is not None:
         children.append(xml.Node("periodic", nsdefs=[(None, NS_YP)], children=[
@@ -270,8 +277,17 @@ def parse_establish_subscription(op: xml.Node) -> EstablishParams:
     on_change = oc is not None
     dampening_period = _parse_int(_text_of(_child_by_tag(oc, "dampening-period")))
     sync_node = _child_by_tag(oc, "sync-on-start")
-    sync_on_start = sync_node is not None and sync_node.text != "false"
-    return EstablishParams(datastore, period, on_change, dampening_period, sync_on_start)
+    # RFC 8641's YANG model gives sync-on-start a default of true.
+    sync_on_start = False
+    if on_change:
+        sync_on_start = True
+        if sync_node is not None:
+            if sync_node.text == "false":
+                sync_on_start = False
+    sf = _child_by_tag(op, "datastore-subtree-filter")
+    subtree_filter = sf.children if sf is not None else None
+    xpath_filter = _text_of(_child_by_tag(op, "datastore-xpath-filter"))
+    return EstablishParams(datastore, period, on_change, dampening_period, sync_on_start, subtree_filter, xpath_filter)
 
 
 def parse_delete_subscription(op: xml.Node) -> ?int:

--- a/src/yp.act
+++ b/src/yp.act
@@ -132,7 +132,7 @@ def build_establish_subscription(
         if dampening_period is not None:
             oc_children.append(xml.Node("dampening-period", text=str(dampening_period)))
         if sync_on_start:
-            oc_children.append(xml.Node("sync-on-start"))
+            oc_children.append(xml.Node("sync-on-start", text="true"))
         children.append(xml.Node("on-change", nsdefs=[(None, NS_YP)], children=oc_children))
     elif period is not None:
         children.append(xml.Node("periodic", nsdefs=[(None, NS_YP)], children=[
@@ -269,7 +269,8 @@ def parse_establish_subscription(op: xml.Node) -> EstablishParams:
     oc = _child_by_tag(op, "on-change")
     on_change = oc is not None
     dampening_period = _parse_int(_text_of(_child_by_tag(oc, "dampening-period")))
-    sync_on_start = _child_by_tag(oc, "sync-on-start") is not None
+    sync_node = _child_by_tag(oc, "sync-on-start")
+    sync_on_start = sync_node is not None and sync_node.text != "false"
     return EstablishParams(datastore, period, on_change, dampening_period, sync_on_start)
 
 

--- a/src/yp/engine.act
+++ b/src/yp/engine.act
@@ -34,6 +34,7 @@ publisher gets its value back from a plain call.
 import logging
 import std.xml as xml
 
+import yang.gdata as gdata
 import yp
 
 
@@ -44,25 +45,30 @@ class YangPushBackend(object):
     module) without advancing. sample advances the source by one step and returns
     the new full contents (periodic). change advances the source and returns a
     ready-built <yang-patch> of what changed since the last call, or None if nothing
-    changed (on-change) — the backend owns the diff and its yang-patch rendering, so
-    the publisher stays content-agnostic. A concrete backend is a class delegating
-    to an actor, which is what lets the publisher read the value back from an
-    ordinary call even when the actor had to do real work to produce it."""
-    snapshot: proc() -> list[xml.Node]
-    sample: proc() -> list[xml.Node]
-    change: proc() -> ?xml.Node
+    changed (on-change). prepare_filter turns a subscription's raw
+    datastore-subtree-filter XML into a gdata filter once at establish-subscription
+    time; snapshot/sample/change then reuse it. The backend owns that conversion
+    because it has the schema needed to parse the wire filter. A concrete backend is
+    a class delegating to an actor, which is what lets the publisher read the value
+    back from a plain call."""
+    prepare_filter: proc(?list[xml.Node]) -> ?gdata.FNode
+    snapshot: proc(?gdata.FNode) -> list[xml.Node]
+    sample: proc(?gdata.FNode) -> list[xml.Node]
+    change: proc(?gdata.FNode) -> ?xml.Node
 
 
 class SubState(object):
     interval: float     # tick period in seconds
     on_change: bool     # on-change subscription (vs periodic)
     sync_on_start: bool # on-change: emit a full baseline before the first delta
+    filter: ?gdata.FNode
     active: bool
 
-    def __init__(self, interval: float, on_change: bool=False, sync_on_start: bool=False):
+    def __init__(self, interval: float, on_change: bool=False, sync_on_start: bool=False, filter: ?gdata.FNode=None):
         self.interval = interval
         self.on_change = on_change
         self.sync_on_start = sync_on_start
+        self.filter = filter
         self.active = True
 
 
@@ -85,10 +91,13 @@ actor YangPushPublisher(deliver: action(xml.Node) -> None,
         On-change subscriptions are event-driven: nothing is pushed until something
         calls trigger_change - a real source on a datastore change, or the mock
         server on a manual trigger."""
+        if params.xpath_filter is not None:
+            return None
+        filter = backend.prepare_filter(params.subtree_filter)
         if params.on_change:
             sub_id = next_id
             next_id += 1
-            subs[sub_id] = SubState(0.0, on_change=True, sync_on_start=params.sync_on_start)
+            subs[sub_id] = SubState(0.0, on_change=True, sync_on_start=params.sync_on_start, filter=filter)
             _log.info("establish-subscription id={sub_id} mode=on-change")
             return sub_id
         pp = params.periodic_period
@@ -97,7 +106,7 @@ actor YangPushPublisher(deliver: action(xml.Node) -> None,
                 interval = float(pp) / 100.0
                 sub_id = next_id
                 next_id += 1
-                subs[sub_id] = SubState(interval)
+                subs[sub_id] = SubState(interval, filter=filter)
                 _log.info("establish-subscription id={sub_id} mode=periodic period={interval}s")
                 return sub_id
         return None
@@ -112,10 +121,10 @@ actor YangPushPublisher(deliver: action(xml.Node) -> None,
                     # Event-driven: only the optional sync-on-start baseline emits
                     # now; deltas wait for trigger_change.
                     if st.sync_on_start:
-                        snap = backend.snapshot()
+                        snap = backend.snapshot(st.filter)
                         deliver(yp.build_notification(yp.event_time_now(), yp.build_push_update(sub_id, snap)))
                 else:
-                    snap = backend.snapshot()
+                    snap = backend.snapshot(st.filter)
                     deliver(yp.build_notification(yp.event_time_now(), yp.build_push_update(sub_id, snap)))
                     after st.interval: _tick(sub_id)
 
@@ -147,7 +156,7 @@ actor YangPushPublisher(deliver: action(xml.Node) -> None,
         if sub_id in subs:
             st = subs[sub_id]
             if st.active:
-                contents = backend.sample()
+                contents = backend.sample(st.filter)
                 deliver(yp.build_notification(yp.event_time_now(), yp.build_push_update(sub_id, contents)))
                 after st.interval: _tick(sub_id)
 
@@ -155,8 +164,8 @@ actor YangPushPublisher(deliver: action(xml.Node) -> None,
         """Emit a push-change-update to every active on-change subscription from the
         backend's current delta. This is the event-driven entry point: a real
         datastore source calls it on a change, and the mock server wires it to a
-        manual trigger. The delta is computed once and fanned out, so multiple
-        on-change subs on one backend stay consistent."""
+        manual trigger. The backend receives each subscription's filter so
+        it can render the patch in the subscribed view of the datastore."""
         targets: list[int] = []
         for sid, st in subs.items():
             if st.active and st.on_change:
@@ -164,7 +173,8 @@ actor YangPushPublisher(deliver: action(xml.Node) -> None,
         if len(targets) == 0:
             return
         _log.info("on-change trigger: notifying {len(targets)} subscription(s)")
-        patch = backend.change()
-        if patch is not None:
-            for sid in targets:
+        for sid in targets:
+            st = subs[sid]
+            patch = backend.change(st.filter)
+            if patch is not None:
                 deliver(yp.build_notification(yp.event_time_now(), yp.build_push_change_update(sid, patch)))

--- a/src/yp/engine.act
+++ b/src/yp/engine.act
@@ -25,10 +25,10 @@ ordering, and so RESTCONF has its seam: there establish happens on one request a
 delivery attaches on a later GET to the stream.
 
 The data source is the injected backend, a YangPushBackend the publisher simply
-calls: snapshot returns the current contents and sample advances the source by one
-step and returns the new contents. A concrete backend is a class in front of an
-actor, so reading real datastore state still happens in the actor while the
-publisher gets its value back from a plain call.
+calls: snapshot returns the current contents, sample returns the contents for a
+periodic tick, and change renders the latest source delta. A concrete backend is a
+class in front of an actor, so reading real datastore state still happens in the
+actor while the publisher gets its value back from a plain call.
 """
 
 import logging
@@ -42,10 +42,9 @@ class YangPushBackend(object):
     """The datastore source the publisher pulls from.
 
     snapshot returns the current contents (a list of top-level data nodes, one per
-    module) without advancing. sample advances the source by one step and returns
-    the new full contents (periodic). change advances the source and returns a
-    ready-built <yang-patch> of what changed since the last call, or None if nothing
-    changed (on-change). prepare_filter turns a subscription's raw
+    module). sample returns the current full contents for a periodic update. change
+    returns a ready-built <yang-patch> of the latest source change, or None if
+    nothing changed (on-change). prepare_filter turns a subscription's raw
     datastore-subtree-filter XML into a gdata filter once at establish-subscription
     time; snapshot/sample/change then reuse it. The backend owns that conversion
     because it has the schema needed to parse the wire filter. A concrete backend is

--- a/src/yp/mock_backend.act
+++ b/src/yp/mock_backend.act
@@ -10,20 +10,38 @@ its state as a gdata tree so it can serve every pull from one source: snapshot
 returns the current counters as XML and oper_data the same as a gdata tree (for
 <get>); sample advances them once and returns the new XML (periodic); and change
 advances them once and returns an RFC 8072 yang-patch of the delta (on-change) by
-running gdata.diff over the before/after trees and rendering it with ypatch. The
-mutable state lives in an actor, with a small class in front so the publisher gets
-its values back from a plain call.
+running gdata.diff over the before/after filtered trees and rendering it with
+ypatch. The mutable state lives in an actor, with a small class in front so the
+publisher gets its values back from a plain call.
 """
 
 import std.xml as xml
 
+import yang
 import yang.gdata as gdata
+import yang.schema as yschema
+import yang.xml as yxml
 import yang.ypatch as ypatch
 
 from yp.engine import YangPushBackend
 
 NS_IF: str = "urn:mock:interfaces"
 MOD_IF: str = "mock-interfaces"
+
+INTERFACES_YANG: str = r"""module mock-interfaces {
+  yang-version 1.1;
+  namespace "urn:mock:interfaces";
+  prefix mif;
+  container interfaces {
+    config false;
+    list interface {
+      key name;
+      leaf name { type string; }
+      leaf in-octets { type uint64; }
+      leaf out-octets { type uint64; }
+    }
+  }
+}"""
 
 
 class MockBackend(YangPushBackend):
@@ -56,7 +74,11 @@ def _tree(if_names: list[str], in_octets: dict[str, int], out_octets: dict[str, 
         gdata.Container({gdata.Id(NS_IF, "interface"): iflist}, ns=NS_IF, module=MOD_IF)})
 
 
-actor _Counters(if_names: list[str], in_step: int, out_step: int):
+def build_interfaces_schema() -> yschema.DRoot:
+    return yang.compile([INTERFACES_YANG])
+
+
+actor _Counters(if_names: list[str], in_step: int, out_step: int, schema: ?yschema.DRoot):
     """Holds the mutable per-interface counters and produces snapshots/samples/changes."""
     var in_octets: dict[str, int] = {}
     var out_octets: dict[str, int] = {}
@@ -71,41 +93,63 @@ actor _Counters(if_names: list[str], in_step: int, out_step: int):
             in_octets[n] = in_octets[n] + in_step
             out_octets[n] = out_octets[n] + out_step
 
-    def snapshot() -> list[xml.Node]:
-        return _tree(if_names, in_octets, out_octets).to_xml(deterministic=True)
+    def prepare_filter(subtree_filter: ?list[xml.Node]) -> ?gdata.FNode:
+        if subtree_filter is not None:
+            wrapper = xml.Node("filter", attributes=[("type", "subtree")], children=subtree_filter)
+            return yxml.from_filter_xml(schema!, wrapper)
+        return None
+
+    def snapshot(filter: ?gdata.FNode) -> list[xml.Node]:
+        data = _tree(if_names, in_octets, out_octets)
+        if filter is not None:
+            xml_nodes = gdata.filter(data, filter)?.to_xml(deterministic=True)
+            return xml_nodes if xml_nodes is not None else []
+        return data.to_xml(deterministic=True)
 
     def oper_data() -> gdata.Container:
         return _tree(if_names, in_octets, out_octets)
 
-    def sample() -> list[xml.Node]:
+    def sample(filter: ?gdata.FNode) -> list[xml.Node]:
         _advance()
-        return _tree(if_names, in_octets, out_octets).to_xml(deterministic=True)
+        data = _tree(if_names, in_octets, out_octets)
+        if filter is not None:
+            xml_nodes = gdata.filter(data, filter)?.to_xml(deterministic=True)
+            return xml_nodes if xml_nodes is not None else []
+        return data.to_xml(deterministic=True)
 
-    def change() -> ?xml.Node:
-        old = _tree(if_names, in_octets, out_octets)
+    def change(filter: ?gdata.FNode) -> ?xml.Node:
+        old: ?gdata.Node = _tree(if_names, in_octets, out_octets)
+        if filter is not None:
+            old = gdata.filter(old, filter)
         _advance()
-        new = _tree(if_names, in_octets, out_octets)
-        d = gdata.diff(old, new)
-        if d is not None:
-            patch_seq += 1
-            return ypatch.diff_to_patch(d, "patch" + str(patch_seq)).to_xml()
+        new: ?gdata.Node = _tree(if_names, in_octets, out_octets)
+        if filter is not None:
+            new = gdata.filter(new, filter)
+        if new is not None:
+            d = gdata.diff(old, new)
+            if d is not None:
+                patch_seq += 1
+                return ypatch.diff_to_patch(d, "patch{patch_seq}").to_xml()
         return None
 
 
 class InterfaceCountersBackend(MockBackend):
     """A mock backend whose per-interface octet counters increase on each pull."""
 
-    def __init__(self, if_names: list[str], in_step: int=100, out_step: int=200):
-        self._c = _Counters(if_names, in_step, out_step)
+    def __init__(self, if_names: list[str], in_step: int=100, out_step: int=200, schema: ?yschema.DRoot=None):
+        self._c = _Counters(if_names, in_step, out_step, schema)
 
-    def snapshot(self) -> list[xml.Node]:
-        return self._c.snapshot()
+    def prepare_filter(self, subtree_filter: ?list[xml.Node]) -> ?gdata.FNode:
+        return self._c.prepare_filter(subtree_filter)
+
+    def snapshot(self, filter: ?gdata.FNode) -> list[xml.Node]:
+        return self._c.snapshot(filter)
 
     def oper_data(self) -> gdata.Node:
         return self._c.oper_data()
 
-    def sample(self) -> list[xml.Node]:
-        return self._c.sample()
+    def sample(self, filter: ?gdata.FNode) -> list[xml.Node]:
+        return self._c.sample(filter)
 
-    def change(self) -> ?xml.Node:
-        return self._c.change()
+    def change(self, filter: ?gdata.FNode) -> ?xml.Node:
+        return self._c.change(filter)

--- a/src/yp/mock_backend.act
+++ b/src/yp/mock_backend.act
@@ -8,11 +8,11 @@ pipe and the standalone mock server that ncurl connects to.
 InterfaceCountersBackend is the YangPushBackend the publisher pulls from. It holds
 its state as a gdata tree so it can serve every pull from one source: snapshot
 returns the current counters as XML and oper_data the same as a gdata tree (for
-<get>); sample advances them once and returns the new XML (periodic); and change
-advances them once and returns an RFC 8072 yang-patch of the delta (on-change) by
-running gdata.diff over the before/after filtered trees and rendering it with
-ypatch. The mutable state lives in an actor, with a small class in front so the
-publisher gets its values back from a plain call.
+<get>); sample returns the current XML for periodic push; change renders the most
+recent explicit counter advance as an RFC 8072 yang-patch by running gdata.diff
+over the before/after filtered trees and rendering it with ypatch. The mutable
+state lives in an actor, with a small class in front so the publisher gets its
+values back from a plain call.
 """
 
 import std.xml as xml
@@ -49,10 +49,11 @@ class MockBackend(YangPushBackend):
     tree, for serving <get> and for overlaying further operational state (e.g. the
     ietf-yang-library tree) on top of it.
 
-    oper_data is declared via proc here because a concrete class method that awaits
-    an actor call (return self._c.oper_data()) only compiles when the method is
-    declared in a proc-typed parent - otherwise the CPS pass crashes."""
+    oper_data is declared via proc here because a concrete class method that
+    awaits an actor call (return self._c.oper_data()) only compiles when the
+    method is declared in a proc-typed parent - otherwise the CPS pass crashes."""
     oper_data: proc() -> gdata.Node
+    advance: proc() -> None
 
 
 def _tree(if_names: list[str], in_octets: dict[str, int], out_octets: dict[str, int]) -> gdata.Container:
@@ -82,16 +83,21 @@ actor _Counters(if_names: list[str], in_step: int, out_step: int, schema: ?ysche
     """Holds the mutable per-interface counters and produces snapshots/samples/changes."""
     var in_octets: dict[str, int] = {}
     var out_octets: dict[str, int] = {}
-    var patch_seq: int = 0
+    var change_seq: int = 0
+    var last_old: ?gdata.Node = None
+    var last_new: ?gdata.Node = None
 
     for _n in if_names:
         in_octets[_n] = 0
         out_octets[_n] = 0
 
-    def _advance() -> None:
+    def advance() -> None:
+        last_old = _tree(if_names, in_octets, out_octets)
         for n in if_names:
             in_octets[n] = in_octets[n] + in_step
             out_octets[n] = out_octets[n] + out_step
+        last_new = _tree(if_names, in_octets, out_octets)
+        change_seq += 1
 
     def prepare_filter(subtree_filter: ?list[xml.Node]) -> ?gdata.FNode:
         if subtree_filter is not None:
@@ -110,7 +116,6 @@ actor _Counters(if_names: list[str], in_step: int, out_step: int, schema: ?ysche
         return _tree(if_names, in_octets, out_octets)
 
     def sample(filter: ?gdata.FNode) -> list[xml.Node]:
-        _advance()
         data = _tree(if_names, in_octets, out_octets)
         if filter is not None:
             xml_nodes = gdata.filter(data, filter)?.to_xml(deterministic=True)
@@ -118,18 +123,16 @@ actor _Counters(if_names: list[str], in_step: int, out_step: int, schema: ?ysche
         return data.to_xml(deterministic=True)
 
     def change(filter: ?gdata.FNode) -> ?xml.Node:
-        old: ?gdata.Node = _tree(if_names, in_octets, out_octets)
-        if filter is not None:
-            old = gdata.filter(old, filter)
-        _advance()
-        new: ?gdata.Node = _tree(if_names, in_octets, out_octets)
-        if filter is not None:
-            new = gdata.filter(new, filter)
+        old: ?gdata.Node = last_old
+        new: ?gdata.Node = last_new
+        if new is not None:
+            if filter is not None:
+                old = gdata.filter(old, filter)
+                new = gdata.filter(new, filter)
         if new is not None:
             d = gdata.diff(old, new)
             if d is not None:
-                patch_seq += 1
-                return ypatch.diff_to_patch(d, "patch{patch_seq}").to_xml()
+                return ypatch.diff_to_patch(d, "patch{change_seq}").to_xml()
         return None
 
 
@@ -138,6 +141,9 @@ class InterfaceCountersBackend(MockBackend):
 
     def __init__(self, if_names: list[str], in_step: int=100, out_step: int=200, schema: ?yschema.DRoot=None):
         self._c = _Counters(if_names, in_step, out_step, schema)
+
+    def advance(self) -> None:
+        self._c.advance()
 
     def prepare_filter(self, subtree_filter: ?list[xml.Node]) -> ?gdata.FNode:
         return self._c.prepare_filter(subtree_filter)

--- a/src/yp_mockserver.act
+++ b/src/yp_mockserver.act
@@ -1,16 +1,16 @@
 """Standalone YANG-push-capable mock NETCONF server.
 
 A self-contained NETCONF server (over SSH) that serves YANG-push subscriptions
-backed by the InterfaceCountersBackend mock data generator — no datastore engine
-(no TTT) involved. It exists so a client such as ncurl monitor can connect to a
-real NETCONF/SSH server and stream pushes of generated data.
+backed by one shared InterfaceCountersBackend mock data source — no datastore
+engine (no TTT) involved. It exists so a client such as ncurl monitor can connect
+to a real NETCONF/SSH server and stream pushes of generated data.
 
-Each accepted SSH session gets its own netconf.Server + a NetconfSubscriptionService
-wired to its own InterfaceCountersBackend, so subscribers are independent. It serves
+Each accepted SSH session gets its own netconf.Server + NetconfSubscriptionService,
+all observing the same continuously advancing InterfaceCountersBackend. It serves
 periodic subscriptions (timer-driven push-update) and on-change subscriptions
-(push-change-update carrying a yang-patch). On-change is event-driven: press Enter
-on the server's stdin to trigger a change, and every on-change subscriber gets a
-push-change-update with the delta.
+(push-change-update carrying a yang-patch). The server advances the shared source
+on a timer and fans the resulting change out to active sessions; pressing Enter
+triggers an immediate extra advance.
 
 The mock has a real schema (a small mock-interfaces module compiled with the
 ietf-yang-library closure), so it is a proper discoverable NETCONF server: it
@@ -21,7 +21,7 @@ operational data merged with the ietf-yang-library tree, subtree-filtered.
 
 Run:  yp_mockserver [--address ::] [--port 12830] [--username admin]
                     [--password admin] [--interfaces eth0,eth1] [--verbose]
-Press Enter to trigger an on-change update; 'q' then Enter to quit.
+Press Enter to trigger an immediate on-change update; 'q' then Enter to quit.
 """
 
 import argparse
@@ -94,7 +94,7 @@ def build_mock_schema() -> MockSchema:
 
 
 class OperBackend(mb.MockBackend):
-    """The mock's operational datastore: the per-session interface counters overlaid
+    """The mock's operational datastore: the shared interface counters overlaid
     with the static ietf-yang-library tree.
 
     This single source feeds both <get> and the yang-push subscription, so a periodic
@@ -116,6 +116,9 @@ class OperBackend(mb.MockBackend):
 
     def prepare_filter(self, subtree_filter: ?list[xml.Node]) -> ?ygdata.FNode:
         return self._counters.prepare_filter(subtree_filter)
+
+    def advance(self) -> None:
+        self._counters.advance()
 
     def snapshot(self, filter: ?ygdata.FNode) -> list[xml.Node]:
         data = self._counters.snapshot(filter)
@@ -146,12 +149,11 @@ actor StaticAuthChecker(expected_user: str, expected_password: str):
 
 actor YpMockSession(pipe,
                     log_handler: logging.Handler,
-                    if_names: list[str],
+                    backend: mb.MockBackend,
                     ms: MockSchema,
                     on_close: ?action(YpMockSession) -> None=None):
     """One NETCONF session: a Server + a YANG-push service over a mock backend."""
     _log = logging.Logger(log_handler)
-    backend = OperBackend(if_names, ms.schema, ms.yl_view)
     var service: ?nyp.NetconfSubscriptionService = None
 
     def _get_data() -> ygdata.Node:
@@ -216,10 +218,12 @@ actor YpMockServer(listen_cap: net.TCPListenCap,
                    port: int=12830,
                    username: str="admin",
                    password: str="admin",
+                   tick_interval: float=1.0,
                    on_listen: ?action(?Exception) -> None=None):
     """SSH listener that turns each accepted channel into a YpMockSession."""
     _log = logging.Logger(log_handler)
     _auth = StaticAuthChecker(username, password).check
+    backend = OperBackend(if_names, ms.schema, ms.yl_view)
     var sessions: list[YpMockSession] = []
     var listener: ?sshpipe.SshPipeListener = None
 
@@ -232,13 +236,28 @@ actor YpMockServer(listen_cap: net.TCPListenCap,
 
     def _on_accept(l: sshpipe.SshPipeListener, p: sshpipe.SshListenPipe):
         _log.info("session accepted")
-        sessions.append(YpMockSession(p, log_handler, if_names, ms, on_close=_session_closed))
+        sessions.append(YpMockSession(p, log_handler, backend, ms, on_close=_session_closed))
 
-    def trigger_all() -> None:
-        """Trigger an on-change update on every active session."""
-        print("triggered on-change update across {len(sessions)} session(s)")
+    def _notify_sessions(report: bool=False) -> None:
+        """Trigger an on-change update on every active session. The per-session
+        subscriber counts are logged by each publisher; here we just report how many
+        sessions were poked, computed before the loop so no int is held across an
+        actor-call await (that pattern trips an RTS codegen bug)."""
+        if report:
+            print("triggered on-change update across {len(sessions)} session(s)")
         for s in sessions:
             s.trigger_change()
+
+    def trigger_all() -> None:
+        """Advance the shared counter source once and notify all active sessions."""
+        backend.advance()
+        _notify_sessions(report=True)
+
+    def _tick() -> None:
+        backend.advance()
+        _notify_sessions()
+        if tick_interval > 0.0:
+            after tick_interval: _tick()
 
     def _on_listen(l: sshpipe.SshPipeListener, err: ?Exception):
         if err is not None:
@@ -259,6 +278,9 @@ actor YpMockServer(listen_cap: net.TCPListenCap,
         subsystem="netconf",
         host_key=None,
         log_handler=log_handler)
+
+    if tick_interval > 0.0:
+        after tick_interval: _tick()
 
     def close():
         l = listener
@@ -295,14 +317,22 @@ actor main(env):
         port = args.get_int("port")
         username = args.get_str("username")
         password = args.get_str("password")
+        tick_interval_s = args.get_str("tick-interval")
+        tick_interval = 1.0
+        try:
+            tick_interval = float(tick_interval_s)
+        except ValueError:
+            print("Error: --tick-interval must be a number of seconds, got '{tick_interval_s}'", err=True)
+            env.exit(1)
+            return
         if_names = args.get_strlist("interfaces")
         if if_names == []:
             if_names = ["eth0", "eth1"]
 
         listen_cap = net.TCPListenCap(net.TCPCap(net.NetCap(env.auth)))
-        server = YpMockServer(listen_cap, logh, if_names, build_mock_schema(), address, port, username, password)
+        server = YpMockServer(listen_cap, logh, if_names, build_mock_schema(), address, port, username, password, tick_interval)
         env.stdin_install(on_stdin=_on_input)
-        print("yp mock server ready. Press Enter to trigger an on-change update; 'q' then Enter to quit.")
+        print("yp mock server ready. Advancing every {tick_interval}s; press Enter for an immediate update; 'q' then Enter to quit.")
         # No env.exit(): the SSH listener keeps the runtime alive until killed.
 
     def _parse_args():
@@ -312,6 +342,7 @@ actor main(env):
         p.add_option("username", "str", "?", "admin", "Username for authentication")
         p.add_option("password", "str", "?", "admin", "Password for authentication")
         p.add_option("interfaces", "strlist", "*", [], "Interface names to generate counters for")
+        p.add_option("tick-interval", "str", "?", "1.0", "Seconds between automatic counter advances (0 disables the timer)")
         p.add_bool("verbose", "Verbose logging")
         return p.parse(env.argv)
 

--- a/src/yp_mockserver.act
+++ b/src/yp_mockserver.act
@@ -43,23 +43,6 @@ import yp
 import yp.mock_backend as mb
 import swyang
 
-
-INTERFACES_YANG: str = r"""module mock-interfaces {
-  yang-version 1.1;
-  namespace "urn:mock:interfaces";
-  prefix mif;
-  container interfaces {
-    config false;
-    list interface {
-      key name;
-      leaf name { type string; }
-      leaf in-octets { type uint64; }
-      leaf out-octets { type uint64; }
-    }
-  }
-}"""
-
-
 class MockSchema(object):
     """The compiled mock data model plus everything the server needs to advertise and
     serve it: the schema (for subtree filtering), the ietf-yang-library view and the
@@ -84,7 +67,7 @@ def build_mock_schema() -> MockSchema:
     (which makes a client establish a real yang-push subscription rather than polling),
     and answers get-schema for every module."""
     modules: list[(name: str, src: str)] = [
-        (name="mock-interfaces", src=INTERFACES_YANG),
+        (name="mock-interfaces", src=mb.INTERFACES_YANG),
         (name="ietf-yang-library", src=swyang.ietf_yang_library),
         (name="ietf-datastores", src=swyang.ietf_datastores),
         (name="ietf-yang-types", src=swyang.ietf_yang_types),
@@ -122,8 +105,8 @@ class OperBackend(mb.MockBackend):
     _yl: ?ygdata.Node
     _yl_xml: list[xml.Node]
 
-    def __init__(self, if_names: list[str], yl_view: ?(root: ygdata.Node, content_id: str)):
-        self._counters = mb.InterfaceCountersBackend(if_names)
+    def __init__(self, if_names: list[str], schema: yschema.DRoot, yl_view: ?(root: ygdata.Node, content_id: str)):
+        self._counters = mb.InterfaceCountersBackend(if_names, schema=schema)
         if yl_view is not None:
             self._yl = yl_view.root
             self._yl_xml = yl_view.root.to_xml(deterministic=True)
@@ -131,11 +114,16 @@ class OperBackend(mb.MockBackend):
             self._yl = None
             self._yl_xml = []
 
-    def snapshot(self) -> list[xml.Node]:
-        return self._counters.snapshot() + self._yl_xml
+    def prepare_filter(self, subtree_filter: ?list[xml.Node]) -> ?ygdata.FNode:
+        return self._counters.prepare_filter(subtree_filter)
 
-    def sample(self) -> list[xml.Node]:
-        return self._counters.sample() + self._yl_xml
+    def snapshot(self, filter: ?ygdata.FNode) -> list[xml.Node]:
+        data = self._counters.snapshot(filter)
+        return data if filter is not None else data + self._yl_xml
+
+    def sample(self, filter: ?ygdata.FNode) -> list[xml.Node]:
+        data = self._counters.sample(filter)
+        return data if filter is not None else data + self._yl_xml
 
     def oper_data(self) -> ygdata.Node:
         base: ygdata.Node = self._counters.oper_data()
@@ -144,10 +132,10 @@ class OperBackend(mb.MockBackend):
             return ygdata.merge(base, yl)
         return base
 
-    def change(self) -> ?xml.Node:
+    def change(self, filter: ?ygdata.FNode) -> ?xml.Node:
         # The yang-library tree is static, so an on-change delta is just the counter
         # change the inner backend produces.
-        return self._counters.change()
+        return self._counters.change(filter)
 
 
 actor StaticAuthChecker(expected_user: str, expected_password: str):
@@ -163,7 +151,7 @@ actor YpMockSession(pipe,
                     on_close: ?action(YpMockSession) -> None=None):
     """One NETCONF session: a Server + a YANG-push service over a mock backend."""
     _log = logging.Logger(log_handler)
-    backend = OperBackend(if_names, ms.yl_view)
+    backend = OperBackend(if_names, ms.schema, ms.yl_view)
     var service: ?nyp.NetconfSubscriptionService = None
 
     def _get_data() -> ygdata.Node:


### PR DESCRIPTION
It emits sync-on-start as a real boolean XML value, compiles fetched device schemas with strict_quoting disabled, handles partial NETCONF chunk prefixes, applies YANG Push subtree filters through gdata FNode, and makes the mock YANG Push counter source autonomous and shared across sessions.
