### PR TITLE
Support IOS XE YANG Push periodic subscriptions

### DIFF
--- a/src/adapters/netconf.act
+++ b/src/adapters/netconf.act
@@ -113,6 +113,115 @@ def _test_yang_push_dialect_yang_library_modules():
         testing.assertEqual(dialect, True)
 
 
+def _xpath_literal(v) -> ?str:
+    if isinstance(v, ygdata.VWildcard):
+        return None
+    s = ygdata.yang_str(v)
+    if "'" in s:
+        return None
+    return "'" + s + "'"
+
+
+def _xpath_name(name: ygdata.Id, prefixes: dict[str, str], nsdefs: list[(?str, str)]) -> str:
+    if name.q == "":
+        return name.name
+    if name.q not in prefixes:
+        prefix = "ypf" + str(len(prefixes))
+        prefixes[name.q] = prefix
+        nsdefs.append((prefix, name.q))
+    return prefixes[name.q] + ":" + name.name
+
+
+def _fnode_xpath_step(filt: ygdata.FNode, prefixes: dict[str, str], nsdefs: list[(?str, str)]) -> ?str:
+    if filt.name is None or filt.value_match is not None:
+        return None
+
+    step = _xpath_name(filt.name!, prefixes, nsdefs)
+    predicates: list[str] = []
+    path_child: ?str = None
+
+    for child in filt.children:
+        if child.value_match is not None:
+            if child.name is None or len(child.children) > 0:
+                return None
+            lit = _xpath_literal(child.value_match!)
+            if lit is None:
+                return None
+            predicates.append(_xpath_name(child.name!, prefixes, nsdefs) + "=" + lit!)
+        else:
+            if path_child is not None:
+                return None
+            child_path = _fnode_xpath_step(child, prefixes, nsdefs)
+            if child_path is None:
+                return None
+            path_child = child_path
+
+    if len(predicates) > 0:
+        step = step + "[" + " and ".join(predicates) + "]"
+
+    if path_child is not None:
+        return step + "/" + path_child!
+    return step
+
+
+def _fnode_to_xpath_filter(filt: ygdata.FNode) -> (xpath: ?str, nsdefs: list[(?str, str)]):
+    root = filt
+    if root.name is None:
+        if root.value_match is not None or len(root.children) != 1:
+            return (xpath=None, nsdefs=[])
+        root = root.children[0]
+
+    prefixes: dict[str, str] = {}
+    nsdefs: list[(?str, str)] = []
+    path = _fnode_xpath_step(root, prefixes, nsdefs)
+    if path is None:
+        return (xpath=None, nsdefs=[])
+    return (xpath="/" + path!, nsdefs=nsdefs)
+
+
+def _test_fnode_to_xpath_filter_simple_path():
+    ns = "urn:test:system"
+    res = _fnode_to_xpath_filter(ygdata.FNode(children=[
+        ygdata.FNode(ygdata.Id(ns, "system-state"), children=[
+            ygdata.FNode(ygdata.Id(ns, "clock"), children=[
+                ygdata.FNode(ygdata.Id(ns, "current-datetime"))
+            ])
+        ])
+    ]))
+    testing.assertEqual(res.xpath, "/ypf0:system-state/ypf0:clock/ypf0:current-datetime")
+    testing.assertEqual(len(res.nsdefs), 1)
+    testing.assertEqual(res.nsdefs[0].0, "ypf0")
+    testing.assertEqual(res.nsdefs[0].1, ns)
+
+
+def _test_fnode_to_xpath_filter_list_predicate():
+    ns = "urn:test:interfaces"
+    res = _fnode_to_xpath_filter(ygdata.FNode(children=[
+        ygdata.FNode(ygdata.Id(ns, "interfaces"), children=[
+            ygdata.FNode(ygdata.Id(ns, "interface"), children=[
+                ygdata.FNode(ygdata.Id(ns, "name"), value_match="eth0"),
+                ygdata.FNode(ygdata.Id(ns, "in-octets"))
+            ])
+        ])
+    ]))
+    testing.assertEqual(res.xpath, "/ypf0:interfaces/ypf0:interface[ypf0:name='eth0']/ypf0:in-octets")
+    testing.assertEqual(len(res.nsdefs), 1)
+    testing.assertEqual(res.nsdefs[0].1, ns)
+
+
+def _test_fnode_to_xpath_filter_rejects_multi_branch():
+    ns = "urn:test:system"
+    res = _fnode_to_xpath_filter(ygdata.FNode(children=[
+        ygdata.FNode(ygdata.Id(ns, "system-state"), children=[
+            ygdata.FNode(ygdata.Id(ns, "clock"), children=[
+                ygdata.FNode(ygdata.Id(ns, "current-datetime")),
+                ygdata.FNode(ygdata.Id(ns, "boot-datetime"))
+            ])
+        ])
+    ]))
+    testing.assertEqual(res.xpath is None, True)
+
+
 def _mock_capabilities_from_dmc(new_dmc: DeviceMetaConfig) -> list[str]:
     """True protocol capabilities for the mock device hello exchange.
     """
@@ -1436,12 +1545,25 @@ actor NetconfDriver(dev: swdev.DeviceMgr, bundled_schema: DeviceSchema, init_dmc
         c = client
         if c is not None:
             filt_xml: ?list[xml.Node] = None
+            xpath_filter: ?str = None
+            xpath_nsdefs: list[(?str, str)] = []
             sf = st.spec.filt
             if sf is not None:
-                # Carry the whole filter, including multi-root filters; dropping
-                # it would subscribe to the entire datastore and leak far more
-                # operational data than the subscriber asked for.
-                filt_xml = ygdata.expect(sf, "subscription filter").to_filter_xml(deterministic=True)
+                filt = sf!
+                if _yp_event_notifs:
+                    xpath = _fnode_to_xpath_filter(filt)
+                    if xpath.xpath is None:
+                        err = ValueError("event-notifications yang-push only supports simple subscription filters")
+                        for owner_id in st.owners:
+                            _owner_publish(owner_id, err)
+                        return
+                    xpath_filter = xpath.xpath
+                    xpath_nsdefs = xpath.nsdefs
+                else:
+                    # Carry the whole filter, including multi-root filters; dropping
+                    # it would subscribe to the entire datastore and leak far more
+                    # operational data than the subscriber asked for.
+                    filt_xml = filt.to_filter_xml(deterministic=True)
 
             def on_est(cc: netconf.Client, sid: ?int, err: ?netconf.NetconfError):
                 yp_pending.discard(spec)
@@ -1461,13 +1583,15 @@ actor NetconfDriver(dev: swdev.DeviceMgr, bundled_schema: DeviceSchema, init_dmc
                 # first, seeding latest; later push-change-updates apply as deltas.
                 yp_pending.add(spec)
                 c.establish_subscription(on_est, on_change=True, sync_on_start=True,
-                    subtree_filter=filt_xml, event_notifs=_yp_event_notifs)
+                    subtree_filter=filt_xml, xpath_filter=xpath_filter,
+                    event_notifs=_yp_event_notifs, xpath_nsdefs=xpath_nsdefs)
             else:
                 period_cs = _period_centiseconds(st.spec.period)
                 if period_cs is not None:
                     yp_pending.add(spec)
                     c.establish_subscription(on_est, period=period_cs, subtree_filter=filt_xml,
-                        event_notifs=_yp_event_notifs)
+                        xpath_filter=xpath_filter, event_notifs=_yp_event_notifs,
+                        xpath_nsdefs=xpath_nsdefs)
                 else:
                     err = ValueError("yang-push requires a periodic subscription")
                     for owner_id in st.owners:

--- a/src/adapters/netconf.act
+++ b/src/adapters/netconf.act
@@ -442,18 +442,23 @@ actor NetconfDriver(dev: swdev.DeviceMgr, bundled_schema: DeviceSchema, init_dmc
             new_modset[m.name] = m
         return new_modset
 
-    def _supports_yang_push(capabilities: list[str], modules: dict[str, ModCap]) -> bool:
-        # The device supports datastore push subscriptions if it implements
-        # ietf-yang-push. Servers advertise their modules either as
-        # "<namespace>?module=ietf-yang-push..." URIs in <hello> (older style) or
-        # via ietf-yang-library (e.g. netopeer2), where the module list is in the
-        # discovered module set rather than the hello capabilities — so check both.
-        if "ietf-yang-push" in modules:
+    def _supports_module(name: str, capabilities: list[str], modules: dict[str, ModCap]) -> bool:
+        # Servers advertise modules either as "<namespace>?module=..." URIs in
+        # <hello> (older style) or via ietf-yang-library, where the module list is
+        # in the discovered module set rather than the hello capabilities.
+        if name in modules:
             return True
         for cap in capabilities:
-            if "ietf-yang-push" in cap:
+            if "?module=" not in cap and "&module=" not in cap:
+                continue
+            if parse_cap(cap).name == name:
                 return True
         return False
+
+    def _supports_yang_push(capabilities: list[str], modules: dict[str, ModCap]) -> bool:
+        # The device supports datastore push subscriptions if it implements
+        # ietf-yang-push.
+        return _supports_module("ietf-yang-push", capabilities, modules)
 
     def _supports_schema_discovery(capabilities: list[str]) -> bool:
         for cap in capabilities:

--- a/src/adapters/netconf.act
+++ b/src/adapters/netconf.act
@@ -2,6 +2,7 @@ import hash.wyhash as wyhash
 import logging
 import net
 import time
+import testing
 import std.xml as xml
 
 import yang.schema as yschema
@@ -26,6 +27,10 @@ from adapters.adapter import \
     subscription_delay, merge_subscription_tree, \
     SubscriptionStatus, SUBSCRIPTION_YANG_PUSH, SUBSCRIPTION_POLL, SUBSCRIPTION_CONNECTING
 
+MODULE_YANG_PUSH = "ietf-yang-push"
+MODULE_SUBSCRIBED_NOTIFICATIONS = "ietf-subscribed-notifications"
+MODULE_EVENT_NOTIFICATIONS = "ietf-event-notifications"
+
 def extract_txid(conf: ?xml.Node) -> ?str:
     """Attempt to extract a txid from configuration
 
@@ -38,6 +43,74 @@ def extract_txid(conf: ?xml.Node) -> ?str:
             for attr_name, attr_value in configuration_tag.attributes:
                 if attr_name == "junos:commit-seconds":
                     return attr_value
+
+
+def _supports_module(name: str, capabilities: list[str], modules: dict[str, ModCap]) -> bool:
+    # Servers advertise modules either as "<namespace>?module=..." URIs in
+    # <hello> (older style) or via ietf-yang-library, where the module list is in
+    # the discovered module set rather than the hello capabilities.
+    if name in modules:
+        return True
+    for cap in capabilities:
+        if "?module=" not in cap and "&module=" not in cap:
+            continue
+        if parse_cap(cap).name == name:
+            return True
+    return False
+
+
+def _yang_push_event_notifs(capabilities: list[str], modules: dict[str, ModCap]) -> ?bool:
+    """Return the YANG Push RPC dialect, or None when dynamic YANG Push is absent.
+
+    False means the standard RFC 8639/8641 combination: ietf-yang-push over
+    ietf-subscribed-notifications. True means IOS XE's non-standard
+    ietf-yang-push over ietf-event-notifications shape.
+    """
+    if not _supports_module(MODULE_YANG_PUSH, capabilities, modules):
+        return None
+    if _supports_module(MODULE_SUBSCRIBED_NOTIFICATIONS, capabilities, modules):
+        return False
+    if _supports_module(MODULE_EVENT_NOTIFICATIONS, capabilities, modules):
+        return True
+    return None
+
+
+def _test_yang_push_dialect_standard_caps():
+    dialect = _yang_push_event_notifs([
+        "urn:ietf:params:xml:ns:yang:ietf-yang-push?module=ietf-yang-push",
+        "urn:ietf:params:xml:ns:yang:ietf-subscribed-notifications?module=ietf-subscribed-notifications",
+        "urn:ietf:params:xml:ns:yang:ietf-event-notifications?module=ietf-event-notifications",
+    ], {})
+    testing.assertEqual(dialect is not None, True)
+    if dialect is not None:
+        testing.assertEqual(dialect, False)
+
+
+def _test_yang_push_dialect_event_notifs_caps():
+    dialect = _yang_push_event_notifs([
+        "urn:ietf:params:xml:ns:yang:ietf-yang-push?module=ietf-yang-push",
+        "urn:ietf:params:xml:ns:yang:ietf-event-notifications?module=ietf-event-notifications",
+    ], {})
+    testing.assertEqual(dialect is not None, True)
+    if dialect is not None:
+        testing.assertEqual(dialect, True)
+
+
+def _test_yang_push_dialect_requires_subscription_rpc():
+    dialect = _yang_push_event_notifs([
+        "urn:ietf:params:xml:ns:yang:ietf-yang-push?module=ietf-yang-push",
+    ], {})
+    testing.assertEqual(dialect is None, True)
+
+
+def _test_yang_push_dialect_yang_library_modules():
+    dialect = _yang_push_event_notifs([], {
+        MODULE_YANG_PUSH: ModCap(MODULE_YANG_PUSH, "urn:ietf:params:xml:ns:yang:ietf-yang-push"),
+        MODULE_EVENT_NOTIFICATIONS: ModCap(MODULE_EVENT_NOTIFICATIONS, "urn:ietf:params:xml:ns:yang:ietf-event-notifications"),
+    })
+    testing.assertEqual(dialect is not None, True)
+    if dialect is not None:
+        testing.assertEqual(dialect, True)
 
 
 def _mock_capabilities_from_dmc(new_dmc: DeviceMetaConfig) -> list[str]:
@@ -422,11 +495,14 @@ actor NetconfDriver(dev: swdev.DeviceMgr, bundled_schema: DeviceSchema, init_dmc
 
     # How we monitor this device, decided from its advertised capabilities at
     # connect time (None until connected): yang-push when supported, else periodic
-    # <get> polling. When using yang-push we establish device-side subscriptions
-    # and route their push-update notifications back to the matching shared spec
-    # via these id maps; yp_pending guards against establishing twice while an
-    # establish-subscription is in flight.
+    # <get> polling. _yp_event_notifs selects IOS XE's event-notifications
+    # RPC dialect; False is the standard subscribed-notifications dialect. When
+    # using yang-push we establish device-side subscriptions and route their
+    # push-update notifications back to the matching shared spec via these id maps;
+    # yp_pending guards against establishing twice while an establish-subscription
+    # is in flight.
     var _yang_push: ?bool = None
+    var _yp_event_notifs = False
     var yp_subid_spec: dict[int, ygdata.SubscriptionSpec] = {}
     var yp_spec_subid: dict[ygdata.SubscriptionSpec, int] = {}
     var yp_pending: set[ygdata.SubscriptionSpec] = set()
@@ -441,24 +517,6 @@ actor NetconfDriver(dev: swdev.DeviceMgr, bundled_schema: DeviceSchema, init_dmc
             m = parse_cap(cap)
             new_modset[m.name] = m
         return new_modset
-
-    def _supports_module(name: str, capabilities: list[str], modules: dict[str, ModCap]) -> bool:
-        # Servers advertise modules either as "<namespace>?module=..." URIs in
-        # <hello> (older style) or via ietf-yang-library, where the module list is
-        # in the discovered module set rather than the hello capabilities.
-        if name in modules:
-            return True
-        for cap in capabilities:
-            if "?module=" not in cap and "&module=" not in cap:
-                continue
-            if parse_cap(cap).name == name:
-                return True
-        return False
-
-    def _supports_yang_push(capabilities: list[str], modules: dict[str, ModCap]) -> bool:
-        # The device supports datastore push subscriptions if it implements
-        # ietf-yang-push.
-        return _supports_module("ietf-yang-push", capabilities, modules)
 
     def _supports_schema_discovery(capabilities: list[str]) -> bool:
         for cap in capabilities:
@@ -500,7 +558,11 @@ actor NetconfDriver(dev: swdev.DeviceMgr, bundled_schema: DeviceSchema, init_dmc
             # Pick the monitoring method from the device's capabilities. A fresh
             # client session invalidates any prior device-side subscriptions, so
             # drop the stale id maps and (re-)establish for this connection.
-            _yang_push = _supports_yang_push(c.get_capabilities(), new_modset)
+            yp_event_notifs = _yang_push_event_notifs(c.get_capabilities(), new_modset)
+            _yang_push = yp_event_notifs is not None
+            _yp_event_notifs = False
+            if yp_event_notifs is not None:
+                _yp_event_notifs = yp_event_notifs
             yp_subid_spec = {}
             yp_spec_subid = {}
             yp_pending = set()
@@ -1323,7 +1385,7 @@ actor NetconfDriver(dev: swdev.DeviceMgr, bundled_schema: DeviceSchema, init_dmc
                 del yp_subid_spec[sid]
             c = client
             if c is not None:
-                c.delete_subscription((lambda cc, err: None), sid)
+                c.delete_subscription((lambda cc, err: None), sid, event_notifs=_yp_event_notifs)
         yp_pending.discard(spec)
 
     def _period_centiseconds(period_ns) -> ?int:
@@ -1398,12 +1460,14 @@ actor NetconfDriver(dev: swdev.DeviceMgr, bundled_schema: DeviceSchema, init_dmc
                 # sync-on-start makes the device send a full push-update baseline
                 # first, seeding latest; later push-change-updates apply as deltas.
                 yp_pending.add(spec)
-                c.establish_subscription(on_est, on_change=True, sync_on_start=True, subtree_filter=filt_xml)
+                c.establish_subscription(on_est, on_change=True, sync_on_start=True,
+                    subtree_filter=filt_xml, event_notifs=_yp_event_notifs)
             else:
                 period_cs = _period_centiseconds(st.spec.period)
                 if period_cs is not None:
                     yp_pending.add(spec)
-                    c.establish_subscription(on_est, period=period_cs, subtree_filter=filt_xml)
+                    c.establish_subscription(on_est, period=period_cs, subtree_filter=filt_xml,
+                        event_notifs=_yp_event_notifs)
                 else:
                     err = ValueError("yang-push requires a periodic subscription")
                     for owner_id in st.owners:

--- a/src/adapters/netconf.act
+++ b/src/adapters/netconf.act
@@ -17,6 +17,7 @@ from yp.engine import YangPushBackend
 import device as swdev
 import ietf_yang_library as yl
 import monitoring
+import schema_filter
 from device_schema import DeviceSchema
 from device_meta_config import \
     stratoweave_rfs__device_entry as DeviceMetaConfig
@@ -30,6 +31,23 @@ from adapters.adapter import \
 MODULE_YANG_PUSH = "ietf-yang-push"
 MODULE_SUBSCRIBED_NOTIFICATIONS = "ietf-subscribed-notifications"
 MODULE_EVENT_NOTIFICATIONS = "ietf-event-notifications"
+RUNTIME_SCHEMA_MODULE_SETS = ["no-openconfig"]
+
+# TODO: Delete this table and read module prefixes from the compiled YANG
+# schema instead. XML namespace prefixes are supposed to be aliases, but IOS XE's
+# event-notifications YANG Push XPath handling currently rejects otherwise
+# equivalent filters when we generate synthetic prefixes such as "ypf0". This
+# hard-coded list is only here to keep the IOS XE interop path working while the
+# adapter is forced to synthesize XPath from FNode. The right place for this
+# knowledge is acton-yang/schema metadata: given a namespace, ask the compiled
+# schema for the advertised module prefix and use that when serializing XPath.
+XPATH_PREFERRED_PREFIXES = {
+    "urn:ietf:params:xml:ns:yang:iana-if-type": "ianaift",
+    "urn:ietf:params:xml:ns:yang:ietf-interfaces": "if",
+    "urn:ietf:params:xml:ns:yang:ietf-ip": "ip",
+    "urn:ietf:params:xml:ns:yang:ietf-system": "sys",
+    "urn:ietf:params:xml:ns:yang:ietf-yang-library": "yanglib",
+}
 
 def extract_txid(conf: ?xml.Node) -> ?str:
     """Attempt to extract a txid from configuration
@@ -126,7 +144,11 @@ def _xpath_name(name: ygdata.Id, prefixes: dict[str, str], nsdefs: list[(?str, s
     if name.q == "":
         return name.name
     if name.q not in prefixes:
-        prefix = "ypf" + str(len(prefixes))
+        preferred = XPATH_PREFERRED_PREFIXES.get(name.q)
+        if preferred is not None:
+            prefix = preferred!
+        else:
+            prefix = "ypf" + str(len(prefixes))
         prefixes[name.q] = prefix
         nsdefs.append((prefix, name.q))
     return prefixes[name.q] + ":" + name.name
@@ -165,6 +187,16 @@ def _fnode_xpath_step(filt: ygdata.FNode, prefixes: dict[str, str], nsdefs: list
 
 
 def _fnode_to_xpath_filter(filt: ygdata.FNode) -> (xpath: ?str, nsdefs: list[(?str, str)]):
+    # TODO: Remove this whole FNode-to-XPath bridge. FNode is the internal
+    # subtree-filter representation, and translating it back into an XPath string
+    # here is a leaky compatibility hack for IOS XE's event-notifications YANG
+    # Push implementation. It only handles a single simple path with equality
+    # predicates, rejects multi-branch filters, cannot preserve arbitrary XPath
+    # expressions, and currently has to paper over IOS XE's prefix sensitivity via
+    # XPATH_PREFERRED_PREFIXES above. The cleaner design is for the filter layer
+    # to carry an adapter-neutral typed filter that can be rendered as either
+    # subtree XML or XPath at the protocol boundary, with prefixes supplied by the
+    # compiled schema rather than by this adapter.
     root = filt
     if root.name is None:
         if root.value_match is not None or len(root.children) != 1:
@@ -206,6 +238,17 @@ def _test_fnode_to_xpath_filter_list_predicate():
     ]))
     testing.assertEqual(res.xpath, "/ypf0:interfaces/ypf0:interface[ypf0:name='eth0']/ypf0:in-octets")
     testing.assertEqual(len(res.nsdefs), 1)
+    testing.assertEqual(res.nsdefs[0].1, ns)
+
+
+def _test_fnode_to_xpath_filter_prefers_known_prefix():
+    ns = "urn:ietf:params:xml:ns:yang:ietf-interfaces"
+    res = _fnode_to_xpath_filter(ygdata.FNode(children=[
+        ygdata.FNode(ygdata.Id(ns, "interfaces-state"))
+    ]))
+    testing.assertEqual(res.xpath, "/if:interfaces-state")
+    testing.assertEqual(len(res.nsdefs), 1)
+    testing.assertEqual(res.nsdefs[0].0, "if")
     testing.assertEqual(res.nsdefs[0].1, ns)
 
 
@@ -717,6 +760,9 @@ actor NetconfDriver(dev: swdev.DeviceMgr, bundled_schema: DeviceSchema, init_dmc
                     continue
                 elif s.identifier == "tailf-rollback" or s.identifier.startswith("cisco-xe-openconfig"):
                     _log.debug("Device._on_connect: skipping broken schema", {"identifier": s.identifier, "reason": "Cisco IOS XE"})
+                    continue
+                elif not schema_filter.should_include_module(s.identifier, RUNTIME_SCHEMA_MODULE_SETS):
+                    _log.debug("Device._on_connect: skipping schema by module set", {"identifier": s.identifier, "module_sets": ",".join(RUNTIME_SCHEMA_MODULE_SETS)})
                     continue
                 elif s.identifier == "openconfig-isis-types" and s.version == "2017-01-13":
                     _log.debug("Device._on_connect: skipping broken schema", {"identifier": s.identifier, "version": s.version, "reason": "incorrect escape in double-quoted string"})

--- a/src/ncurl.act
+++ b/src/ncurl.act
@@ -23,7 +23,7 @@ import yang.schema as yschema
 import yang.xml as yxml
 import device as swdev
 import adapters.netconf as swna
-import ncurl.schema_filter as schema_filter
+import schema_filter
 
 from device_meta_config import \
     stratoweave_rfs__device_entry as DeviceMetaConfig, \
@@ -447,7 +447,7 @@ actor CmdGetData(env, args, log_handler, use_get_config: bool):
             if s.identifier.startswith("junos-rpc"):
                 print("Skipping {s.identifier}: undefined grouping common-forwarding", err=True)
                 continue
-            elif s.identifier == "tailf-rollback" or s.identifier.startswith("cicso-xe-openconfig"):
+            elif s.identifier == "tailf-rollback" or s.identifier.startswith("cisco-xe-openconfig"):
                 print("Skipping {s.identifier}: Cisco IOS XE", err=True)
                 continue
             if not schema_filter.should_include_module(s.identifier, module_sets):

--- a/src/netconf.act
+++ b/src/netconf.act
@@ -446,7 +446,8 @@ actor Client(
                                on_change: bool=False,
                                dampening_period: ?int=None,
                                sync_on_start: bool=True,
-                               event_notifs: bool=False) -> None:
+                               event_notifs: bool=False,
+                               xpath_nsdefs: list[(?str, str)]=[]) -> None:
         """Establish a YANG-push subscription (RFC 8639 + 8641 / 8640).
 
         Pass period (centiseconds) for a periodic subscription, or on_change=True for
@@ -461,7 +462,7 @@ actor Client(
         ietf-subscribed-notifications.
         """
         _log.info("NETCONF establish-subscription", {"datastore": datastore, "period": period, "on_change": on_change, "event_notifs": event_notifs})
-        op = yp.build_establish_subscription(datastore, subtree_filter, xpath_filter, period, on_change, dampening_period, sync_on_start, event_notifs)
+        op = yp.build_establish_subscription(datastore, subtree_filter, xpath_filter, period, on_change, dampening_period, sync_on_start, event_notifs, xpath_nsdefs)
         def _on_reply(c: Client, reply: ?xml.Node, err: ?NetconfError) -> None:
             if err is not None:
                 cb(c, None, err)

--- a/src/netconf.act
+++ b/src/netconf.act
@@ -445,7 +445,8 @@ actor Client(
                                period: ?int=None,
                                on_change: bool=False,
                                dampening_period: ?int=None,
-                               sync_on_start: bool=True) -> None:
+                               sync_on_start: bool=True,
+                               event_notifs: bool=False) -> None:
         """Establish a YANG-push subscription (RFC 8639 + 8641 / 8640).
 
         Pass period (centiseconds) for a periodic subscription, or on_change=True for
@@ -454,10 +455,13 @@ actor Client(
         pass false to request deltas only. The callback receives the allocated
         subscription-id on success; push notifications then arrive via the Client's
         on_notif callback — push-update for periodic and sync-on-start, and
-        push-change-update carrying a yang-patch for on-change deltas.
+        push-change-update carrying a yang-patch for on-change deltas. Set
+        event_notifs=True for IOS XE's non-standard ietf-yang-push over
+        ietf-event-notifications RPC shape; the default is standard YANG Push over
+        ietf-subscribed-notifications.
         """
-        _log.info("NETCONF establish-subscription", {"datastore": datastore, "period": period, "on_change": on_change})
-        op = yp.build_establish_subscription(datastore, subtree_filter, xpath_filter, period, on_change, dampening_period, sync_on_start)
+        _log.info("NETCONF establish-subscription", {"datastore": datastore, "period": period, "on_change": on_change, "event_notifs": event_notifs})
+        op = yp.build_establish_subscription(datastore, subtree_filter, xpath_filter, period, on_change, dampening_period, sync_on_start, event_notifs)
         def _on_reply(c: Client, reply: ?xml.Node, err: ?NetconfError) -> None:
             if err is not None:
                 cb(c, None, err)
@@ -468,15 +472,31 @@ actor Client(
                 if sub_id is not None:
                     cb(c, sub_id, None)
                 else:
-                    cb(c, None, NetconfError("establish-subscription reply carried no subscription-id"))
+                    result = yp.parse_subscription_result(reply)
+                    if result is not None and result != "ok" and result != "notif-bis:ok":
+                        cb(c, None, NetconfError("establish-subscription failed: subscription-result {result}"))
+                    else:
+                        cb(c, None, NetconfError("establish-subscription reply carried no subscription-id"))
             else:
                 cb(c, None, NetconfError("Empty establish-subscription reply"))
         rpc(op, _on_reply)
 
-    def delete_subscription(cb: action(Client, ?NetconfError) -> None, id: int) -> None:
+    def delete_subscription(cb: action(Client, ?NetconfError) -> None, id: int,
+                            event_notifs: bool=False) -> None:
         """Delete a YANG-push subscription previously established on this session."""
-        _log.info("NETCONF delete-subscription", {"id": id})
-        rpc(yp.build_delete_subscription(id), lambda c, _, err: cb(c, err))
+        _log.info("NETCONF delete-subscription", {"id": id, "event_notifs": event_notifs})
+        def _on_reply(c: Client, reply: ?xml.Node, err: ?NetconfError) -> None:
+            if err is not None:
+                cb(c, err)
+            elif reply is not None:
+                result = yp.parse_subscription_result(reply)
+                if result is not None and result != "ok" and result != "notif-bis:ok":
+                    cb(c, NetconfError("delete-subscription failed: subscription-result {result}"))
+                else:
+                    cb(c, None)
+            else:
+                cb(c, None)
+        rpc(yp.build_delete_subscription(id, event_notifs), _on_reply)
 
     def get_schema(cb: action(Client, ?xml.Node, ?NetconfError) -> None, identifier: str, version: ?str=None, format: str="yang") -> None:
         _log.info("NETCONF get-schema", {"identifier": identifier, "version": version, "format": format})

--- a/src/netconf/test_yp.act
+++ b/src/netconf/test_yp.act
@@ -29,9 +29,10 @@ actor _test_event_notifs_yangpush_rpc_shape(t: testing.EnvT):
     periodic = yp.build_establish_subscription(
         xpath_filter="/if:interfaces-state",
         period=100,
-        event_notifs=True)
+        event_notifs=True,
+        xpath_nsdefs=[("if", "urn:ietf:params:xml:ns:yang:ietf-interfaces")])
     testing.assertEqual(periodic.encode(),
-        '<establish-subscription xmlns="urn:ietf:params:xml:ns:yang:ietf-event-notifications" xmlns:yp="urn:ietf:params:xml:ns:yang:ietf-yang-push"><stream>yp:yang-push</stream><filter-type><xpath-filter xmlns="urn:ietf:params:xml:ns:yang:ietf-yang-push">/if:interfaces-state</xpath-filter></filter-type><periodic xmlns="urn:ietf:params:xml:ns:yang:ietf-yang-push"><period>100</period></periodic></establish-subscription>')
+        '<establish-subscription xmlns="urn:ietf:params:xml:ns:yang:ietf-event-notifications" xmlns:yp="urn:ietf:params:xml:ns:yang:ietf-yang-push"><stream>yp:yang-push</stream><filter-type><xpath-filter xmlns="urn:ietf:params:xml:ns:yang:ietf-yang-push" xmlns:if="urn:ietf:params:xml:ns:yang:ietf-interfaces">/if:interfaces-state</xpath-filter></filter-type><periodic xmlns="urn:ietf:params:xml:ns:yang:ietf-yang-push"><period>100</period></periodic></establish-subscription>')
 
     on_change = yp.build_establish_subscription(
         on_change=True,

--- a/src/netconf/test_yp.act
+++ b/src/netconf/test_yp.act
@@ -32,7 +32,7 @@ actor _test_event_notifs_yangpush_rpc_shape(t: testing.EnvT):
         event_notifs=True,
         xpath_nsdefs=[("if", "urn:ietf:params:xml:ns:yang:ietf-interfaces")])
     testing.assertEqual(periodic.encode(),
-        '<establish-subscription xmlns="urn:ietf:params:xml:ns:yang:ietf-event-notifications" xmlns:yp="urn:ietf:params:xml:ns:yang:ietf-yang-push"><stream>yp:yang-push</stream><filter-type><xpath-filter xmlns="urn:ietf:params:xml:ns:yang:ietf-yang-push" xmlns:if="urn:ietf:params:xml:ns:yang:ietf-interfaces">/if:interfaces-state</xpath-filter></filter-type><periodic xmlns="urn:ietf:params:xml:ns:yang:ietf-yang-push"><period>100</period></periodic></establish-subscription>')
+        '<establish-subscription xmlns="urn:ietf:params:xml:ns:yang:ietf-event-notifications" xmlns:yp="urn:ietf:params:xml:ns:yang:ietf-yang-push"><stream>yp:yang-push</stream><xpath-filter xmlns="urn:ietf:params:xml:ns:yang:ietf-yang-push" xmlns:if="urn:ietf:params:xml:ns:yang:ietf-interfaces">/if:interfaces-state</xpath-filter><period xmlns="urn:ietf:params:xml:ns:yang:ietf-yang-push">100</period></establish-subscription>')
 
     on_change = yp.build_establish_subscription(
         on_change=True,
@@ -40,7 +40,7 @@ actor _test_event_notifs_yangpush_rpc_shape(t: testing.EnvT):
         sync_on_start=False,
         event_notifs=True)
     testing.assertEqual(on_change.encode(),
-        '<establish-subscription xmlns="urn:ietf:params:xml:ns:yang:ietf-event-notifications" xmlns:yp="urn:ietf:params:xml:ns:yang:ietf-yang-push"><stream>yp:yang-push</stream><on-change xmlns="urn:ietf:params:xml:ns:yang:ietf-yang-push"><no-synch-on-start/><dampening-period>0</dampening-period></on-change></establish-subscription>')
+        '<establish-subscription xmlns="urn:ietf:params:xml:ns:yang:ietf-event-notifications" xmlns:yp="urn:ietf:params:xml:ns:yang:ietf-yang-push"><stream>yp:yang-push</stream><no-synch-on-start xmlns="urn:ietf:params:xml:ns:yang:ietf-yang-push"/><dampening-period xmlns="urn:ietf:params:xml:ns:yang:ietf-yang-push">0</dampening-period></establish-subscription>')
 
     delete = yp.build_delete_subscription(17, event_notifs=True)
     testing.assertEqual(delete.encode(),
@@ -49,6 +49,30 @@ actor _test_event_notifs_yangpush_rpc_shape(t: testing.EnvT):
     reply = xml.decode('<rpc-reply><subscription-result xmlns="urn:ietf:params:xml:ns:yang:ietf-event-notifications">notif-bis:ok</subscription-result><subscription-id xmlns="urn:ietf:params:xml:ns:yang:ietf-event-notifications">17</subscription-id></rpc-reply>')
     testing.assertEqual(yp.parse_subscription_result(reply), "notif-bis:ok")
     testing.assertEqual(yp.parse_subscription_id(reply), 17)
+    t.success()
+
+
+actor _test_event_notifs_yangpush_push_update_payload(t: testing.EnvT):
+    """IOS XE's event-notifications YANG Push payload uses subscription-id and
+    datastore-contents-xml rather than the RFC 8641 id/datastore-contents pair."""
+    notif = xml.decode(
+        '<notification xmlns="urn:ietf:params:xml:ns:netconf:notification:1.0">'
+        '<eventTime>2026-06-29T14:00:00Z</eventTime>'
+        '<push-update xmlns="urn:ietf:params:xml:ns:yang:ietf-yang-push">'
+        '<subscription-id>42</subscription-id>'
+        '<datastore-contents-xml>'
+        '<interfaces-state xmlns="urn:ietf:params:xml:ns:yang:ietf-interfaces">'
+        '<interface><name>GigabitEthernet1</name></interface>'
+        '</interfaces-state>'
+        '</datastore-contents-xml>'
+        '</push-update>'
+        '</notification>')
+    pu = yp.parse_push_update(notif)
+    testing.assertEqual(pu is not None, True)
+    if pu is not None:
+        testing.assertEqual(pu.sub_id, 42)
+        testing.assertEqual(len(pu.contents), 1)
+        testing.assertEqual(pu.contents[0].tag, "interfaces-state")
     t.success()
 
 

--- a/src/netconf/test_yp.act
+++ b/src/netconf/test_yp.act
@@ -23,6 +23,34 @@ import netconf.yp as yn
 import yang.ypatch as ypatch
 
 
+actor _test_event_notifs_yangpush_rpc_shape(t: testing.EnvT):
+    """The IOS XE event-notifications YANG Push dialect uses a different RPC
+    namespace and reply id leaf from RFC 8639 subscribed-notifications."""
+    periodic = yp.build_establish_subscription(
+        xpath_filter="/if:interfaces-state",
+        period=100,
+        event_notifs=True)
+    testing.assertEqual(periodic.encode(),
+        '<establish-subscription xmlns="urn:ietf:params:xml:ns:yang:ietf-event-notifications" xmlns:yp="urn:ietf:params:xml:ns:yang:ietf-yang-push"><stream>yp:yang-push</stream><filter-type><xpath-filter xmlns="urn:ietf:params:xml:ns:yang:ietf-yang-push">/if:interfaces-state</xpath-filter></filter-type><periodic xmlns="urn:ietf:params:xml:ns:yang:ietf-yang-push"><period>100</period></periodic></establish-subscription>')
+
+    on_change = yp.build_establish_subscription(
+        on_change=True,
+        dampening_period=0,
+        sync_on_start=False,
+        event_notifs=True)
+    testing.assertEqual(on_change.encode(),
+        '<establish-subscription xmlns="urn:ietf:params:xml:ns:yang:ietf-event-notifications" xmlns:yp="urn:ietf:params:xml:ns:yang:ietf-yang-push"><stream>yp:yang-push</stream><on-change xmlns="urn:ietf:params:xml:ns:yang:ietf-yang-push"><no-synch-on-start/><dampening-period>0</dampening-period></on-change></establish-subscription>')
+
+    delete = yp.build_delete_subscription(17, event_notifs=True)
+    testing.assertEqual(delete.encode(),
+        '<delete-subscription xmlns="urn:ietf:params:xml:ns:yang:ietf-event-notifications"><subscription-id>17</subscription-id></delete-subscription>')
+
+    reply = xml.decode('<rpc-reply><subscription-result xmlns="urn:ietf:params:xml:ns:yang:ietf-event-notifications">notif-bis:ok</subscription-result><subscription-id xmlns="urn:ietf:params:xml:ns:yang:ietf-event-notifications">17</subscription-id></rpc-reply>')
+    testing.assertEqual(yp.parse_subscription_result(reply), "notif-bis:ok")
+    testing.assertEqual(yp.parse_subscription_id(reply), 17)
+    t.success()
+
+
 actor _test_yangpush_periodic(t: testing.EnvT):
     """Client subscribes periodic; expect repeated push-update snapshots."""
     log = logging.Logger(t.log_handler)

--- a/src/schema_filter.act
+++ b/src/schema_filter.act
@@ -70,6 +70,12 @@ OPENCONFIG = ModuleSet(
     include_patterns=["^openconfig-"]
 )
 
+NO_OPENCONFIG = ModuleSet(
+    "no-openconfig",
+    "All available models except OpenConfig",
+    exclude_patterns=["^openconfig-", ".*openconfig.*"]
+)
+
 IETF = ModuleSet(
     "ietf",
     "IETF standard models",
@@ -87,6 +93,7 @@ MODULE_SETS = {
     "cisco-xr-unified-model": CISCO_XR_UNIFIED_MODEL,
     "cisco-xe-native": CISCO_XE_NATIVE,
     "openconfig": OPENCONFIG,
+    "no-openconfig": NO_OPENCONFIG,
     "ietf": IETF,
     "all": ALL_MODULES
 }

--- a/src/yp.act
+++ b/src/yp.act
@@ -132,13 +132,11 @@ def build_establish_subscription(
         children.append(xml.Node("stream", text="yp:yang-push"))
 
         if subtree_filter is not None:
-            children.append(xml.Node("filter-type", children=[
-                xml.Node("subtree-filter", nsdefs=[(None, NS_YP)], children=subtree_filter)
-            ]))
+            children.append(xml.Node("subtree-filter", nsdefs=[(None, NS_YP)],
+                children=subtree_filter))
         elif xpath_filter is not None:
-            children.append(xml.Node("filter-type", children=[
-                xml.Node("xpath-filter", nsdefs=[(None, NS_YP)] + xpath_nsdefs, text=xpath_filter)
-            ]))
+            children.append(xml.Node("xpath-filter", nsdefs=[(None, NS_YP)] + xpath_nsdefs,
+                text=xpath_filter))
     else:
         # <datastore> is an identityref in the ietf-datastores module, carried in the
         # ietf-yang-push namespace.
@@ -154,18 +152,25 @@ def build_establish_subscription(
                 text=xpath_filter))
 
     if on_change:
-        oc_children: list[xml.Node] = []
-        if event_notifs and not sync_on_start:
-            oc_children.append(xml.Node("no-synch-on-start"))
-        if dampening_period is not None:
-            oc_children.append(xml.Node("dampening-period", text=str(dampening_period)))
-        if not event_notifs:
+        if event_notifs:
+            if not sync_on_start:
+                children.append(xml.Node("no-synch-on-start", nsdefs=[(None, NS_YP)]))
+            if dampening_period is not None:
+                children.append(xml.Node("dampening-period", nsdefs=[(None, NS_YP)],
+                    text=str(dampening_period)))
+        else:
+            oc_children: list[xml.Node] = []
+            if dampening_period is not None:
+                oc_children.append(xml.Node("dampening-period", text=str(dampening_period)))
             oc_children.append(xml.Node("sync-on-start", text="true" if sync_on_start else "false"))
-        children.append(xml.Node("on-change", nsdefs=[(None, NS_YP)], children=oc_children))
+            children.append(xml.Node("on-change", nsdefs=[(None, NS_YP)], children=oc_children))
     elif period is not None:
-        children.append(xml.Node("periodic", nsdefs=[(None, NS_YP)], children=[
-            xml.Node("period", text=str(period))
-        ]))
+        if event_notifs:
+            children.append(xml.Node("period", nsdefs=[(None, NS_YP)], text=str(period)))
+        else:
+            children.append(xml.Node("periodic", nsdefs=[(None, NS_YP)], children=[
+                xml.Node("period", text=str(period))
+            ]))
 
     if event_notifs:
         return xml.Node("establish-subscription", nsdefs=[(None, NS_EN), ("yp", NS_YP)], children=children)
@@ -282,7 +287,11 @@ def parse_push_update(notif: xml.Node) -> ?PushUpdate:
     if payload is not None:
         if payload.tag == "push-update":
             sub_id = _parse_int(_text_of(_child_by_tag(payload, "id")))
+            if sub_id is None:
+                sub_id = _parse_int(_text_of(_child_by_tag(payload, "subscription-id")))
             dc = _child_by_tag(payload, "datastore-contents")
+            if dc is None:
+                dc = _child_by_tag(payload, "datastore-contents-xml")
             contents = dc.children if dc is not None else []
             return PushUpdate(sub_id, notification_event_time(notif), contents)
     return None
@@ -297,7 +306,11 @@ def parse_push_change_update(notif: xml.Node) -> ?PushChangeUpdate:
     if payload is not None:
         if payload.tag == "push-change-update":
             sub_id = _parse_int(_text_of(_child_by_tag(payload, "id")))
+            if sub_id is None:
+                sub_id = _parse_int(_text_of(_child_by_tag(payload, "subscription-id")))
             dc = _child_by_tag(payload, "datastore-changes")
+            if dc is None:
+                dc = _child_by_tag(payload, "datastore-changes-xml")
             yang_patch = _child_by_tag(dc, "yang-patch")
             return PushChangeUpdate(sub_id, notification_event_time(notif), yang_patch)
     return None

--- a/src/yp.act
+++ b/src/yp.act
@@ -112,7 +112,8 @@ def build_establish_subscription(
         on_change: bool=False,
         dampening_period: ?int=None,
         sync_on_start: bool=True,
-        event_notifs: bool=False) -> xml.Node:
+        event_notifs: bool=False,
+        xpath_nsdefs: list[(?str, str)]=[]) -> xml.Node:
     """Build an <establish-subscription> operation node (RFC 8639 + 8641).
 
     Pass period (centiseconds) for a periodic subscription, or on_change=True for an
@@ -136,7 +137,7 @@ def build_establish_subscription(
             ]))
         elif xpath_filter is not None:
             children.append(xml.Node("filter-type", children=[
-                xml.Node("xpath-filter", nsdefs=[(None, NS_YP)], text=xpath_filter)
+                xml.Node("xpath-filter", nsdefs=[(None, NS_YP)] + xpath_nsdefs, text=xpath_filter)
             ]))
     else:
         # <datastore> is an identityref in the ietf-datastores module, carried in the
@@ -149,7 +150,7 @@ def build_establish_subscription(
             children.append(xml.Node("datastore-subtree-filter", nsdefs=[(None, NS_YP)],
                 children=subtree_filter))
         elif xpath_filter is not None:
-            children.append(xml.Node("datastore-xpath-filter", nsdefs=[(None, NS_YP)],
+            children.append(xml.Node("datastore-xpath-filter", nsdefs=[(None, NS_YP)] + xpath_nsdefs,
                 text=xpath_filter))
 
     if on_change:

--- a/src/yp.act
+++ b/src/yp.act
@@ -30,6 +30,7 @@ import time
 
 # Namespaces
 NS_SN: str = "urn:ietf:params:xml:ns:yang:ietf-subscribed-notifications"
+NS_EN: str = "urn:ietf:params:xml:ns:yang:ietf-event-notifications"
 NS_YP: str = "urn:ietf:params:xml:ns:yang:ietf-yang-push"
 NS_NOTIF: str = "urn:ietf:params:xml:ns:netconf:notification:1.0"
 NS_DATASTORES: str = "urn:ietf:params:xml:ns:yang:ietf-datastores"
@@ -110,7 +111,8 @@ def build_establish_subscription(
         period: ?int=None,
         on_change: bool=False,
         dampening_period: ?int=None,
-        sync_on_start: bool=True) -> xml.Node:
+        sync_on_start: bool=True,
+        event_notifs: bool=False) -> xml.Node:
     """Build an <establish-subscription> operation node (RFC 8639 + 8641).
 
     Pass period (centiseconds) for a periodic subscription, or on_change=True for an
@@ -118,39 +120,63 @@ def build_establish_subscription(
     defaults to the RFC 8641/YANG default of true; pass false to request
     push-change-update notifications only. on-change takes precedence if both are
     given. A filter is optional; pass either subtree_filter (the filter's top-level
-    data nodes, each carrying its own module namespace) or xpath_filter.
+    data nodes, each carrying its own module namespace) or xpath_filter. Set
+    event_notifs=True for IOS XE's non-standard ietf-yang-push over
+    ietf-event-notifications RPC shape; the default is standard YANG Push over
+    ietf-subscribed-notifications.
     """
     children: list[xml.Node] = []
 
-    # <datastore> is an identityref in the ietf-datastores module, carried in the
-    # ietf-yang-push namespace.
-    children.append(xml.Node("datastore",
-        nsdefs=[(None, NS_YP), ("ds", NS_DATASTORES)],
-        text="ds:" + datastore))
+    if event_notifs:
+        children.append(xml.Node("stream", text="yp:yang-push"))
 
-    if subtree_filter is not None:
-        children.append(xml.Node("datastore-subtree-filter", nsdefs=[(None, NS_YP)],
-            children=subtree_filter))
-    elif xpath_filter is not None:
-        children.append(xml.Node("datastore-xpath-filter", nsdefs=[(None, NS_YP)],
-            text=xpath_filter))
+        if subtree_filter is not None:
+            children.append(xml.Node("filter-type", children=[
+                xml.Node("subtree-filter", nsdefs=[(None, NS_YP)], children=subtree_filter)
+            ]))
+        elif xpath_filter is not None:
+            children.append(xml.Node("filter-type", children=[
+                xml.Node("xpath-filter", nsdefs=[(None, NS_YP)], text=xpath_filter)
+            ]))
+    else:
+        # <datastore> is an identityref in the ietf-datastores module, carried in the
+        # ietf-yang-push namespace.
+        children.append(xml.Node("datastore",
+            nsdefs=[(None, NS_YP), ("ds", NS_DATASTORES)],
+            text="ds:" + datastore))
+
+        if subtree_filter is not None:
+            children.append(xml.Node("datastore-subtree-filter", nsdefs=[(None, NS_YP)],
+                children=subtree_filter))
+        elif xpath_filter is not None:
+            children.append(xml.Node("datastore-xpath-filter", nsdefs=[(None, NS_YP)],
+                text=xpath_filter))
 
     if on_change:
         oc_children: list[xml.Node] = []
+        if event_notifs and not sync_on_start:
+            oc_children.append(xml.Node("no-synch-on-start"))
         if dampening_period is not None:
             oc_children.append(xml.Node("dampening-period", text=str(dampening_period)))
-        oc_children.append(xml.Node("sync-on-start", text="true" if sync_on_start else "false"))
+        if not event_notifs:
+            oc_children.append(xml.Node("sync-on-start", text="true" if sync_on_start else "false"))
         children.append(xml.Node("on-change", nsdefs=[(None, NS_YP)], children=oc_children))
     elif period is not None:
         children.append(xml.Node("periodic", nsdefs=[(None, NS_YP)], children=[
             xml.Node("period", text=str(period))
         ]))
 
+    if event_notifs:
+        return xml.Node("establish-subscription", nsdefs=[(None, NS_EN), ("yp", NS_YP)], children=children)
     return xml.Node("establish-subscription", nsdefs=[(None, NS_SN)], children=children)
 
 
-def build_delete_subscription(sub_id: int) -> xml.Node:
+def build_delete_subscription(sub_id: int, event_notifs: bool=False) -> xml.Node:
     """Build a <delete-subscription> operation node (RFC 8639)."""
+    if event_notifs:
+        return xml.Node("delete-subscription", nsdefs=[(None, NS_EN)], children=[
+            xml.Node("subscription-id", text=str(sub_id))
+        ])
     return xml.Node("delete-subscription", nsdefs=[(None, NS_SN)], children=[
         xml.Node("id", text=str(sub_id))
     ])
@@ -224,9 +250,16 @@ def parse_subscription_id(rpc_reply: xml.Node) -> ?int:
     The id is a top-level child of the rpc-reply (an augmented reply).
     """
     id_node = _child_by_tag(rpc_reply, "id")
+    if id_node is None:
+        id_node = _child_by_tag(rpc_reply, "subscription-id")
     if id_node is not None:
         return _parse_int(id_node.text)
     return None
+
+
+def parse_subscription_result(rpc_reply: xml.Node) -> ?str:
+    """Extract an ietf-event-notifications subscription-result reply leaf."""
+    return _text_of(_child_by_tag(rpc_reply, "subscription-result"))
 
 
 def notification_payload(notif: xml.Node) -> ?xml.Node:


### PR DESCRIPTION
Adds support for IOS XE's event-notifications YANG Push dialect so periodic subscriptions can be established through the NETCONF adapter and ncurl. The RPC builder now emits the event-notifications filter and period leaves in the shape IOS XE accepts, and the notification parser handles IOS XE push-update payload names such as subscription-id and datastore-contents-xml.

Runtime schema fetch now uses the shared schema filtering helper with a no-openconfig module set, which avoids downloading and compiling the OpenConfig models that block IOS XE schema compilation. The temporary FNode-to-XPath bridge and hard-coded XPath prefix preference are marked with TODOs because the longer-term fix should render XPath using prefixes from the compiled schema.

This has been checked against the local IOS XE container with ncurl monitor using an ietf-interfaces interfaces-state filter, including a keyed filter for GigabitEthernet1. The focused netconf.test_yp and adapters.netconf tests pass, and the project builds with the latest Acton binary.
