### PR TITLE
Reconnect on set_dmc only when it affects the connection

### DIFF
--- a/src/adapters/netconf.act
+++ b/src/adapters/netconf.act
@@ -651,20 +651,23 @@ actor NetconfDriver(dev: swdev.DeviceMgr, bundled_schema: DeviceSchema, init_dmc
 
     def set_dmc(new_dmc: DeviceMetaConfig):
         _log.debug("Device.set_dmc", {"dmc": dmc.to_gdata().to_yang_jsonstr(), "new_dmc": new_dmc.to_gdata().to_yang_jsonstr()})
-        # TODO: implement Eq for adata
-        #if dmc is not None and dmc == new_dmc:
-        if dmc is not None and new_dmc is not None:
-            old_dmcg = dmc.to_gdata()
-            new_dmcg = new_dmc.to_gdata()
-            if old_dmcg is not None and new_dmcg is not None:
-                if old_dmcg == new_dmcg:
-                    _log.debug("Device.set_dmc: ignoring new device meta-config identical to current device meta-config")
-                    return
+        # TODO: implement Eq for adata so we can compare without going via gdata
+        if dmc.to_gdata() == new_dmc.to_gdata():
+            _log.debug("Device.set_dmc: ignoring new device meta-config identical to current device meta-config")
+            return
 
-        con_log_level = logging.TRACE if dmc.debug.connection else logging.WARNING
+        con_log_level = logging.TRACE if new_dmc.debug.connection else logging.WARNING
         _con_log_handler.set_output_level(con_log_level)
 
-        _connect(new_dmc)
+        # Reconnect only when session parameters / feature-flags change
+        if not (dmc.credentials.to_gdata() == new_dmc.credentials.to_gdata()
+                and dmc.address.to_gdata() == new_dmc.address.to_gdata()
+                and dmc.mock.to_gdata() == new_dmc.mock.to_gdata()
+                and dmc.feature_flags.to_gdata() == new_dmc.feature_flags.to_gdata()):
+            _log.debug("Device.set_dmc: reconnect required, reconnecting")
+            _connect(new_dmc)
+        else:
+            _log.debug("Device.set_dmc: no reconnect required, keeping client")
         dmc = new_dmc
 
     def _connect(new_dmc):
@@ -704,9 +707,6 @@ actor NetconfDriver(dev: swdev.DeviceMgr, bundled_schema: DeviceSchema, init_dmc
         address = addr.address
         addr_port = addr.port
         port = addr_port if addr_port is not None else bigint(830)
-
-        # TODO: we only need o use a new client if connection parameters have
-        # changed, other settings don't require a new client
 
         if connect_cap is not None and password is not None:
             state = CONNECTING


### PR DESCRIPTION
Avoid reconnecting in NetconfDriver.set_dmc() if the change to device meta-config doesn't affect the established session.