### PR TITLE
Operational documentation

### DIFF
--- a/docs/operations/devices.md
+++ b/docs/operations/devices.md
@@ -1,0 +1,160 @@
+# Device management
+
+StratoWeave keeps managed devices in the intent tree rather than in a separate
+out-of-band inventory. The transform layer immediately above the RFS layer owns
+that intent: it decides which devices exist, which generated device type each
+device uses, how the orchestrator reaches it, and which RFS transforms should
+be created for it.
+
+## Build-time: device adapters come from the system spec
+
+Each supported vendor OS version is declared as a separate device type in the
+system specification. Every `DeviceType.from_dir(...)` call loads one specific
+directory of YANG modules, and the generated application builds a typed device
+adapter for that exact module set.
+
+```acton title="spec/src/sorespo_gen.act"
+spec = stratoweave.build.SysSpec("sorespo", [
+		cfs_layer,
+		rfs_layer,
+], [
+		stratoweave.build.DeviceType.from_dir(fc, "CiscoIosXr_25_3_1", "yang/CiscoIosXr_25_3_1"),
+		stratoweave.build.DeviceType.from_dir(fc, "CiscoIosXr_25_4_1", "yang/CiscoIosXr_25_4_1"),
+		stratoweave.build.DeviceType.from_dir(fc, "JuniperCRPD_24_4R1_9", "yang/JuniperCRPD_24_4R1_9"),
+])
+
+spec.gen_app(fc, "../src/")
+```
+
+When a vendor ships a new release with a different set of YANG modules or
+revisions, add a new directory and a new `DeviceType.from_dir(...)` entry, and
+rebuild the application. At runtime, the value written into `device.type` must
+match one of these device type names exactly.
+
+## Operations-time: device entries are part of intent
+
+Operators do not create `DeviceMgr` instances directly. Instead, they submit
+northbound intent, and the layer above RFS emits two related outputs for each
+managed device:
+
+- a `device` entry that selects the generated adapter and supplies connection
+	details
+- an `rfs` entry that carries the resource-facing service data for that same
+	device
+
+In a two-layer system this is the CFS transform. In a three-layer system it
+would be the intermediate layer.
+
+## Exposing device inputs on the northbound
+
+If device address, credentials, or adapter selection should be operator
+provided, those inputs must exist in the northbound YANG model.
+
+```yang title="spec/yang/cfs/netinfra.yang"
+...
+	container netinfra {
+		list router {
+			key name;
+
+			sw:transform sorespo.cfs.Router;
+
+			leaf name {
+				type string;
+			}
+			leaf device-type {
+				type string;
+			}
+			leaf mgmt-address {
+				type inet:host;
+			}
+			leaf device-username {
+				type string;
+			}
+			leaf device-password {
+				type string;
+			}
+		}
+	}
+```
+
+If your northbound model exposes these leaves, operators can provide them in a
+startup XML file or over a northbound API such as NETCONF:
+
+```xml title="SORESPO-style northbound intent"
+<netinfra xmlns="...">
+	<router>
+		<name>pe1</name>
+		<device-type>CiscoIosXr_25_3_1</device-type>
+		<mgmt-address>192.0.2.10</mgmt-address>
+		<device-username>netops</device-username>
+		<device-password>netops-password</device-password>
+	</router>
+</netinfra>
+```
+
+In other scenarios, the northbound model may not expose these leaves,
+and the transform layer above RFS may instead look up the device type and
+credentials from an internal database or a secrets manager. In that case,
+the northbound intent would only need to provide e.g. the device name,
+and the transform would fill in the rest.
+
+## Creating device and RFS entries in the transform
+
+The transform above RFS creates the device entry and the matching RFS subtree
+together. The important pattern is:
+
+```acton title="src/sorespo/cfs.act"
+class Router(base.Router):
+		def transform(self, i, linked, dynstate):
+				o = base.o_root()
+
+				dev = o.device.create(i.name)
+				dev.type = i.device_type
+
+				oob = dev.address.create("oob")
+				oob.address = i.mgmt_address
+
+				dev.credentials.username = i.device_username
+				dev.credentials.password = i.device_password
+
+				rfs = o.rfs.create(i.name)
+				rfs.base_config.name = i.name
+
+				return o
+```
+
+Here, `o.device.create(i.name)` adds the managed device entry consumed by the
+generated device layer. `dev.type` selects one of the build-time device types,
+for example `CiscoIosXr_25_3_1`. `o.rfs.create(i.name)` creates the RFS object
+bound to that same device.
+
+If credentials should not be operator supplied, keep them out of the
+northbound YANG and set the same `dev.credentials` fields from an internal
+lookup instead.
+
+## RFS models still define the service-specific southbound data
+
+The built-in device list already comes from the StratoWeave RFS schema. Your
+project-specific RFS YANG augments that schema with the service-specific nodes
+that your RFS transforms need.
+
+```yang title="spec/yang/rfs/sorespo-rfs.yang"
+module sorespo-rfs {
+	...
+	augment "/sw-rfs:rfs" {
+		container base-config {
+			sw:rfs-transform sorespo.rfs.BaseConfig;
+
+			leaf name {
+				type string;
+			}
+		}
+	}
+}
+```
+
+In other words, the layer above RFS creates both the `device` entry and the
+matching `rfs` subtree as part of the same overall intent. The generated device
+layer then uses the `device` entry to select the correct per-version adapter
+and reconcile the rendered configuration against the target device.
+

--- a/docs/operations/http-api.md
+++ b/docs/operations/http-api.md
@@ -1,0 +1,298 @@
+# HTTP inspection API
+
+StratoWeave orchestrators expose a small HTTP inspection API rooted at `/`.
+
+This API is useful for inspecting devices, layer state, configuration queues,
+and rendered southbound configuration.
+
+## Conventions
+
+You can call these endpoints against any StratoWeave orchestrator with a base
+URL like this:
+
+```sh
+curl "$STRATOWEAVE_API_ORIGIN/device/AMS-CORE-1/running?format=xml"
+```
+
+A few conventions matter when you call these endpoints directly:
+
+- Device names in `/device/<name>/...` are case-sensitive.
+- The `/device/<name>/*` config endpoints select output format with the
+  `format` query parameter.
+- The `/layer/<idx>` endpoint does not use `?format=`. It selects output from
+  the `Accept` header instead.
+- For Acton adata output, both `/device/<name>/*` and `/layer/<idx>` support a
+  `loose` query parameter. It defaults to `true`.
+
+## SORESPO quicklab examples
+
+SORESPO quicklab Makefiles use these inspection endpoints today:
+
+- `GET /layer/<idx>`
+- `GET /device/<name>/target?format=<fmt>`
+- `GET /device/<name>/running?format=<fmt>`
+- `GET /device/<name>/diff?format=<fmt>`
+- `GET /device/<name>/resync`
+
+Typical Make targets include:
+
+```sh
+make get-config0
+make get-config-json2
+make get-config-adata3
+make get-target-ams-core-1
+make get-running-ams-core-1
+make get-diff-ams-core-1
+make resync-ams-core-1
+```
+
+## Inspection API
+
+### `GET /device`
+Returns the list of managed device names as JSON.
+
+Example response:
+
+```json
+{"devices":["AMS-CORE-1","FRA-CORE-1"]}
+```
+
+### `GET /device/<name>/info`
+Returns device metadata and current orchestration state as JSON.
+
+This includes:
+
+- device name and configured type
+- approval mode
+- configured addresses
+- configured username
+- `has_running_config`
+- `has_target_config`
+- `queue_length`
+- `pending_approvals`
+- feature flags
+- discovered module list
+
+This is the best summary endpoint when you need to understand whether a device
+is configured, queued, or missing data.
+
+### `GET /device/<name>/capabilities`
+Returns device capabilities as JSON.
+
+Example response shape:
+
+```json
+{"capabilities":["urn:ietf:params:netconf:base:1.1"]}
+```
+
+### `GET /device/<name>/modules`
+Returns the device module set as JSON.
+
+Each module entry contains the module name, namespace, revision, and features.
+This is useful when you need to confirm the live schema seen by the device
+manager.
+
+### `GET /device/<name>/running?format=<fmt>`
+Returns the current running configuration known for the device.
+
+Supported formats:
+
+- `json`
+- `xml`
+- `gdata`
+- `adata`
+
+Example:
+
+```sh
+curl "$STRATOWEAVE_API_ORIGIN/device/AMS-CORE-1/running?format=xml"
+```
+
+If no running configuration is available, the endpoint returns a `200` with the
+plain-text message `# No running configuration available`.
+
+### `GET /device/<name>/target?format=<fmt>`
+Returns StratoWeave's target configuration for the device: the config the
+orchestrator wants the device to have.
+
+Supported formats:
+
+- `json`
+- `xml`
+- `gdata`
+- `adata`
+
+Example:
+
+```sh
+curl "$STRATOWEAVE_API_ORIGIN/device/AMS-CORE-1/target?format=xml"
+```
+
+If no target configuration is available, the endpoint returns a `200` with the
+plain-text message `# No target configuration available`.
+
+### `GET /device/<name>/diff?format=<fmt>`
+Returns the difference between running and target configuration for the device.
+
+Supported formats:
+
+- `json`
+- `xml`
+- `gdata`
+- `adata`
+
+Example:
+
+```sh
+curl "$STRATOWEAVE_API_ORIGIN/device/AMS-CORE-1/diff?format=xml"
+```
+
+If there is no diff, the endpoint returns `# No differences`. If either side is
+missing, it returns `# Configuration not available`.
+
+### `GET /device/<name>/log?format=<fmt>`
+Returns the device configuration event log as JSON.
+
+Each log item contains:
+
+- `timestamp`
+- `event`
+- `conf_diff`
+
+Supported diff renderings inside the JSON payload:
+
+- `json`
+- `xml`
+- `gdata`
+
+`adata` is not implemented for this endpoint.
+
+### `GET /device/<name>/q`
+Returns the device's configuration queue as JSON.
+
+The response is a map keyed by queue item id. Each value currently includes the
+transaction id.
+
+Example response shape:
+
+```json
+{
+  "7": {"tid": "1234"},
+  "8": {"tid": "1235"}
+}
+```
+
+### `GET /device/<name>/q/<id>?format=<fmt>`
+Returns one queue item in JSON, including the diff awaiting approval or
+application.
+
+Fields include:
+
+- `tid`
+- `config_diff`
+- `device_txid`
+- `format`
+
+Supported diff formats for this endpoint are narrower than the device config
+endpoints:
+
+- `xml` (default)
+- `gdata`
+- `json` returns `# JSON diff not available`
+- `adata` returns `# Adata diff not available`
+
+### `POST /device/<name>/q/<id>/set_approval`
+Sets approval for a queued device config item.
+
+Request body:
+
+```json
+{"device_txid":"abc123","approved":true}
+```
+
+Response:
+
+```json
+{"status":"ok","approved":true}
+```
+
+This is the approval action behind configuration approval workflows such as the
+SORESPO queue UI.
+
+### `GET /config-queue`
+Returns all pending approvals across all devices as JSON.
+
+Each device entry contains:
+
+- `device_id`
+- `pending_count`
+- `items`
+
+Each item contains:
+
+- `queue_id`
+- `tid`
+- `device_txid`
+- `approved`
+
+This is the best endpoint for a global approval queue view.
+
+### `GET /device/<name>/resync`
+Triggers a device resynchronization and returns a JSON acknowledgement.
+
+Example:
+
+```sh
+curl "$STRATOWEAVE_API_ORIGIN/device/AMS-CORE-1/resync"
+```
+
+Response:
+
+```json
+{"status":"ok","message":"Resync initiated"}
+```
+
+## Layer inspection
+
+### `GET /layer/<idx>`
+Returns the stored configuration for one StratoWeave layer.
+
+Unlike the device config endpoints, serialization is selected with the
+`Accept` header:
+
+- `application/yang-data+xml`
+- `application/yang-data+json`
+- `application/yang-data+acton-adata`
+
+Examples:
+
+```sh
+curl -H "Accept: application/yang-data+xml" \
+  "$STRATOWEAVE_API_ORIGIN/layer/0"
+
+curl -H "Accept: application/yang-data+json" \
+  "$STRATOWEAVE_API_ORIGIN/layer/2"
+
+curl -H "Accept: application/yang-data+acton-adata" \
+  "$STRATOWEAVE_API_ORIGIN/layer/3?loose=true"
+```
+
+The meaning of each layer index depends on the system specification.
+
+For example, in SORESPO the layer numbers are:
+
+- `0`: CFS
+- `1`: Inter
+- `2`: RFS
+- `3`: Device
+
+If the index is out of range, the endpoint returns `404`.
+
+## Choosing the right endpoint
+
+Use `/layer/<idx>` when you want to inspect StratoWeave's stored state at a
+specific transform layer. Use `/device/<name>/target` and
+`/device/<name>/running` when you want to compare the orchestrator's intended
+southbound device config with the device's current running config. Use
+`/device/<name>/diff` and `/config-queue` when you are diagnosing rollout or
+approval behavior.

--- a/docs/operations/index.md
+++ b/docs/operations/index.md
@@ -1,7 +1,3 @@
 # Operations Guide
 
 This section of the documentation is for operators responsible for deploying and maintaining StratoWeave-based systems.
-
-## Deployment
-A StratoWeave-based Orchestrator is a single binary that can be deployed on any Linux-based system.
-The only runtime requirement is [libssh](https://www.libssh.org).

--- a/docs/operations/index.md
+++ b/docs/operations/index.md
@@ -1,3 +1,14 @@
 # Operations Guide
 
 This section of the documentation is for operators responsible for deploying and maintaining StratoWeave-based systems.
+
+## Topics
+
+- [Running StratoWeave](run.md): deployment, runtime flags, and startup
+	configuration files.
+- [Device management](devices.md): how managed devices are modeled and created
+	through intent.
+- [HTTP inspection API](http-api.md): StratoWeave-specific endpoints for
+	inspecting devices, layers, queues, and rendered device configuration.
+- [RESTCONF](restconf.md): the standard northbound RESTCONF interface for
+	reading and editing service intent.

--- a/docs/operations/restconf.md
+++ b/docs/operations/restconf.md
@@ -1,0 +1,89 @@
+# RESTCONF
+
+StratoWeave orchestrators expose a standard RESTCONF interface rooted at
+`/restconf` for retrieving and modifying northbound service intent.
+
+## Entry points
+
+### `GET /.well-known/host-meta`
+Returns host metadata that points clients at the RESTCONF root.
+
+### `GET /restconf/yang-library-version`
+Returns the advertised RESTCONF YANG library version.
+
+### `GET /restconf/data`
+Returns the top-level northbound data tree.
+
+XML example:
+
+```sh
+curl -H "Accept: application/yang-data+xml" \
+  "$STRATOWEAVE_API_ORIGIN/restconf/data"
+```
+
+JSON example:
+
+```sh
+curl -H "Accept: application/yang-data+json" \
+  "$STRATOWEAVE_API_ORIGIN/restconf/data"
+```
+
+## Editing northbound intent
+
+The RESTCONF root is also used for configuration operations such as `PATCH` and
+`DELETE`.
+
+For example, a StratoWeave orchestrator can accept northbound intent updates
+like this:
+
+```sh
+curl -f -X PATCH \
+  -H "Content-Type: application/yang-data+xml" \
+  -d @netinfra.xml \
+  "$STRATOWEAVE_API_ORIGIN/restconf/data"
+```
+
+JSON payloads can also be used:
+
+```sh
+curl -f -X PATCH \
+  -H "Content-Type: application/yang-data+json" \
+  -d @netinfra.json \
+  "$STRATOWEAVE_API_ORIGIN/restconf/data"
+```
+
+To remove a node, send `DELETE` to the resource path below `/restconf/data`:
+
+```sh
+curl -f -X DELETE \
+  "$STRATOWEAVE_API_ORIGIN/restconf/data/netinfra:netinfra/router=STO-CORE-1"
+```
+
+## SORESPO quicklab examples
+
+SORESPO quicklab Makefiles use RESTCONF directly for both reads and writes.
+Typical targets include:
+
+```sh
+make get-config-restconf
+make get-config-restconf-json
+make send-config-wait FILE="netinfra.xml"
+make send-config-json-wait FILE="netinfra.json"
+make send-config-async FILE="netinfra.xml"
+```
+
+SORESPO quicklab also uses RESTCONF resource paths for simple validation, for
+example:
+
+```sh
+curl -sS -f -H "Accept: application/yang-data+json" \
+  "$STRATOWEAVE_API_ORIGIN/restconf/data/netinfra:netinfra/router=AMS-CORE-1"
+```
+
+## When to use RESTCONF vs the inspection API
+
+Use RESTCONF when you want the northbound service model exactly as exposed by
+your orchestrator, or when you want to submit service intent. Use the
+[StratoWeave inspection API](http-api.md) for internal state such as layer
+snapshots, rendered per-device configuration, device module inventory, and
+approval queues.

--- a/docs/operations/run.md
+++ b/docs/operations/run.md
@@ -1,0 +1,85 @@
+
+# Running StratoWeave
+A StratoWeave-based Orchestrator is a single binary that can be deployed on any
+Linux-based system.
+The only runtime requirement is [libssh](https://www.libssh.org).
+
+## Deployment
+The simplest way to deploy a StratoWeave orchestrator is wrap up the binary
+into a container image and deploy it to a container orchestration platform such as
+Kubernetes. The following example shows a simple Dockerfile that wraps the
+SORESPO binary into a container image.
+
+```dockerfile title="Dockerfile for a StratoWeave orchestrator"
+FROM ubuntu:22.04
+RUN apt-get update && apt-get install -y libssh-4
+COPY out/bin/sorespo /usr/local/bin/sorespo
+ENTRYPOINT ["/usr/local/bin/sorespo"]
+```
+
+!!! tip
+    You could use a more minimal base image such as `alpine` or `debian:slim`,
+    and in the future we intend to enable you to use a `FROM scratch` base
+    image.
+
+## Logging
+StratoWeave orchestrators log to `stdout` and `stderr` by default. When you run
+the orchestrator in a container, these streams are captured by the container
+runtime and can be viewed with `docker logs` or `kubectl logs`.
+Through [Docker logging drivers](https://docs.docker.com/engine/logging/configure/),
+you can also redirect these streams to a file or a logging service of your
+choice.
+
+## Run-time configuration
+Running `--help` is the fastest way to confirm the exact interface exposed by
+the StratoWeave orchestrator binary you are using. The following example shows
+the output of `--help` for SORESPO, the reference implementation of a
+StratoWeave orchestrator.
+
+```console title="Inspect runtime options for a StratoWeave orchestrator"
+out/bin/sorespo --help
+Usage: /sorespo [--db DB] [--exit-on-done] [--help] [--http-port HTTP-PORT] [--netconf-host-key NETCONF-HOST-KEY] [--netconf-password NETCONF-PASSWORD] [--netconf-port NETCONF-PORT] [--netconf-user NETCONF-USER] FILE [FILE ...]
+
+Positional arguments:
+  FILE           Config XML file(s)
+
+Options:
+  --db DB        LMDB directory for TTT persistence
+  --exit-on-done Exit after startup config has been applied
+  --help         show this help message
+  --http-port HTTP-PORT HTTP listen port
+  --netconf-host-key NETCONF-HOST-KEY SSH host key file for NETCONF; ephemeral in-memory key if unset
+  --netconf-password NETCONF-PASSWORD NETCONF SSH password (v1 static credential)
+  --netconf-port NETCONF-PORT NETCONF SSH listen port
+  --netconf-user NETCONF-USER NETCONF SSH username (v1 static credential)
+```
+
+The required `FILE` arguments are startup configuration documents that are
+loaded in the order given. In practice, operators often keep a base system
+configuration in one file and add environment-specific overlays as later
+arguments.
+
+The most important runtime options are:
+
+- `--db` enables LMDB-backed persistence, specifying the directory in which
+  to store the database. If you omit this option, your StratoWeave
+  orchestrator will run in a stateless mode and all configuration will be
+  lost on shutdown.
+- `--http-port` changes the HTTP listener, which defaults to `80`.
+- `--netconf-port` changes the NETCONF over SSH listener, which defaults to
+  `830`.
+- `--netconf-host-key` points to a persistent SSH host key. If you omit it,
+  SORESPO generates an ephemeral in-memory key at startup.
+- `--netconf-user` and `--netconf-password` configure the built-in static
+  NETCONF credentials. They default to `admin` / `admin` and should be
+  overridden outside local testing.
+- `--exit-on-done` applies the supplied startup configuration and then exits
+  instead of continuing to serve traffic. This is useful for CI validation or
+  one-shot initialization jobs.
+
+### Acton Runtime System
+As for any Acton application, you can also configure the [Acton Runtime System](https://acton.guide/rts.html).
+
+!!! note
+    There is generally no need to change these settings, the defaults are
+    suitable for most deployments.


### PR DESCRIPTION
Document the operations surface for StratoWeave orchestrators.

This adds operator-focused docs for:
- runtime and startup configuration
- device management and how device entries are created through intent
- the StratoWeave HTTP inspection API
- the RESTCONF interface