### PR TITLE
Disable strict_quoting when building sysspec

### DIFF
--- a/src/build.act
+++ b/src/build.act
@@ -65,7 +65,7 @@ class SysSpec(object):
         def _compile_dev_type(dev_type: DeviceType, idx: int) -> CompiledDeviceType:
             print("Compiling device type {dev_type.name} ({idx+1}/{num_dev_types})...", end='', flush=True)
             sw = time.Stopwatch()
-            r = CompiledDeviceType(yang.compile(dev_type.models, allow_failure=allow_failure), dev_type.models, dev_type.name)
+            r = CompiledDeviceType(yang.compile(dev_type.models, strict_quoting=False, allow_failure=allow_failure), dev_type.models, dev_type.name)
             print(" {sw.elapsed().to_float():.3f}s")
             return r
         compiled_layers = [_compile_layer(l, idx) for (idx, l) in enumerate(self.layers)]


### PR DESCRIPTION
Vendor device models often include incorrectly escaped characters in quoted patterns. We avoid compilation errors by disabling YANG 1.1 strict quoting enforcement.