### PR TITLE
Handle TTT LMDB map exhaustion

### DIFF
--- a/Build.act
+++ b/Build.act
@@ -13,8 +13,8 @@ dependencies = {
     ),
     "lmdb": (
         repo_url="https://github.com/stratoweave/acton-lmdb",
-        url="https://github.com/stratoweave/acton-lmdb/archive/bad98443d45abed27c898114978116610d9b5af6.zip",
-        hash="N-V-__8AAMTaAABretZVTryDhoTumlwy3ekD-xmohzaqWwTH"
+        url="https://github.com/stratoweave/acton-lmdb/archive/05c9a1ae51360443150e002a9f7effac5a0be884.zip",
+        hash="N-V-__8AAJ8BAQBaDaW6N50DeQxT7GngYhvgGmTTKZX93ttB"
     ),
     "pipe": (
         repo_url="https://github.com/actonlang/pipe.git",

--- a/minisys/Build.act
+++ b/minisys/Build.act
@@ -3,8 +3,8 @@ fingerprint = 0xf1e1a54ca50c7652
 dependencies = {
     "lmdb": (
         repo_url="https://github.com/stratoweave/acton-lmdb",
-        url="https://github.com/stratoweave/acton-lmdb/archive/bad98443d45abed27c898114978116610d9b5af6.zip",
-        hash="N-V-__8AAMTaAABretZVTryDhoTumlwy3ekD-xmohzaqWwTH"
+        url="https://github.com/stratoweave/acton-lmdb/archive/05c9a1ae51360443150e002a9f7effac5a0be884.zip",
+        hash="N-V-__8AAJ8BAQBaDaW6N50DeQxT7GngYhvgGmTTKZX93ttB"
     ),
     "stratoweave": (
         path="../"

--- a/src/lib.act
+++ b/src/lib.act
@@ -12,6 +12,10 @@ import netconf_server as swnetconf
 import test_rig as swts
 
 
+# Reserve a 1 TiB virtual map; LMDB grows physical storage with its data.
+TTT_DB_MAP_SIZE = 1 << 40
+
+
 def main(sysspec: swapp.SysSpec, env: Env, http: bool=True, netconf: bool=True):
     """Start a production StratoWeave application.
 
@@ -64,7 +68,7 @@ def main(sysspec: swapp.SysSpec, env: Env, http: bool=True, netconf: bool=True):
     top_schema = sysspec.schema_for_layer(0)
     db_path = args.db_path
     if db_path is not None:
-        db = lmdb.Db(file.WriteFileCap(fcap), db_path)
+        db = lmdb.Db(file.WriteFileCap(fcap), db_path, TTT_DB_MAP_SIZE)
     else:
         db = None
 

--- a/src/test_ttt_persistence.act
+++ b/src/test_ttt_persistence.act
@@ -625,7 +625,7 @@ actor reject_db_persist_failure_without_committing_memory(t: testing.EnvT):
         layer.edit_config(struct_tree, None, after_recovery)
 
     def after_failure(r: value) -> None:
-        testing.assertEqual(isinstance(r, lmdb.LMDBKeySizeError), True)
+        testing.assertEqual(isinstance(r, lmdb.KeySizeError), True)
         read_txn = db.begin_read()
         testing.assertEqual(read_txn.get(swdb.META_KEY), None)
         await async read_txn.commit()

--- a/src/test_ttt_persistence.act
+++ b/src/test_ttt_persistence.act
@@ -127,13 +127,11 @@ overlap_expected_cfg = gdata.Container({
     q("extra"): gdata.Leaf(7)
 })
 
-oversized_list_key = "k" * 600
-
-oversized_struct_tree = gdata.Container({
+map_full_struct_tree = gdata.Container({
     q("items"): gdata.List([q("name")], [
         gdata.Container({
-            q("name"): gdata.Leaf(oversized_list_key),
-            q("value"): gdata.Leaf(1)
+            q("name"): gdata.Leaf("a"),
+            q("value"): gdata.Leaf("x" * (512 * 1024))
         })
     ])
 })
@@ -600,12 +598,12 @@ actor reject_restore_into_nonempty_tree(t: testing.EnvT):
     restored.edit_config(persist_cfg, after_initial_commit)
 
 
-actor reject_db_persist_failure_without_committing_memory(t: testing.EnvT):
+actor reject_map_full_without_committing_memory(t: testing.EnvT):
     fc = file.FileCap(t.env.cap)
     fs = file.FS(fc)
-    db_path = fs.mktmpdir("test_ttt_persist_fail_")
+    db_path = fs.mktmpdir("test_ttt_map_full_")
     cap = file.WriteFileCap(fc)
-    var db = lmdb.Db(cap, db_path)
+    var db = lmdb.Db(cap, db_path, 256 * 1024)
     var layer = ttt.Layer("struct", struct_root, None, db)
 
     def after_recovery(r: value) -> None:
@@ -625,13 +623,13 @@ actor reject_db_persist_failure_without_committing_memory(t: testing.EnvT):
         layer.edit_config(struct_tree, None, after_recovery)
 
     def after_failure(r: value) -> None:
-        testing.assertEqual(isinstance(r, lmdb.KeySizeError), True)
+        testing.assertEqual(isinstance(r, lmdb.MapFullError), True)
         read_txn = db.begin_read()
-        testing.assertEqual(read_txn.get(swdb.META_KEY), None)
+        testing.assertEqual(read_txn.cursor().seek_prefix(swdb.META_KEY), None)
         await async read_txn.commit()
         after 0.01: after_failure_settled()
 
-    layer.edit_config(oversized_struct_tree, after_failure)
+    layer.edit_config(map_full_struct_tree, after_failure)
 
 
 actor restore_transform_memory_round_trip(t: testing.EnvT):


### PR DESCRIPTION
TTT persistence currently inherits acton-lmdb's 10 MiB map, so realistic persistent workloads can exhaust it. Once full, the failed transaction must be discarded without committing the in-memory TTT state.

Upgrade acton-lmdb for typed LMDB errors and deterministic failed-transaction cleanup. Exercise the real MDB_MAP_FULL path with a deliberately small map, verifying that MapFullError reaches the callback, no partial records become visible, in-memory state rolls back, and a later write succeeds.

Use a fixed 1 TiB virtual map in the production StratoWeave entry point. This avoids exposing another operator setting while leaving internal LMDB callers free to choose a different size.

Fixes #466
